### PR TITLE
fix: add index for slow tokenTransfers query

### DIFF
--- a/run/migrations/20260310050000-add-token-transfer-events-workspace-tokentype-index.js
+++ b/run/migrations/20260310050000-add-token-transfer-events-workspace-tokentype-index.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * Adds a composite index on (workspaceId, tokenType) to token_transfer_events.
+ * This speeds up the tokenTransfers endpoint which filters by workspaceId and tokenType
+ * but was doing sequential scans across all hypertable chunks (~104 chunks, ~1.3s).
+ */
+module.exports = {
+    async up(queryInterface) {
+        await queryInterface.sequelize.query(
+            'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_token_transfer_events_workspace_tokentype ON token_transfer_events ("workspaceId", "tokenType")'
+        );
+    },
+    async down(queryInterface) {
+        await queryInterface.sequelize.query(
+            'DROP INDEX CONCURRENTLY IF EXISTS idx_token_transfer_events_workspace_tokentype'
+        );
+    }
+};
+
+module.exports.config = { transaction: false };


### PR DESCRIPTION
## Summary
- Adds composite index on `token_transfer_events("workspaceId", "tokenType")` using `CREATE INDEX CONCURRENTLY`
- The `/api/workspaces/:id/tokenTransfers?tokenTypes[]=erc721&tokenTypes[]=erc1155` endpoint was taking ~1.3s due to sequential scans across 104 hypertable chunks
- EXPLAIN ANALYZE confirmed 0 matching rows but 104 seq scans with no usable index

## Test plan
- [ ] Migration runs successfully (CONCURRENTLY, no transaction)
- [ ] Verify index exists: `\di idx_token_transfer_events_workspace_tokentype`
- [ ] Re-run EXPLAIN ANALYZE on the query to confirm index scan instead of seq scans
- [ ] Test tokenTransfers endpoint response time on Adventure Layer explorer

🤖 Generated with [Claude Code](https://claude.com/claude-code)