### PR TITLE
fix: clean up legacy BullMQ priority keys to prevent Redis OOM

### DIFF
--- a/run/jobs/queueMonitoring.js
+++ b/run/jobs/queueMonitoring.js
@@ -6,10 +6,11 @@
  */
 
 const { Queue } = require('bullmq');
-const connection = require('../lib/redis');
+const redis = require('../lib/redis');
 const logger = require('../lib/logger');
 const { createIncident } = require('../lib/opsgenie');
 const { maxTimeWithoutEnqueuedJob, queueMonitoringMaxProcessingTime, queueMonitoringHighProcessingTimeThreshold, queueMonitoringHighWaitingJobCountThreshold, queueMonitoringMaxWaitingJobCount } = require('../lib/env');
+const priorities = require('../workers/priorities');
 
 const monitoredPerformances = ['blockSync', 'receiptSync'];
 
@@ -43,7 +44,7 @@ module.exports = async () => {
     let incidentCreated = false;
 
     for (const queueName of monitoredActivity) {
-        const queue = new Queue(queueName, { connection });
+        const queue = new Queue(queueName, { connection: redis });
         const completedJobs = await queue.getCompleted();
         const latestJob = completedJobs[0];
 
@@ -59,7 +60,7 @@ module.exports = async () => {
     }
 
     for (const queueName of monitoredPerformances) {
-        const queue = new Queue(queueName, { connection });
+        const queue = new Queue(queueName, { connection: redis });
         const completedJobs = await queue.getCompleted();
 
         const p95ProcessingTime = computeP95ProcessingTime(completedJobs);
@@ -97,6 +98,19 @@ module.exports = async () => {
                 );
                 incidentCreated = true;
             }
+        }
+    }
+
+    // Clean up legacy BullMQ v4 'priority' sorted sets that leak memory.
+    // BullMQ v5 uses 'prioritized' instead, but orphaned entries accumulate
+    // in the old 'priority' key and can consume gigabytes of Redis memory.
+    const allQueues = [...priorities['high'], ...priorities['medium'], ...priorities['low'], 'processHistoricalBlocks'];
+    for (const queueName of allQueues) {
+        const key = `bull:${queueName}:priority`;
+        const count = await redis.zcard(key);
+        if (count > 0) {
+            await redis.unlink(key);
+            logger.info('Cleaned legacy priority key', { queueName, entriesRemoved: count });
         }
     }
 

--- a/run/tests/jobs/queueMonitoring.test.js
+++ b/run/tests/jobs/queueMonitoring.test.js
@@ -17,6 +17,11 @@ jest.mock('bullmq', () => ({
     }))
 }));
 
+jest.mock('../../lib/redis', () => ({
+    zcard: jest.fn().mockResolvedValue(0),
+    unlink: jest.fn().mockResolvedValue(1),
+}));
+
 const queueMonitoring = require('../../jobs/queueMonitoring');
 
 beforeEach(() => {


### PR DESCRIPTION
## Summary

- Adds periodic cleanup of legacy `bull:*:priority` sorted sets in the `queueMonitoring` job
- BullMQ v5 uses `prioritized` instead of `priority`, but orphaned entries accumulate in the old key
- In production, `bull:blockSync:priority` grew to 70.5M entries (7.1 GB), pushing Redis to its 9.28 GB maxmemory limit and blocking all queue processing
- The cleanup runs on every queueMonitoring cycle, checking all queues and deleting any legacy priority keys with entries

## Test plan

- [x] Verified the fix resolves the OOM by manually cleaning the key in production (Redis dropped from 9.28 GB to 2.16 GB, all queues resumed)
- [x] Existing queueMonitoring tests pass (1 pre-existing failure unrelated to this change)
- [x] Added Redis mock for the new `zcard`/`unlink` calls in test

🤖 Generated with [Claude Code](https://claude.com/claude-code)