### PR TITLE
fix: clear redis mocks in queueMonitoring test

### DIFF
--- a/run/tests/jobs/queueMonitoring.test.js
+++ b/run/tests/jobs/queueMonitoring.test.js
@@ -44,6 +44,19 @@ beforeEach(() => {
     createIncident.mockClear();
     logger.info.mockClear();
     logger.error.mockClear();
+    redis.get.mockClear().mockResolvedValue(null);
+    redis.set.mockClear().mockResolvedValue('OK');
+    redis.pipeline.mockClear().mockReturnValue({
+        zcard: jest.fn().mockReturnThis(),
+        unlink: jest.fn().mockReturnThis(),
+        zrevrange: jest.fn().mockReturnThis(),
+        llen: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue([
+            [null, 0],
+            [null, 0],
+            [null, 0]
+        ])
+    });
     mockGetCompleted = jest.fn().mockResolvedValue([]);
     mockGetWaitingCount = jest.fn().mockResolvedValue(0);
     mockGetDelayedCount = jest.fn().mockResolvedValue(0);


### PR DESCRIPTION
## Summary
- Clear and reset redis mocks (get, set, pipeline) in `beforeEach` to isolate each test
- The throttle test expected `redis.pipeline` not to be called, but previous tests accumulated pipeline calls

## Test plan
- [x] `queueMonitoring.test.js` — all 12 tests pass
- [x] Full suite — 111/111 suites, 0 failures