### PR TITLE
fix(pipeline): add domain stop words to prevent false positive dedup

### DIFF
--- a/tweet-pipeline/lib/source-selector.js
+++ b/tweet-pipeline/lib/source-selector.js
@@ -107,6 +107,10 @@ const STOP_WORDS = new Set([
     'about', 'just', 'also', 'now', 'here', 'there', 'one', 'two', 'three',
     'new', 'your', 'you', 'they', 'them', 'their', 'our', 'we', 'my',
     'his', 'her', 'get', 'got', 'per', 'via', 'yet', 'still',
+    // Domain stop words — too common in Ethernal tweets to be meaningful for dedup
+    'evm', 'chain', 'blockchain', 'ethereum', 'explorer', 'block',
+    'transaction', 'contract', 'smart', 'dev', 'developer', 'web3',
+    'onchain', 'mainnet', 'testnet', 'deploy', 'node', 'network',
 ]);
 
 /**

--- a/tweet-pipeline/lib/source-selector.test.js
+++ b/tweet-pipeline/lib/source-selector.test.js
@@ -144,7 +144,7 @@ Body.`;
         it('extracts numbers with units as keywords', () => {
             const result = extractKeywords('$50.4M swapped for $36,000 in one transaction');
             assert.ok(result.has('swap'));       // "swapped" -> stem -> "swap"
-            assert.ok(result.has('transac'));    // "transaction" -> stem -> "transac"
+            // "transaction" is a domain stop word — not extracted
             assert.ok(result.has('50.4m'));
             assert.ok(result.has('36,000'));
         });


### PR DESCRIPTION
## Summary

Terms like "evm", "chain", "explorer", "dev" appear in nearly every Ethernal tweet, causing false positive dedup matches between unrelated topics. Adding 18 domain-specific stop words so dedup focuses on topic-specific keywords.

## Test plan
- [x] 22 tests passing (updated test for "transaction" now being a stop word)

🤖 Generated with [Claude Code](https://claude.com/claude-code)