### PR TITLE
fix(blog): guard PR step on publish outputs

### DIFF
--- a/.github/workflows/blog-publish.yml
+++ b/.github/workflows/blog-publish.yml
@@ -91,7 +91,7 @@ jobs:
           echo "title=$TITLE" >> $GITHUB_OUTPUT
 
       - name: Create and merge PR
-        if: steps.resolve.outputs.article != ''
+        if: steps.publish.outputs.slug != ''
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
           SLUG: ${{ steps.publish.outputs.slug }}


### PR DESCRIPTION
Prevents failure when article is already published.