### PR TITLE
fix(pipeline): prevent scheduling tweets in the past

### DIFF
--- a/tweet-pipeline/config.js
+++ b/tweet-pipeline/config.js
@@ -64,5 +64,11 @@ export function getScheduledTime(date, baseHourUTC) {
     const scheduled = new Date(date);
     scheduled.setUTCHours(baseHourUTC, 0, 0, 0);
     const jitterMs = (Math.random() * 2 - 1) * SCHEDULE.jitterMinutes * 60 * 1000;
-    return new Date(scheduled.getTime() + jitterMs);
+    const result = new Date(scheduled.getTime() + jitterMs);
+
+    // If the scheduled time is in the past (draft ran late), push to at least 20 min from now
+    const minDelay = new Date(Date.now() + 20 * 60 * 1000);
+    if (result < minDelay) return minDelay;
+
+    return result;
 }


### PR DESCRIPTION
## Summary

When a draft runs late (e.g., slot 3 drafts at 15:32 with baseHour 15), negative jitter could produce a `scheduledAt` in the past. The publisher would post it immediately at the next 10-min cycle, causing two tweets within 40 minutes.

**Root cause:** `getScheduledTime(now, 15)` at 15:32 with -26 min jitter = 15:03 (past). Publisher sees "past scheduledAt" and posts immediately.

**Fix:** If the calculated time is in the past, push to at least 20 minutes from now.

## Test plan
- [x] Existing config tests still pass
- [x] Logic verified: `new Date(Date.now() + 20min)` always future

🤖 Generated with [Claude Code](https://claude.com/claude-code)