### PR TITLE
ui: widen RPC URL input field on landing homepage

### DIFF
--- a/landing/src/components/DemoExplorerForm.vue
+++ b/landing/src/components/DemoExplorerForm.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="demo-form" style="max-width: 560px;">
+    <div class="demo-form" style="max-width: 640px;">
         <v-slide-x-transition mode="out-in">
             <div :key="step">
                 <!-- Step 1: RPC URL -->

--- a/landing/src/components/LandingHero.vue
+++ b/landing/src/components/LandingHero.vue
@@ -3,7 +3,7 @@
         <div class="hero-glow"></div>
         <v-container style="max-width: 1280px; position: relative; z-index: 1;">
             <v-row align="center" justify="center" class="py-8 py-lg-0">
-                <v-col cols="12" lg="6" class="py-12">
+                <v-col cols="12" lg="7" class="py-12">
                     <h1 class="hero-headline font-heading mb-5">
                         <span class="gradient-text">Etherscan</span> for your blockchain
                     </h1>
@@ -31,7 +31,7 @@
                     </div>
                 </v-col>
 
-                <v-col cols="12" lg="6" class="d-none d-lg-flex justify-center">
+                <v-col cols="12" lg="5" class="d-none d-lg-flex justify-center" style="margin-top: -40px;">
                     <div class="hero-preview-wrap">
                         <div class="hero-preview">
                             <div class="preview-header">
@@ -115,7 +115,7 @@ const txns = [
 .hero-subtitle {
     font-size: 1.2rem;
     color: var(--text-secondary);
-    max-width: 520px;
+    max-width: 580px;
     line-height: 1.7;
 }
 


### PR DESCRIPTION
## Summary
- Widen left column from `lg=6` to `lg=7` to give more space for the RPC input
- Increase form max-width from `560px` to `640px`
- Shift browser preview visual up by `40px` to compensate for the narrower right column
- Widen subtitle max-width from `520px` to `580px` to match

## Test plan
- [ ] Visit landing page on desktop, verify RPC input field is visibly wider
- [ ] Verify browser preview visual doesn't overlap or clip
- [ ] Check responsive behavior at breakpoints (lg and below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)