### PR TITLE
fix(pipeline): use fetch+merge instead of pull in promote-blog

### DIFF
--- a/tweet-pipeline/promote-blog.sh
+++ b/tweet-pipeline/promote-blog.sh
@@ -57,7 +57,8 @@ fi
 
 # Pull latest to get updated articles and images
 cd "$REPO_DIR"
-git pull origin develop --ff-only --autostash 2>&1 | tee -a "$LOG_FILE" || log "WARNING: git pull failed — using existing checkout"
+git fetch origin develop 2>&1 | tee -a "$LOG_FILE" || true
+git merge --ff-only FETCH_HEAD 2>&1 | tee -a "$LOG_FILE" || log "WARNING: git merge failed — using existing checkout"
 
 # Ensure we're in the right directory for Node.js imports
 cd "$SCRIPT_DIR"


### PR DESCRIPTION
## Summary
Fixes #761

- **Root cause:** `.promoted-articles` and `promote-blog.sh` were owned by `root:root` on the Hetzner server, but the systemd service runs as `blog` user. `touch .promoted-articles` failed with permission denied.
- **Secondary issue:** `git pull origin develop --ff-only` can fail with "Cannot fast-forward to multiple branches" when `FETCH_HEAD` has stale entries from concurrent pipeline runs.
- **Server fix:** `chown blog:blog` on both files (already applied).
- **Code fix:** Split `git pull` into `git fetch` + `git merge --ff-only FETCH_HEAD` to avoid the FETCH_HEAD multi-branch ambiguity.

## Test plan
- [x] Fixed file ownership on server
- [x] Verified `git fetch + merge` works correctly on server
- [ ] Next tweet-publish timer run (every 10 min) should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)