### PR TITLE
fix: address PR #518 review — confidence regex and recover-stuck label check

### DIFF
--- a/.github/workflows/sentry-auto-fix.yml
+++ b/.github/workflows/sentry-auto-fix.yml
@@ -604,7 +604,12 @@ jobs:
           GREPTILE_COMMENT=$(gh api repos/${{ github.repository }}/issues/${{ steps.pr_info.outputs.pr_number }}/comments \
             --jq '[.[] | select(.user.login == "greptile-apps[bot]")] | last | .body // ""')
 
-          SCORE=$(echo "$GREPTILE_COMMENT" | grep -oP '(\d)\/5' | head -1 | cut -d'/' -f1)
+          # Greptile formats as "<h3>Confidence Score: X/5</h3>" — anchor to that
+          SCORE=$(echo "$GREPTILE_COMMENT" | grep -oP '(?i)confidence\s+score[:\s]*\K\d(?=/5)' | head -1)
+          # Fallback: last X/5 occurrence (summary score appears after per-file scores)
+          if [ -z "$SCORE" ]; then
+            SCORE=$(echo "$GREPTILE_COMMENT" | grep -oP '\d(?=/5)' | tail -1)
+          fi
 
           if [ -z "$SCORE" ]; then
             echo "No confidence score found, proceeding"
@@ -914,6 +919,14 @@ jobs:
             MERGEABLE=$(gh pr view "$PR_NUM" --repo ${{ github.repository }} --json mergeable -q '.mergeable')
             if [ "$MERGEABLE" != "MERGEABLE" ]; then
               echo "PR #$PR_NUM is $MERGEABLE, skipping"
+              continue
+            fi
+
+            # Skip PRs flagged for human review
+            HAS_NEEDS_HUMAN=$(gh pr view "$PR_NUM" --repo ${{ github.repository }} --json labels \
+              -q '[.labels[].name] | any(. == "needs-human")')
+            if [ "$HAS_NEEDS_HUMAN" = "true" ]; then
+              echo "PR #$PR_NUM has needs-human label, skipping"
               continue
             fi
 


### PR DESCRIPTION
## Summary
Addresses two valid review comments from Greptile on PR #518:

- **Confidence score regex**: Anchored to Greptile's `Confidence Score: X/5` header format instead of grabbing the first `X/5` match (which could be a per-file score). Falls back to last `X/5` occurrence if the header format doesn't match.
- **recover-stuck bypasses confidence gate**: Added `needs-human` label check so PRs flagged by the confidence gate are never auto-merged by the recovery cron job.

## Test plan
- [x] YAML syntax validated
- [x] Verified against actual Greptile comment format from PR #518 (`<h3>Confidence Score: 2/5</h3>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)