### PR TITLE
fix(pipeline): filter stop words after stemming to catch plurals

### DIFF
--- a/tweet-pipeline/lib/source-selector.js
+++ b/tweet-pipeline/lib/source-selector.js
@@ -175,8 +175,9 @@ export function extractKeywords(text) {
         .map(w => w.replace(/[.,]+$/, ''))
         .filter(w => w.length >= 3 && !STOP_WORDS.has(w));
 
-    // Apply stemming for better cross-text matching
-    const stemmed = words.map(w => stem(w)).filter(w => w.length >= 3);
+    // Apply stemming for better cross-text matching, then re-filter stop words
+    // (plurals like "transactions" pass the pre-stem filter but stem back to "transaction")
+    const stemmed = words.map(w => stem(w)).filter(w => w.length >= 3 && !STOP_WORDS.has(w));
 
     return new Set([...stemmed, ...amounts]);
 }

--- a/tweet-pipeline/lib/source-selector.test.js
+++ b/tweet-pipeline/lib/source-selector.test.js
@@ -160,6 +160,17 @@ Body.`;
             assert.ok(result.has('rout'));       // "routing" -> stem -> "rout"
             assert.ok(result.has('failur'));     // "failure" -> stem -> "failur"
         });
+
+        it('filters domain stop words even in plural/inflected forms', () => {
+            const result = extractKeywords('Multiple transactions on different chains and blocks in the network');
+            // Plurals stem back to stop words — should all be excluded
+            assert.ok(!result.has('transaction'));  // "transactions" -> stem -> "transaction"
+            assert.ok(!result.has('chain'));        // "chains" -> stem -> "chain"
+            assert.ok(!result.has('block'));        // "blocks" -> stem -> "block"
+            assert.ok(!result.has('network'));      // singular, direct stop word
+            assert.ok(result.has('multiple'));      // not a stop word, kept
+            assert.ok(result.has('different'));     // not a stop word, kept
+        });
     });
 
     describe('isSemanticallyDuplicate', () => {


### PR DESCRIPTION
## Summary

- Fixes the stemming bypass identified in #777's Greptile review: plurals like "transactions", "contracts", "blocks" passed the pre-stem stop word filter, then stemmed back to their singular stop word roots, re-introducing false positive dedup matches
- Adds `!STOP_WORDS.has(w)` check to the post-stemming filter in `extractKeywords()`
- Adds test covering plural/inflected domain stop word filtering

## Test plan

- [x] All 23 existing source-selector tests pass
- [x] New test verifies "transactions", "chains", "blocks" are excluded after stemming
- [ ] Monitor tweet pipeline for a few days to confirm no regression in dedup behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)