### PR TITLE
fix(pipeline): align slot detection ranges with timer schedule

### DIFF
--- a/tweet-pipeline/draft.sh
+++ b/tweet-pipeline/draft.sh
@@ -78,11 +78,12 @@ fi
 if [ -n "${1:-}" ]; then
   SLOT="$1"
 else
+  # Ranges match timer schedule: 06:30, 09:30, 12:30, 15:30, 18:30 UTC
   HOUR=$(date -u +%-H)
-  if   [ "$HOUR" -lt 9  ]; then SLOT=1
-  elif [ "$HOUR" -lt 12 ]; then SLOT=2
-  elif [ "$HOUR" -lt 17 ]; then SLOT=3
-  elif [ "$HOUR" -lt 19 ]; then SLOT=4
+  if   [ "$HOUR" -lt 8  ]; then SLOT=1
+  elif [ "$HOUR" -lt 11 ]; then SLOT=2
+  elif [ "$HOUR" -lt 14 ]; then SLOT=3
+  elif [ "$HOUR" -lt 17 ]; then SLOT=4
   else                          SLOT=5
   fi
 fi


### PR DESCRIPTION
## Summary

The hour ranges for auto-detecting tweet slots didn't match the systemd timer schedule, causing slot 3 to draft twice and slot 5 to never fire.

| Timer | Hour | Old Slot | New Slot |
|-------|------|----------|----------|
| 06:30 | 6 | 1 | 1 |
| 09:30 | 9 | 2 | 2 |
| 12:30 | 12 | 3 | 3 |
| 15:30 | 15 | **3 (dup!)** | **4** |
| 18:30 | 18 | **4** | **5** |

This caused today's double-post: slot 3 drafted at 12:30 (newsletter story) and again at 15:30 (product tip), both posted within 40 minutes.

## Test plan
- [x] Verified each timer hour maps to a unique slot
- [x] No slot overlap in the new ranges

🤖 Generated with [Claude Code](https://claude.com/claude-code)