### PR TITLE
fix: limit BullMQ stacktrace storage to prevent Redis OOM

### DIFF
--- a/run/queues.js
+++ b/run/queues.js
@@ -7,6 +7,7 @@ priorities['high'].forEach(jobName => {
     queues[jobName] = new Queue(jobName, {
         defaultJobOptions: {
             attempts: 50,
+            stackTraceLimit: 3,
             removeOnComplete: {
                 count: 100,
                 age: 4 * 60
@@ -31,6 +32,7 @@ priorities['medium'].forEach(jobName => {
     queues[jobName] = new Queue(jobName, {
         defaultJobOptions: {
             attempts: 40,
+            stackTraceLimit: 3,
             removeOnComplete: 20,
             removeOnFail: 20,
             timeout: 30000,
@@ -47,6 +49,7 @@ priorities['low'].forEach(jobName => {
     queues[jobName] = new Queue(jobName, {
         defaultJobOptions: {
             attempts: 10,
+            stackTraceLimit: 3,
             removeOnComplete: 10,
             removeOnFail: 10,
             timeout: 30000,
@@ -62,6 +65,7 @@ priorities['low'].forEach(jobName => {
 queues['processHistoricalBlocks'] = new Queue('processHistoricalBlocks', {
     defaultJobOptions: {
         attempts: 5,
+        stackTraceLimit: 3,
         removeOnComplete: {
             count: 100,
             age: 4 * 60


### PR DESCRIPTION
## Summary
- Failed BullMQ jobs were storing all retry stacktraces (up to 50 per job, ~50KB each). With 149K accumulated failed `processBlock` jobs, this consumed ~7.5GB of the 9.28GB Redis, causing OOM errors that blocked all queue processing.
- Adds `stackTraceLimit: 3` to all queue priority groups so only the last 3 stacktraces are kept per failed job, reducing per-job storage from ~50KB to ~3KB.

## Test plan
- [x] Verified `stackTraceLimit` is a valid BullMQ job option (confirmed in source: `job.js` line 972-976)
- [ ] Deploy and monitor Redis memory usage over 24h
- [ ] Verify failed jobs still retain useful diagnostic info (last 3 stacktraces)

🤖 Generated with [Claude Code](https://claude.com/claude-code)