### PR TITLE
fix: verify review comments before reacting with emoji

### DIFF
--- a/.github/workflows/sentry-auto-fix.yml
+++ b/.github/workflows/sentry-auto-fix.yml
@@ -559,7 +559,14 @@ jobs:
                # For issue-level comments:
                gh api repos/${{ github.repository }}/issues/comments/{comment_id}/reactions -f content='-1'
                ```
-            4. If it's unclear → ask for clarification in a reply (no reaction yet)
+            4. If it was a **valid issue but already fixed** by a later commit on this branch → reply noting it was valid but already addressed, and react with 👍:
+               ```bash
+               # For inline review comments:
+               gh api repos/${{ github.repository }}/pulls/comments/{comment_id}/reactions -f content='+1'
+               # For issue-level comments:
+               gh api repos/${{ github.repository }}/issues/comments/{comment_id}/reactions -f content='+1'
+               ```
+            5. If it's unclear → ask for clarification in a reply (no reaction yet)
 
             **IMPORTANT:** Do NOT react to comments before verifying them. Verify first, then react with the appropriate emoji based on your assessment.
             If the review summary is clean (no issues flagged), react with 👍 on the summary.


### PR DESCRIPTION
## Summary
The process-review bot was reacting 👍 to all Greptile comments in Step 2 before verifying them in Step 3. This caused incorrect upvotes on wrong comments (as seen on PR #519 where all 3 comments were incorrect but got 👍).

Merged the "react" and "process" steps so the bot now:
1. Fetches all comments
2. Verifies each comment against the actual code (checking all commits, not just the diff), then reacts with the appropriate emoji
3. Signals merge readiness

## Test plan
- [x] YAML syntax validated
- [x] Prompt clearly instructs verify-first, react-after

🤖 Generated with [Claude Code](https://claude.com/claude-code)