### PR TITLE
feat(pipeline): post-draft semantic dedup + enriched feature tips

### DIFF
--- a/tweet-pipeline/draft.sh
+++ b/tweet-pipeline/draft.sh
@@ -331,6 +331,35 @@ check_claude_output "$PHASE3_OUTPUT" "Humanize (Phase 3)"
 log "Phase 3 complete."
 
 # ============================================================
+# Post-draft semantic dedup — catch overlaps Claude introduced
+# ============================================================
+DRAFT_HOOK=$(jq -r '.hook // empty' .draft.json 2>/dev/null)
+if [ -n "$DRAFT_HOOK" ]; then
+  RECENT_HOOKS_POST=$(find "$QUEUE_DIR" -name 'tweet-*.json' -mtime -30 -exec cat {} + 2>/dev/null \
+    | jq -r '.hook // empty' 2>/dev/null \
+    | jq -R -s 'split("\n") | map(select(. != ""))' 2>/dev/null \
+    || echo '[]')
+
+  POST_DUP=$(DRAFT_HOOK="$DRAFT_HOOK" RECENT_HOOKS_POST="$RECENT_HOOKS_POST" node --input-type=module -e "
+    import { isSemanticallyDuplicate, fetchPublishedBlogTitles } from './lib/source-selector.js';
+    const isDup = isSemanticallyDuplicate(
+      process.env.DRAFT_HOOK,
+      JSON.parse(process.env.RECENT_HOOKS_POST),
+      fetchPublishedBlogTitles(60),
+      []
+    );
+    console.log(isDup ? 'true' : 'false');
+  " 2>>"$LOG_FILE")
+
+  if [ "$POST_DUP" = "true" ]; then
+    log "WARNING: Drafted hook is semantically similar to recent content — aborting"
+    log "Hook was: $DRAFT_HOOK"
+    rm -f .source.json .research.md .draft.json
+    exit 0
+  fi
+fi
+
+# ============================================================
 # Image generation
 # ============================================================
 log "Generating image..."

--- a/tweet-pipeline/lib/source-selector.js
+++ b/tweet-pipeline/lib/source-selector.js
@@ -18,18 +18,18 @@ const BLOG_DIR = join(REPO_ROOT, 'blog', 'src', 'content', 'blog');
  * @type {Array<{title: string, description: string}>}
  */
 export const FEATURE_TIPS = [
-    { title: 'Custom branding on your explorer', description: 'Add your logo, colors, and domain to make the explorer match your chain\'s identity.' },
-    { title: 'One-click contract verification', description: 'Verify contracts instantly by uploading source code or using Hardhat/Foundry plugins.' },
-    { title: 'Transaction decoding', description: 'Ethernal automatically decodes transaction inputs and logs using uploaded or verified ABIs.' },
-    { title: 'DEX pair tracking', description: 'Track liquidity pools, swaps, and price charts for DEX pairs deployed on your chain.' },
-    { title: 'Token balance history', description: 'View historical token balances for any address, with charts showing changes over time.' },
-    { title: 'Real-time sync with WebSocket', description: 'Get instant updates on new blocks, transactions, and events via WebSocket subscriptions.' },
-    { title: 'Multi-chain workspace', description: 'Manage multiple chains from a single dashboard. Switch between networks in one click.' },
-    { title: 'API access for your explorer', description: 'Full REST API with Etherscan-compatible endpoints for programmatic access to chain data.' },
-    { title: 'Hardhat/Foundry integration', description: 'Auto-sync contracts and transactions during local development with our Hardhat and Foundry plugins.' },
-    { title: 'Historical data sync', description: 'Import historical blocks, transactions, and logs from any point in chain history.' },
-    { title: 'Gas usage analytics', description: 'Visualize gas consumption trends, top gas consumers, and optimize contract deployments.' },
-    { title: 'Hosted or self-hosted', description: 'Use our managed cloud service or deploy the open-source explorer on your own infrastructure.' },
+    { title: 'Custom branding whitelabel explorer', description: 'Add your logo, colors, and domain to make the explorer match your chain\'s identity.' },
+    { title: 'One-click contract verification Solidity Vyper', description: 'Verify contracts instantly by uploading source code or using Hardhat/Foundry plugins.' },
+    { title: 'Transaction decoding ABI calldata events', description: 'Ethernal automatically decodes transaction inputs and logs using uploaded or verified ABIs.' },
+    { title: 'DEX pair tracking liquidity pools swaps', description: 'Track liquidity pools, swaps, and price charts for DEX pairs deployed on your chain.' },
+    { title: 'Token balance history ERC-20 NFT portfolio', description: 'View historical token balances for any address, with charts showing changes over time.' },
+    { title: 'Real-time sync WebSocket eth_subscribe blocks', description: 'Get instant updates on new blocks, transactions, and events via WebSocket subscriptions.' },
+    { title: 'Multi-chain workspace L2 rollup dashboard', description: 'Manage multiple chains from a single dashboard. Switch between networks in one click.' },
+    { title: 'Etherscan-compatible REST API rate-limit-free', description: 'Full REST API with Etherscan-compatible endpoints for programmatic access to chain data.' },
+    { title: 'Hardhat Foundry Anvil integration local dev', description: 'Auto-sync contracts and transactions during local development with our Hardhat and Foundry plugins.' },
+    { title: 'Historical data sync import backfill blocks', description: 'Import historical blocks, transactions, and logs from any point in chain history.' },
+    { title: 'Gas usage analytics cost optimization EVM', description: 'Visualize gas consumption trends, top gas consumers, and optimize contract deployments.' },
+    { title: 'Hosted self-hosted open-source explorer deploy', description: 'Use our managed cloud service or deploy the open-source explorer on your own infrastructure.' },
 ];
 
 /**


### PR DESCRIPTION
## Summary

Fixes the gap where pre-draft dedup passed (generic feature tip title) but Claude drafted a hook about a topic already tweeted (Etherscan paywall story tweeted Mar 17, re-drafted Mar 19).

### Changes
1. **Post-draft dedup** — after Phase 3 (humanize), compares the drafted hook against recent hooks (30d) and blog titles (60d). Aborts before image generation if duplicate detected.
2. **Enriched feature tip titles** — adds domain keywords so pre-draft dedup has better signal (e.g. "API access for your explorer" → "Etherscan-compatible REST API rate-limit-free").

## Test plan
- [x] 22 unit tests passing
- [x] Verified post-draft dedup would catch the Etherscan case
- [ ] Monitor next draft runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)