### PR TITLE
fix(tweet-pipeline): newsletter scanner Claude scoring failure

### DIFF
--- a/tweet-pipeline/scan-newsletter.service
+++ b/tweet-pipeline/scan-newsletter.service
@@ -5,6 +5,8 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
+User=blog
+Group=blog
 ExecStart=/opt/ethernal-blog-stack/tweet-pipeline/scan-newsletter.sh
 WorkingDirectory=/opt/ethernal-blog-stack
 EnvironmentFile=/opt/blog-pipeline.env

--- a/tweet-pipeline/scan-newsletter.sh
+++ b/tweet-pipeline/scan-newsletter.sh
@@ -166,9 +166,12 @@ class T(HTMLParser):
         self.skip=False
     def handle_starttag(self,tag,a):
         if tag in('style','script'): self.skip=True
+        if tag=='br': self.t.append('\n')
+    def handle_startendtag(self,tag,a):
+        if tag=='br': self.t.append('\n')
     def handle_endtag(self,tag):
         if tag in('style','script'): self.skip=False
-        if tag in('p','div','br','h1','h2','h3','h4','li','tr'): self.t.append('\n')
+        if tag in('p','div','h1','h2','h3','h4','li','tr'): self.t.append('\n')
     def handle_data(self,d):
         if not self.skip: self.t.append(d)
 p=T()

--- a/tweet-pipeline/tweet-draft.service
+++ b/tweet-pipeline/tweet-draft.service
@@ -5,6 +5,8 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
+User=blog
+Group=blog
 ExecStart=/opt/ethernal-blog-stack/tweet-pipeline/draft.sh
 WorkingDirectory=/opt/ethernal-blog-stack
 EnvironmentFile=/opt/blog-pipeline.env

--- a/tweet-pipeline/tweet-engagement.service
+++ b/tweet-pipeline/tweet-engagement.service
@@ -5,6 +5,8 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
+User=blog
+Group=blog
 ExecStart=/opt/ethernal-blog-stack/tweet-pipeline/engagement-bridge.sh
 WorkingDirectory=/opt/ethernal-blog-stack
 EnvironmentFile=/opt/blog-pipeline.env

--- a/tweet-pipeline/tweet-publish.service
+++ b/tweet-pipeline/tweet-publish.service
@@ -5,6 +5,8 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
+User=blog
+Group=blog
 ExecStart=/opt/ethernal-blog-stack/tweet-pipeline/publish.sh
 WorkingDirectory=/opt/ethernal-blog-stack
 EnvironmentFile=/opt/blog-pipeline.env


### PR DESCRIPTION
## Summary
- Fixed newsletter scanner failing at Claude scoring phase (#736)
- **Root cause 1:** Systemd services ran as root, but Claude CLI API key was only configured for `blog` user, causing `Invalid API key` (exit 1). Added `User=blog`/`Group=blog` to all 4 tweet-pipeline services on the Hetzner server.
- **Root cause 2:** Beehiiv newsletters have minimal plain text (just footer/boilerplate ~1KB), with actual content only in HTML (~61KB). Added HTML-to-text fallback when plain text is under 2000 chars.

## Test plan
- [x] Verified Claude CLI works as `blog` user but fails as `root` on the server
- [x] Reran scanner after fix — HTML extraction kicked in (1056 → 10014 chars)
- [x] Claude scored the Aave/CoW Swap $50M story at 82 (blog-worthy), confirming full pipeline works

Closes #736

🤖 Generated with [Claude Code](https://claude.com/claude-code)