### PR TITLE
fix: remove wsPath from Pusher config to fix WSS 404

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,7 @@ All traffic goes through Caddy on Fly.io (`ethernal-caddy` app, `fly.caddy.toml`
 - Landing served for `tryethernal.com` and `www.tryethernal.com` only; all other domains get the app frontend
 - Caddy handles on-demand TLS for explorer subdomains and custom domains
 - Self-hosted users generate their own Caddyfile via `generate-env-files.sh` (unaffected)
+- **WebSocket path — DO NOT CHANGE:** Caddy uses `handle /app*` (NOT `handle_path`) to route WebSocket traffic to Soketi while preserving the `/app` prefix. The frontend Pusher client (`src/plugins/pusher.js`) must NOT set `wsPath` — pusher-js already generates `/app/{key}` by default. Setting `wsPath: '/app'` causes a double prefix (`/app/app/{key}`) resulting in 404s. If you change one, you break the other. The correct pairing is: Caddyfile `handle /app*` + no `wsPath` in pusher config.
 - Caddy deploys via `flyctl deploy -c fly.caddy.toml` (also runs in CI as `deploy_caddy` job)
 
 ### Sentry Error & Performance Monitoring

--- a/src/plugins/pusher.js
+++ b/src/plugins/pusher.js
@@ -27,7 +27,6 @@ export default {
                 pusher = envStore.soketiKey ?
                     new Pusher(envStore.soketiKey, {
                         wsHost: window.location.hostname,
-                        wsPath: '/app',
                         forceTLS: window.location.protocol === 'https:',
                         enabledTransports: ['ws', 'wss'],
                         userAuthentication: {


### PR DESCRIPTION
## Summary
- Removes `wsPath: '/app'` from the Pusher client config in `src/plugins/pusher.js`
- pusher-js already generates `/app/{key}` by default — setting `wsPath: '/app'` caused `/app/app/{key}`, resulting in 404s
- This was masked before PR #586 because `handle_path /app*` stripped the first `/app` prefix, but after switching to `handle /app*` (which preserves the path), the double prefix became visible
- Documents the Caddy/Pusher WebSocket path pairing in CLAUDE.md to prevent future regressions

## Root cause
```
pusher-js URL = wsPath + '/app/' + key
             = '/app'  + '/app/' + key
             = '/app/app/key'  ← 404
```

Fixes https://sentry.tryethernal.com/organizations/sentry/issues/22/

## Test plan
- [x] Verify WSS connections work: `wss://explorer.tryethernal.com/app/{key}?protocol=7...` should return 101 Upgrade, not 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)