### PR TITLE
feat: replace Playwright tweet images with Gemini API

### DIFF
--- a/tweet-pipeline/build-showcase.cjs
+++ b/tweet-pipeline/build-showcase.cjs
@@ -1,0 +1,98 @@
+const fs = require('fs');
+const path = require('path');
+
+const queueDir = path.join(__dirname, 'test-queue');
+const outputDir = path.join(__dirname, 'test-output');
+
+const tweets = [];
+for (let slot = 1; slot <= 5; slot++) {
+  const f = path.join(queueDir, `tweet-slot${slot}.json`);
+  if (!fs.existsSync(f)) continue;
+  const d = JSON.parse(fs.readFileSync(f, 'utf-8'));
+  const imgFile = d.imageFile || `tweet-slot${slot}.png`;
+  const hasImage = fs.existsSync(path.join(outputDir, imgFile));
+  tweets.push(Object.assign({}, d, { slot, hasImage, imageFile: hasImage ? imgFile + '?v=' + Date.now() : null }));
+}
+
+const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>@tryethernal Tweet Pipeline</title>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700" rel="stylesheet">
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+html,body{background:#1b2836;font-family:Roboto,sans-serif}
+#page{max-width:441px;margin:0 auto;padding-bottom:40px}
+#topbar{background:#243447;height:53px;position:sticky;top:0;font-size:17px;padding:15px 13px;box-shadow:0 2px 8px #111a22;z-index:999;color:#fff}
+.ss{background:#243447;padding:10px 13px;border-bottom:1px solid #15202a;display:flex;align-items:center;gap:8px}
+.ss .bg{background:#1da1f2;color:#fff;font-size:11px;font-weight:700;padding:2px 8px;border-radius:10px}
+.ss .lb{color:#8a9ba8;font-size:13px}
+.td{padding:13px}
+.td .u{display:flex;align-items:center;gap:10px;margin-bottom:12px}
+.av{width:54px;height:54px;border-radius:50%;background:linear-gradient(135deg,#3D95CE,#1a1a2e);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:22px;color:#fff;flex-shrink:0}
+.avs{width:42px;height:42px;border-radius:50%;background:linear-gradient(135deg,#3D95CE,#1a1a2e);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:16px;color:#fff;flex-shrink:0;z-index:1;position:relative}
+.nm{font-size:15px;font-weight:700;color:#fff;display:flex;align-items:center;gap:4px}
+.nm svg{width:18px;height:18px;fill:#1da1f2}
+.hd{font-size:15px;color:#8a9ba8}
+.tx{color:#fff;font-size:23px;line-height:30px;white-space:pre-wrap;word-wrap:break-word;margin-bottom:12px}
+.mn{color:#1da2f4}
+.td .media{width:100%;border-radius:14px;margin-bottom:12px}
+.dt{color:#8a9ba8;font-size:15px;padding:13px 0;border-bottom:1px solid #15202a}
+.cb{color:#657786;font-size:11px;background:rgba(255,255,255,0.05);padding:1px 5px;border-radius:3px;margin-left:4px;font-family:monospace}
+.ib{display:flex;height:46px;align-items:center;border-bottom:1px solid #15202a}
+.ib .ic{flex:1;display:flex;align-items:center;justify-content:center}
+.ib .ic svg{width:20px;height:20px;fill:#8a9ba8}
+.bx{min-height:80px;padding:13px;display:flex}
+.bx .ln{flex-shrink:0;width:54px;position:relative;display:flex;flex-direction:column;align-items:center}
+.bx .ln .br{position:absolute;left:26px;top:0;bottom:0;width:3px;background:#3d5466}
+.bx:last-child .ln .br{display:none}
+.bx:last-child{border-bottom:1px solid #15202a}
+.bx .ct{flex:1;padding-left:10px;overflow:hidden}
+.bx .inf{display:flex;align-items:center;margin-bottom:2px}
+.bx .inf .nm{font-size:15px;margin-right:4px}
+.bx .inf .nm svg{width:16px;height:16px}
+.bx .rt{color:#8a9ba8;font-size:13px;padding:2px 0 4px}
+.bx .rtx{color:#fff;font-size:15px;line-height:21px;white-space:pre-wrap;word-wrap:break-word;margin-bottom:8px}
+.bx .ri{display:flex;padding-bottom:8px}
+.bx .ri .ic{width:21%;display:flex;align-items:center;gap:6px}
+.bx .ri .ic svg{width:16px;height:16px;fill:#8a9ba8}
+</style>
+</head>
+<body>
+<div id="page">
+<div id="topbar"><b>@tryethernal</b></div>
+<div id="feed"></div>
+</div>
+<script>
+var T=${JSON.stringify(tweets)};
+var V='<svg viewBox="0 0 22 22"><path d="M20.396 11c-.018-.646-.215-1.275-.57-1.816-.354-.54-.852-.972-1.438-1.246.223-.607.27-1.264.14-1.897-.131-.634-.437-1.218-.882-1.687-.47-.445-1.053-.75-1.687-.882-.633-.13-1.29-.083-1.897.14-.273-.587-.704-1.086-1.245-1.44S11.647 1.62 11 1.604c-.646.017-1.273.213-1.813.568s-.969.855-1.24 1.44c-.608-.223-1.267-.272-1.902-.14-.635.13-1.22.436-1.69.882-.445.47-.749 1.055-.878 1.69-.13.633-.08 1.29.144 1.896-.587.274-1.087.705-1.443 1.245-.356.54-.555 1.17-.574 1.817.02.647.218 1.276.574 1.817.356.54.856.972 1.443 1.245-.224.606-.274 1.263-.144 1.896.13.636.433 1.221.878 1.69.47.446 1.055.752 1.69.883.635.13 1.294.083 1.902-.141.27.587.7 1.086 1.24 1.44s1.167.551 1.813.568c.647-.016 1.276-.213 1.817-.567s.972-.854 1.245-1.44c.604.223 1.26.27 1.894.14.634-.132 1.22-.438 1.69-.884.445-.47.75-1.055.88-1.69.13-.634.08-1.29-.14-1.898.585-.273 1.084-.704 1.438-1.244.354-.54.551-1.17.569-1.816zM9.662 14.85l-3.429-3.428 1.293-1.302 2.072 2.072 4.4-4.794 1.347 1.246z"/></svg>';
+var iR='<svg viewBox="0 0 24 24"><path d="M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.25-.862 4.394-2.427 5.862l-8.07 7.57a.75.75 0 0 1-1.024 0l-8.072-7.57C1.8 14.394.938 12.25.938 10h.813z"/></svg>';
+var iT='<svg viewBox="0 0 24 24"><path d="M4.5 3.88l4.432 4.14-1.364 1.46L5.5 7.55V16c0 1.1.896 2 2 2H13v2H7.5c-2.209 0-4-1.79-4-4V7.55L1.432 9.48.068 8.02 4.5 3.88zM16.5 6H11V4h5.5c2.209 0 4 1.79 4 4v8.45l2.068-1.93 1.364 1.46-4.432 4.14-4.432-4.14 1.364-1.46 2.068 1.93V8c0-1.1-.896-2-2-2z"/></svg>';
+var iL='<svg viewBox="0 0 24 24"><path d="M16.697 5.5c-1.222-.06-2.679.51-3.89 2.16l-.805 1.09-.806-1.09C9.984 6.01 8.526 5.44 7.304 5.5c-1.243.07-2.349.78-2.91 1.91-.552 1.12-.633 2.78.479 4.82 1.074 1.97 3.257 4.27 7.129 6.61 3.87-2.34 6.052-4.64 7.126-6.61 1.111-2.04 1.03-3.7.477-4.82-.56-1.13-1.666-1.84-2.908-1.91z"/></svg>';
+var iS='<svg viewBox="0 0 24 24"><path d="M8.75 21V3h2v18h-2zM18.75 21V8.5h2V21h-2zM13.75 21v-6h2v6h-2zM3.75 21v-3h2v3h-2z"/></svg>';
+function e(s){return s.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;")}
+function f(t){return e(t).replace(/@(\\w+)/g,'<span class="mn">@$1</span>')}
+var h="";T.forEach(function(t){
+var thr=t.thread&&t.thread.length>0;
+h+='<div class="ss"><span class="bg">Slot '+t.slot+'</span><span class="lb">'+t.bucket+'</span></div>';
+h+='<div class="td"><div class="u"><div class="av">E</div><div><div class="nm">Ethernal '+V+'</div><div class="hd">@tryethernal</div></div></div>';
+h+='<div class="tx">'+f(t.hook)+'<span class="cb">'+t.hook.length+'</span></div>';
+if(t.hasImage)h+='<img class="media" src="'+t.imageFile+'">';
+h+='<div class="dt">Preview</div>';
+h+='<div class="ib"><div class="ic">'+iR+'</div><div class="ic">'+iT+'</div><div class="ic">'+iL+'</div><div class="ic">'+iS+'</div></div></div>';
+if(thr){h+='<div>';
+t.thread.forEach(function(r,i){
+h+='<div class="bx"><div class="ln"><div class="br"></div><div class="avs">E</div></div><div class="ct"><div class="inf"><div class="nm">Ethernal '+V+'</div><div class="hd">@tryethernal</div></div>';
+h+='<div class="rt">Replying to <span class="mn">@tryethernal</span></div>';
+h+='<div class="rtx">'+f(r)+'<span class="cb">'+r.length+'</span></div>';
+h+='<div class="ri"><div class="ic">'+iR+'</div><div class="ic">'+iT+'</div><div class="ic">'+iL+'</div><div class="ic">'+iS+'</div></div></div></div>';
+});h+='</div>';}});
+document.getElementById("feed").innerHTML=h;
+<\/script>
+</body>
+</html>`;
+
+fs.writeFileSync(path.join(outputDir, 'showcase.html'), html);
+console.log('Written to', path.join(outputDir, 'showcase.html'));

--- a/tweet-pipeline/lib/image-generator.js
+++ b/tweet-pipeline/lib/image-generator.js
@@ -1,64 +1,135 @@
 /**
- * @fileoverview Playwright-based image generator for branded tweet card templates.
- * Renders HTML templates with injected data via URL query params and captures PNG screenshots.
+ * @fileoverview Gemini-based image generator for branded tweet cards.
+ * Uses the same visual style as Ethernal blog cover images.
  * @module image-generator
  */
-import { join } from 'node:path';
-import { chromium } from 'playwright';
-import { PATHS } from '../config.js';
+import { writeFileSync } from 'node:fs';
+
+const GEMINI_MODEL = 'gemini-3.1-flash-image-preview';
+const GEMINI_API_URL = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent`;
 
 /**
- * Maps image spec type names to HTML template filenames.
- * @type {Record<string, string>}
+ * Style prefix matching the Ethernal blog cover aesthetic.
+ * Learned from 4+ rounds of prompt iteration.
  */
-const TEMPLATE_MAP = {
-    stat_card: 'stat-card.html',
-    eip_card: 'eip-card.html',
-    code_snippet: 'code-snippet.html',
-    quote_card: 'quote-card.html',
-};
-
-/** Card dimensions in pixels. */
-const WIDTH = 1200;
-const HEIGHT = 675;
+const STYLE_PREFIX = `Clean flat illustration on a dark navy (#0F1729) background with a subtle dot grid. Simple shapes, soft blue (#3D95CE) and white accents. NOT futuristic, NOT glowy, NOT 3D. Flat design, like a clean tech blog illustration. Landscape format 1200x675. The composition must be properly centered with balanced whitespace on all sides.`;
 
 /**
- * Builds a file:// URL pointing to the appropriate HTML template with data as query params.
- * @param {string} type - Template type (stat_card, eip_card, code_snippet, quote_card).
- * @param {Record<string, string>} data - Key-value pairs to inject as URL search params.
- * @returns {string} A file:// URL with encoded query parameters.
- * @throws {Error} If the template type is unknown.
+ * Prompt rules learned from testing:
+ * - Be explicit about text placement: "Title at top in large white text"
+ * - Say "Do NOT repeat any text" — Gemini tends to duplicate
+ * - Describe diagrams simply: "two-panel", "3 connected boxes", "timeline with nodes"
+ * - Limit text: "Nothing else written below the diagram"
+ * - Use the metric as the hero element when it's a number
  */
-export function buildTemplateUrl(type, data) {
-    const filename = TEMPLATE_MAP[type];
-    if (!filename) {
-        throw new Error(`Unknown template type: "${type}". Valid types: ${Object.keys(TEMPLATE_MAP).join(', ')}`);
+const PROMPT_RULES = `Do NOT repeat any text. Each piece of text appears exactly once. Keep the layout extremely clean and minimal. Maximum 3-4 visual elements.`;
+
+/**
+ * Builds a Gemini prompt from an imageSpec.
+ * @param {Object} spec - Image specification from the draft phase.
+ * @param {string} spec.title - Main title text.
+ * @param {string} spec.subtitle - Secondary text.
+ * @param {string} [spec.metric] - Key number/stat to display prominently.
+ * @param {string} [spec.diagram] - Optional diagram description from the draft.
+ * @param {string} [spec.code] - Code snippet content.
+ * @param {string} [spec.quote] - Quote text.
+ * @param {string} [spec.author] - Quote attribution.
+ * @returns {string} Complete prompt for Gemini.
+ */
+function buildPrompt(spec) {
+    const { title, subtitle, metric, diagram, code, quote, author } = spec;
+
+    let content = `Title at top in large white text: "${title}"`;
+
+    if (metric) {
+        content += `\nDisplay the metric "${metric}" prominently — large font, centered or near the title.`;
     }
 
-    const templatePath = join(PATHS.templateDir, filename);
-    const params = new URLSearchParams(data);
-    return `file://${templatePath}?${params.toString()}`;
+    if (subtitle) {
+        content += `\nSubtitle in smaller gray text below the title: "${subtitle}"`;
+    }
+
+    if (diagram) {
+        content += `\nDiagram: ${diagram}`;
+    } else if (code) {
+        content += `\nShow a code block with dark background containing: ${code.substring(0, 200)}`;
+    } else if (quote) {
+        content += `\nShow a quote card with: "${quote}"${author ? ` — ${author}` : ''}`;
+    } else {
+        // Auto-generate a simple diagram description from the title
+        content += `\nBelow the title, show a simple flat diagram that visually represents the concept. Use labeled boxes, arrows, or icons. Keep it diagrammatic, not illustrative.`;
+    }
+
+    content += `\nNothing else written below the diagram.`;
+
+    return `${STYLE_PREFIX}\n\n${content}\n\n${PROMPT_RULES}`;
 }
 
 /**
- * Renders an HTML card template via headless Chromium and saves a PNG screenshot.
- * @param {Object} imageSpec - Specification for the image to generate.
- * @param {string} imageSpec.type - Template type (stat_card, eip_card, code_snippet, quote_card).
+ * Generates a branded tweet card image using the Gemini API.
+ * Falls back gracefully if the API fails or returns no image.
+ * @param {Object} imageSpec - Specification from the draft phase.
  * @param {string} outputPath - Absolute path where the PNG file will be saved.
- * @returns {Promise<void>}
- * @throws {Error} If the template type is unknown or rendering fails.
+ * @returns {Promise<boolean>} True if image was generated, false on failure.
  */
 export async function generateImage(imageSpec, outputPath) {
-    const { type, ...data } = imageSpec;
-    const url = buildTemplateUrl(type, data);
-
-    const browser = await chromium.launch({ headless: true });
-    try {
-        const page = await browser.newPage();
-        await page.setViewportSize({ width: WIDTH, height: HEIGHT });
-        await page.goto(url, { waitUntil: 'networkidle' });
-        await page.screenshot({ path: outputPath, type: 'png' });
-    } finally {
-        await browser.close();
+    const apiKey = process.env.GEMINI_API_KEY;
+    if (!apiKey) {
+        console.error('GEMINI_API_KEY not set — skipping image generation');
+        return false;
     }
+
+    const { type, slug, ...specData } = imageSpec;
+
+    // blog_cover type uses existing images, not Gemini
+    if (type === 'blog_cover') {
+        console.log('blog_cover type handled by draft.sh, not image-generator');
+        return false;
+    }
+
+    const prompt = buildPrompt(specData);
+
+    for (let attempt = 1; attempt <= 3; attempt++) {
+        try {
+            const res = await fetch(`${GEMINI_API_URL}?key=${apiKey}`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    contents: [{ parts: [{ text: prompt }] }],
+                    generationConfig: { responseModalities: ['TEXT', 'IMAGE'] }
+                })
+            });
+
+            if (!res.ok) {
+                console.error(`Gemini API error (attempt ${attempt}): ${res.status}`);
+                if (attempt < 3) { await sleep(4000); continue; }
+                return false;
+            }
+
+            const data = await res.json();
+            const parts = data.candidates?.[0]?.content?.parts || [];
+            const imagePart = parts.find(p => p.inlineData);
+
+            if (imagePart) {
+                const buf = Buffer.from(imagePart.inlineData.data, 'base64');
+                writeFileSync(outputPath, buf);
+                console.log(`Image generated (attempt ${attempt}): ${outputPath} (${buf.length} bytes)`);
+                return true;
+            }
+
+            console.warn(`Gemini returned no image (attempt ${attempt}) — retrying`);
+            if (attempt < 3) await sleep(4000);
+        } catch (err) {
+            console.error(`Gemini error (attempt ${attempt}):`, err.message);
+            if (attempt < 3) await sleep(4000);
+        }
+    }
+
+    console.error('Failed to generate image after 3 attempts');
+    return false;
 }
+
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+// Keep buildPrompt exported for testing
+export { buildPrompt };

--- a/tweet-pipeline/lib/image-generator.test.js
+++ b/tweet-pipeline/lib/image-generator.test.js
@@ -1,73 +1,58 @@
 /**
- * @fileoverview Tests for the Playwright-based image generator.
+ * @fileoverview Tests for the Gemini-based image generator.
  */
-import { describe, it, after } from 'node:test';
+import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { existsSync, unlinkSync, mkdirSync, statSync, rmdirSync } from 'node:fs';
-import { join, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { buildTemplateUrl, generateImage } from './image-generator.js';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
+import { buildPrompt } from './image-generator.js';
 
 describe('image-generator', () => {
-    const tmpDir = join(__dirname, '..', '.test-output');
-
-    describe('buildTemplateUrl', () => {
-        it('builds correct file:// URL with params for stat_card', () => {
-            const url = buildTemplateUrl('stat_card', { headline: '4,200+', subtitle: 'Contracts verified' });
-            assert.ok(url.startsWith('file://'), 'Should be a file:// URL');
-            assert.ok(url.includes('stat-card.html'), 'Should reference stat-card.html');
-            assert.ok(url.includes('headline=4%2C200%2B'), 'Should encode headline param');
-            assert.ok(url.includes('subtitle=Contracts+verified'), 'Should include subtitle param');
+    describe('buildPrompt', () => {
+        it('includes style prefix', () => {
+            const prompt = buildPrompt({ title: 'Test', subtitle: 'Sub' });
+            assert.ok(prompt.includes('#0F1729'), 'Should include dark navy color');
+            assert.ok(prompt.includes('#3D95CE'), 'Should include blue accent color');
+            assert.ok(prompt.includes('NOT futuristic'), 'Should include style constraint');
         });
 
-        it('builds correct URL for eip_card', () => {
-            const url = buildTemplateUrl('eip_card', { number: 'EIP-4844', title: 'Shard Blob Transactions', summary: 'Proto-danksharding' });
-            assert.ok(url.includes('eip-card.html'), 'Should reference eip-card.html');
-            assert.ok(url.includes('number=EIP-4844'), 'Should include number param');
-            assert.ok(url.includes('title=Shard+Blob+Transactions'), 'Should include title param');
-            assert.ok(url.includes('summary=Proto-danksharding'), 'Should include summary param');
+        it('places title in large white text', () => {
+            const prompt = buildPrompt({ title: 'ERC-8004: Trustless Agents' });
+            assert.ok(prompt.includes('Title at top in large white text: "ERC-8004: Trustless Agents"'));
         });
 
-        it('builds correct URL for code_snippet', () => {
-            const url = buildTemplateUrl('code_snippet', { code: 'console.log("hi")', lang: 'javascript' });
-            assert.ok(url.includes('code-snippet.html'), 'Should reference code-snippet.html');
+        it('includes metric prominently', () => {
+            const prompt = buildPrompt({ title: 'Test', metric: '21,000+' });
+            assert.ok(prompt.includes('"21,000+"'));
+            assert.ok(prompt.includes('prominently'));
         });
 
-        it('builds correct URL for quote_card', () => {
-            const url = buildTemplateUrl('quote_card', { quote: 'Test quote', author: 'Vitalik' });
-            assert.ok(url.includes('quote-card.html'), 'Should reference quote-card.html');
+        it('includes diagram description when provided', () => {
+            const prompt = buildPrompt({
+                title: 'Test',
+                diagram: 'two panels: hex on left, decoded on right'
+            });
+            assert.ok(prompt.includes('Diagram: two panels'));
         });
 
-        it('throws for unknown type', () => {
-            assert.throws(
-                () => buildTemplateUrl('unknown_type', { foo: 'bar' }),
-                { message: /unknown template type/i }
-            );
-        });
-    });
-
-    describe('generateImage', () => {
-        const outputFiles = [];
-
-        after(() => {
-            for (const f of outputFiles) {
-                try { unlinkSync(f); } catch { /* ignore */ }
-            }
-            try { rmdirSync(tmpDir); } catch { /* ignore */ }
+        it('auto-generates diagram description when no diagram/code/quote', () => {
+            const prompt = buildPrompt({ title: 'Test', subtitle: 'Sub' });
+            assert.ok(prompt.includes('simple flat diagram'));
         });
 
-        it('renders stat_card to actual PNG file', async () => {
-            mkdirSync(tmpDir, { recursive: true });
-            const outputPath = join(tmpDir, 'stat-card-test.png');
-            outputFiles.push(outputPath);
+        it('includes code block for code specs', () => {
+            const prompt = buildPrompt({ title: 'Test', code: 'function foo() {}' });
+            assert.ok(prompt.includes('code block'));
+            assert.ok(prompt.includes('function foo'));
+        });
 
-            await generateImage({ type: 'stat_card', headline: '12,345', subtitle: 'Blocks indexed' }, outputPath);
+        it('includes quote for quote specs', () => {
+            const prompt = buildPrompt({ title: 'Test', quote: 'Hello world', author: 'Vitalik' });
+            assert.ok(prompt.includes('"Hello world"'));
+            assert.ok(prompt.includes('Vitalik'));
+        });
 
-            assert.ok(existsSync(outputPath), 'PNG file should exist');
-            const stats = statSync(outputPath);
-            assert.ok(stats.size > 1000, `PNG should be non-trivial size, got ${stats.size} bytes`);
+        it('includes no-repeat rule', () => {
+            const prompt = buildPrompt({ title: 'Test' });
+            assert.ok(prompt.includes('Do NOT repeat any text'));
         });
     });
 });

--- a/tweet-pipeline/package.json
+++ b/tweet-pipeline/package.json
@@ -6,7 +6,6 @@
     "test": "node --test lib/*.test.js"
   },
   "dependencies": {
-    "twitter-api-v2": "^1.29.0",
-    "playwright": "^1.49.0"
+    "twitter-api-v2": "^1.29.0"
   }
 }

--- a/tweet-pipeline/prompts/tweet-2-draft.md
+++ b/tweet-pipeline/prompts/tweet-2-draft.md
@@ -44,16 +44,14 @@ Save to `tweet-pipeline/.draft.json`:
   ],
   "imageSpec": {
     "type": "stat_card | eip_card | code_snippet | quote_card | blog_cover",
-    "title": "main text for the image",
-    "subtitle": "secondary text",
-    "metric": "the big number (for stat_card)",
-    "code": "code block content (for code_snippet)",
-    "quote": "quote text (for quote_card)",
-    "author": "attribution (for quote_card)"
+    "title": "main text for the image (appears as large title)",
+    "subtitle": "secondary text (smaller, below title)",
+    "metric": "the big number to display prominently",
+    "diagram": "describe a simple flat diagram to illustrate the concept (e.g. 'two panels: left=raw hex, right=decoded functions, ABI arrow between them' or 'timeline with 4 labeled nodes' or '3 connected boxes labeled X, Y, Z')"
   }
 }
 ```
 
-Only include the imageSpec fields relevant to the chosen type.
+Only include the imageSpec fields relevant to the chosen type. The `diagram` field is important — it tells the image generator what to draw. Be specific: describe panels, boxes, arrows, labels. Think whiteboard sketch, not abstract art.
 
 Print `::draft-ready::` when done.


### PR DESCRIPTION
## Summary
- Replace Playwright HTML template screenshots with Gemini API image generation
- Uses the same visual style as Ethernal blog cover images (dark navy, flat diagrammatic)
- Draft prompt updated to include `diagram` field for better image instructions
- Removes `playwright` dependency from tweet-pipeline
- 40/40 tests pass

## Test plan
- [x] Generated 5 tweet images locally with Gemini — all match blog cover style
- [x] All tweet-pipeline tests pass (40/40)
- [x] Showcase HTML verified with Playwright browser

Generated with [Claude Code](https://claude.com/claude-code)