### PR TITLE
fixing problem with sub-sub domains not being accepted

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -21,12 +21,12 @@ Vue.use(serverPlugin, { store: store });
 const isEthernalDomain = window.location.host.endsWith(process.env.VUE_APP_MAIN_DOMAIN);
 
 if (isEthernalDomain) {
-    const splits = window.location.host.split('.');
-    const domain = splits[splits.length - 2];
-    const publicExplorerSlug = splits.slice(0, splits.indexOf(domain)).join('.');
-
-    if (!publicExplorerSlug.endsWith('app'))
-        store.dispatch('updatePublicExplorerSlug', publicExplorerSlug);
+    const splitDomain = window.location.host.split('.')
+    // URL needs to start with app and must be at least a subdomain
+    if(!window.location.host.startsWith('app.')
+        && splitDomain.length > 2) {
+        store.dispatch('updatePublicExplorerSlug', splitDomain[0]);
+    }
 }
 else {
     store.dispatch('updatePublicExplorerDomain', window.location.host);


### PR DESCRIPTION
fixed the problem of having more than one subdomain URLs like

```
app.subdomain.maindomain.com
```

Tested with

```
http://app.avalanche-mainnet-browser.<reducted>.com:8080   => does work
http://xapp.avalanche-mainnet-browser.<reducted>.com:8080  => does not work (no app as first subdomain)
http://app.com:8080  => does not work (VUE_APP_MAIN_DOMAIN must be without app. so it will not work)
```