### PR TITLE
new token transfer filter by block number

### DIFF
--- a/run/api/modules/tokens.js
+++ b/run/api/modules/tokens.js
@@ -67,7 +67,7 @@ const transfers = async (req, res) => {
         if (!data.workspace || !req.params.address)
             throw new Error('Missing parameter');
 
-        const result = await db.getTokenTransfers(data.workspace.id, req.params.address, data.page, data.itemsPerPage, data.orderBy, data.order);
+        const result = await db.getTokenTransfers(data.workspace.id, req.params.address, data.page, data.itemsPerPage, data.orderBy, data.order, data.minBlockNumber);
 
         res.status(200).json(result);
     } catch(error) {

--- a/run/lib/firebase.js
+++ b/run/lib/firebase.js
@@ -322,7 +322,7 @@ const getTokenStats = async (workspaceId, address) => {
     };
 };
 
-const getTokenTransfers = async (workspaceId, address, page, itemsPerPage, orderBy, order) => {
+const getTokenTransfers = async (workspaceId, address, page, itemsPerPage, orderBy, order, minBlockNumber) => {
     if (!workspaceId || !address) throw new Error('Missing parameter');
 
     const workspace = await Workspace.findByPk(workspaceId);
@@ -331,7 +331,7 @@ const getTokenTransfers = async (workspaceId, address, page, itemsPerPage, order
     if (!contract)
         throw new Error(`Can't find contract at this address.`);
 
-    const transfers = await contract.getTokenTransfers(page, itemsPerPage, orderBy, order);
+    const transfers = await contract.getTokenTransfers(page, itemsPerPage, orderBy, order, minBlockNumber);
     const transferCount = await contract.countTokenTransfers();
 
     return {

--- a/run/models/contract.js
+++ b/run/models/contract.js
@@ -302,7 +302,7 @@ module.exports = (sequelize, DataTypes) => {
         return result[0].sum || 0;
     }
 
-    getTokenTransfers(page = 1, itemsPerPage = 10, orderBy = 'id', order = 'DESC') {
+    getTokenTransfers(page = 1, itemsPerPage = 10, orderBy = 'id', order = 'DESC', minBlockNumber = 0) {
         let sanitizedOrderBy;
         switch(orderBy) {
             case 'timestamp':
@@ -328,7 +328,8 @@ module.exports = (sequelize, DataTypes) => {
                 {
                     model: sequelize.models.Transaction,
                     as: 'transaction',
-                    attributes: ['hash', 'blockNumber', 'timestamp']
+                    attributes: ['hash', 'blockNumber', 'timestamp'],
+                    where: { blockNumber: {[Op.gte]: minBlockNumber }}
                 },
                 {
                     model: sequelize.models.Contract,


### PR DESCRIPTION
Hi Antoine, this allows us to query the token transfers table so we can get a local copy of it by filtering out by the latest block number we have.