### PR TITLE
fix(blog): shorten description to ≤160 chars, add build validation to pipeline

### DIFF
--- a/blog/pipeline/draft.sh
+++ b/blog/pipeline/draft.sh
@@ -146,6 +146,24 @@ fi
 log "Phase 3 complete."
 
 # ============================================================
+# Validate: Astro build must pass before committing
+# ============================================================
+log "Validating blog build..."
+cd "$REPO_DIR/blog"
+if ! npx astro build 2>&1 | tee -a "$LOG_FILE"; then
+  log "ERROR: Astro build failed — article has schema or syntax errors"
+  cd "$REPO_DIR/blog/pipeline"
+  CARD_ID="$CARD_ID" node --input-type=module -e "
+    import { updateCardStatus } from './project.js';
+    updateCardStatus(process.env.CARD_ID, 'detected');
+    console.log('Card reset to Detected');
+  " 2>&1 | tee -a "$LOG_FILE"
+  exit 1
+fi
+cd "$REPO_DIR"
+log "Build validation passed."
+
+# ============================================================
 # Commit, push, and update card
 # ============================================================
 SLUG=$(basename "$ARTICLE_PATH" .md)

--- a/blog/pipeline/prompts/2-draft.md
+++ b/blog/pipeline/prompts/2-draft.md
@@ -60,7 +60,7 @@ Save the article to `blog/src/content/blog/<slug>.md` with this frontmatter:
 ```yaml
 ---
 title: "Article Title"
-description: "110-160 chars max."
+description: "110-160 chars max. MUST be ≤160 characters (Zod schema in src/content.config.ts enforces this; build will fail if exceeded)."
 date: YYYY-MM-DD
 tags:
   - Tag1

--- a/blog/src/content/blog/the-commerce-layer-erc-8183.md
+++ b/blog/src/content/blog/the-commerce-layer-erc-8183.md
@@ -1,6 +1,6 @@
 ---
 title: "The Commerce Layer: How ERC-8183 Makes AI Agent Payments Verifiable"
-description: "ERC-8183 adds the missing verb to agent commerce: not 'I sent you value' but 'I will pay you when you deliver.' Here's how the job lifecycle and evaluator model work."
+description: "ERC-8183 adds the missing verb to agent commerce: not 'I sent value' but 'I will pay when you deliver.' How the job lifecycle and evaluator work."
 date: 2026-03-12
 tags:
   - AI Agents


### PR DESCRIPTION
## Summary

- **Article fix**: shortened `the-commerce-layer-erc-8183.md` description from 166 to 145 chars (was failing Zod schema validation)
- **Pipeline prompt**: added explicit ≤160 char rule in `2-draft.md` with reference to the Zod constraint in `src/content.config.ts`
- **Build validation gate**: `draft.sh` now runs `npx astro build` after Phase 3 — resets card to Detected and exits on failure instead of committing a broken article

## Test plan

- [ ] Run `cd blog && npx astro build` to confirm no schema errors
- [ ] Verify `draft.sh` build validation section is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)