### PR TITLE
Serve landing from Caddy on Fly.io, remove Netlify

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -110,44 +110,18 @@ jobs:
           tag: ${{ steps.get_changelog.outputs.version }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-  deploy_front:
+  deploy_caddy:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [create_release]
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
+      - uses: superfly/flyctl-actions/setup-flyctl@master
 
-      - name: Install deps & build
-        run: cd landing && npm ci && npm run build
-
-      - uses: nwtgck/actions-netlify@v2.0.0
-        id: netlify_deploy
-        with:
-          publish-dir: './landing/dist'
-          deploy-message: 'Deploying commit ${{ github.sha }}'
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-
-      - name: Store deploy id
-        id: store_deploy_id
-        run: |
-          ID=$(echo ${{ steps.netlify_deploy.outputs.deploy-url }} | sed 's/https:\/\/\(.*\)--tryethernal\.netlify\.app/\1/')
-          echo $ID > deploy_id.txt
-
-      - name: Upload deploy ID
-        uses: actions/upload-artifact@v4
-        with:
-          name: netlify_deploy_id
-          path: deploy_id.txt
+      - name: Deploy Caddy
+        run: flyctl deploy -c fly.caddy.toml
 
   deploy_back_amd64:
     if: startsWith(github.ref, 'refs/tags/v')
@@ -180,7 +154,7 @@ jobs:
         run: |
           flyctl auth docker
           ./build-prod-images-amd64.sh ${{ needs.create_release.outputs.current_version }}
-  
+
   deploy_back_arm64:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [create_release]
@@ -196,7 +170,7 @@ jobs:
           docker buildx create --use
           docker buildx inspect --bootstrap
         shell: bash
-      
+
       - name: Log in to Docker Hub
         run: |
           echo "${{ secrets.DOCKERHUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
@@ -206,25 +180,9 @@ jobs:
           flyctl auth docker
           ./build-prod-images-arm64.sh ${{ needs.create_release.outputs.current_version }}
 
-  release_front:
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: [deploy_front, deploy_back_amd64]
-    runs-on: ubuntu-latest
-    environment: production
-    steps:
-      - name: Download Deploy ID
-        uses: actions/download-artifact@v4
-        with:
-          name: netlify_deploy_id
-
-      - name: Release deploy
-        run: |
-          deploy_id=$(cat deploy_id.txt)
-          curl -H "Authorization: Bearer ${{ secrets.NETLIFY_AUTH_TOKEN }}" -X POST -d {} https://api.netlify.com/api/v1/sites/${{ secrets.NETLIFY_SITE_ID }}/deploys/$deploy_id/restore
-
   release_back:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [deploy_front, deploy_back_amd64, create_release]
+    needs: [deploy_back_amd64, create_release]
     runs-on: ubuntu-latest
     environment: production
     steps:

--- a/Caddyfile
+++ b/Caddyfile
@@ -50,6 +50,18 @@
         reverse_proxy ethernal.internal:8080
     }
 
+    handle /ingest/* {
+        reverse_proxy https://app.posthog.com {
+            header_up Host app.posthog.com
+        }
+    }
+
+    handle /api/2/* {
+        reverse_proxy https://sentry.tryethernal.com {
+            header_up Host sentry.tryethernal.com
+        }
+    }
+
     @fallbackApi {
         path /api*
     }
@@ -69,9 +81,9 @@
     }
 
     handle {
-        reverse_proxy tryethernal.netlify.app {
-            header_up Host tryethernal.netlify.app
-        }
+        root * /srv/landing
+        try_files {path} /index.html
+        file_server
     }
 
     encode gzip

--- a/Dockerfile.caddyfile
+++ b/Dockerfile.caddyfile
@@ -1,5 +1,13 @@
+# Build landing
+FROM node:18-alpine AS landing-build
+WORKDIR /app
+COPY landing/package.json landing/package-lock.json ./
+RUN npm ci
+COPY landing/ ./
+RUN npm run build
+
+# Caddy with landing static files
 FROM caddy:2.7.6-alpine
-
 COPY Caddyfile /etc/caddy/Caddyfile
-
+COPY --from=landing-build /app/dist /srv/landing
 CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]


### PR DESCRIPTION
## **User description**
## Summary
- Build landing site into the Caddy Docker image (`Dockerfile.caddyfile`) and serve as static files from `/srv/landing`
- Replace Netlify proxy catch-all in `Caddyfile` with `file_server` + SPA fallback
- Add PostHog (`/ingest/*`) and Sentry (`/api/2/*`) proxy rules migrated from Netlify `_redirects`
- Replace `deploy_front`/`release_front` CI jobs with a single `deploy_caddy` job

## Test plan
- [ ] Verify `cd landing && npm ci && npm run build` succeeds
- [ ] Verify `docker build -f Dockerfile.caddyfile -t test-caddy .` builds successfully with landing files at `/srv/landing`
- [ ] After deploy: confirm `tryethernal.com` serves landing from Fly.io/Caddy
- [ ] Verify API routes, websocket, and custom explorer domains still work
- [ ] Verify self-hosted `make start` is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Serve the website landing from Caddy on Fly.io and remove Netlify

### What Changed
- The public landing site is now built into and served by the Caddy container on Fly.io instead of being hosted on Netlify; the site falls back to index.html for SPA routing
- CI no longer deploys to Netlify; the release workflow builds/publishes a Caddy image and runs flyctl deploy instead of Netlify upload and restore steps
- PostHog and Sentry endpoints are proxied through the Caddy server so analytics and error ingestion continue to work under the site domain

### Impact
`✅ Serves landing from Fly.io/Caddy`
`✅ Removed Netlify deploy dependency from release pipeline`
`✅ Preserves PostHog and Sentry ingestion under the site domain`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
