### PR TITLE
Fix OP Stack config update failing for custom L1 parents

### DIFF
--- a/run/models/opChainConfig.js
+++ b/run/models/opChainConfig.js
@@ -37,23 +37,8 @@ module.exports = (sequelize, DataTypes) => {
         }
       }
 
-      // Support both parentWorkspaceId (new) and parentChainId (legacy)
-      if (params.parentWorkspaceId !== undefined) {
-        const supportedParentChains = await sequelize.models.Workspace.getAvailableTopOpParent();
-        const parentWorkspace = supportedParentChains.find(chain => chain.id === params.parentWorkspaceId);
-        if (!parentWorkspace) {
-          throw new Error(`Selected parent workspace is not a valid L1 parent.`);
-        }
-        filteredParams.parentWorkspaceId = parentWorkspace.id;
-        filteredParams.parentChainId = parentWorkspace.networkId;
-      } else if (params.parentChainId !== undefined) {
-        const supportedParentChains = await sequelize.models.Workspace.getAvailableTopOpParent();
-        const supportedParentChainIds = supportedParentChains.map(chain => chain.networkId);
-        if (!supportedParentChainIds.includes(params.parentChainId)) {
-          throw new Error(`Parent chain network is not supported yet. Available networks: ${supportedParentChainIds.join(', ')}`);
-        }
-        filteredParams.parentWorkspaceId = supportedParentChains.find(chain => chain.networkId === params.parentChainId).id;
-      }
+      // Parent chain (parentWorkspaceId/parentChainId) cannot be changed after creation.
+      // These fields are intentionally excluded from updates.
 
       return this.update(filteredParams);
     }

--- a/src/components/ExplorerOpSettings.vue
+++ b/src/components/ExplorerOpSettings.vue
@@ -436,9 +436,11 @@ function updateConfig() {
     errorMessage.value = '';
     successMessage.value = '';
 
-    // Don't send networkId on updates - it can't be changed
+    // Don't send parent chain fields on updates - they can't be changed
     const updatePayload = { ...config.value };
     delete updatePayload.networkId;
+    delete updatePayload.parentWorkspaceId;
+    delete updatePayload.parentChainId;
 
     $server.updateOpConfig(props.explorerId, updatePayload)
         .then(({ data: { config: updatedConfig } }) => {


### PR DESCRIPTION
## **User description**
## Summary
- **Bug**: Updating OP Stack settings threw "Selected parent workspace is not a valid L1 parent" for explorers using custom L1 parents
- **Root cause**: `OpChainConfig.safeUpdate()` validated `parentWorkspaceId` against only `isTopL1Parent` workspaces, but custom L1 parents have `isCustomL1Parent=true` instead
- **Fix**: Since parent chain cannot be changed after creation, removed the parent validation from `safeUpdate()` entirely and stripped `parentWorkspaceId`/`parentChainId` from the frontend update payload

## Test plan
- [x] ExplorerOpSettings tests pass
- [ ] Verify updating OP config settings on explorer 10091 no longer throws the error
- [ ] Verify creating a new OP config with a custom L1 parent still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Fix OP Stack config updates failing when explorer uses a custom L1 parent

### What Changed
- Updating an OP Stack config no longer throws "Selected parent workspace is not a valid L1 parent" for explorers that use custom L1 parents
- The frontend stops sending parent chain fields on config updates (networkId, parentWorkspaceId, parentChainId)
- The backend ignores parent chain changes during updates so the existing parent relationship remains unchanged

### Impact
`✅ No more failed OP Stack updates for explorers with custom L1 parents`
`✅ Prevent accidental changes to an explorer's parent chain during config edits`
`✅ Clearer, successful config update experience`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
