### PR TITLE
fix: install ethernal-light from git tag with workspaceId fix

### DIFF
--- a/Dockerfile.pm2
+++ b/Dockerfile.pm2
@@ -4,7 +4,8 @@ WORKDIR /app
 
 COPY pm2-server/package.json pm2-server/yarn.lock pm2-server/app.js pm2-server/index.js pm2-server/ecosystem.config.js pm2-server/logListener.js pm2-server/opLogListener.js ./
 COPY pm2-server/lib/ ./lib
-RUN yarn global add ethernal-light pm2
+RUN yarn global add pm2
+RUN yarn global add https://github.com/tryethernal/ethernal-cli-light.git#v0.1.15
 RUN pm2 install pm2-logrotate
 
 FROM base AS dev


### PR DESCRIPTION
## Summary
NPM publish for ethernal-light is broken (token issue). Install directly from the git tag v0.1.15 which includes the `workspaceId` fix for blockSync jobs.

The cli-light was the only caller enqueuing blockSync without `workspaceId`, causing all blocks to fail with "Missing workspaceId" after PR #804 was deployed.

## Changes
- `Dockerfile.pm2`: Install `ethernal-light` from git tag instead of npm

## Test plan
- [x] PM2 app already deployed with this change and verified working

🤖 Generated with [Claude Code](https://claude.com/claude-code)