### PR TITLE
fix: throw on invalid job params instead of silent return

### DIFF
--- a/run/jobs/batchBlockSync.js
+++ b/run/jobs/batchBlockSync.js
@@ -17,12 +17,11 @@ const RECHUNK_DELAY = 3000;
 module.exports = async job => {
     const data = job.data;
 
-    if (!data.userId || !data.workspace || data.from === null || data.from === undefined || data.to === null || data.to === undefined) {
-        return 'Missing parameter.';
-    }
+    if (!data.userId || !data.workspace || data.from === null || data.from === undefined || data.to === null || data.to === undefined)
+        throw new Error('Missing parameter.');
 
     if (!data.workspaceId)
-        return 'Missing workspaceId.';
+        throw new Error('Missing workspaceId.');
 
     const from = parseInt(data.from);
     const to = parseInt(data.to);

--- a/run/jobs/blockSync.js
+++ b/run/jobs/blockSync.js
@@ -25,14 +25,11 @@ module.exports = async job => {
     const data = job.data;
 
     // Require workspaceId to prevent N+1 query regressions
-    if (!data.workspaceId) {
-        logger.error('blockSync job missing workspaceId — block dropped', { location: 'jobs.blockSync', data });
-        return 'Missing workspaceId - all blockSync jobs must include workspaceId';
-    }
+    if (!data.workspaceId)
+        throw new Error('Missing workspaceId');
 
-    if (data.blockNumber === undefined || data.blockNumber === null) {
-        return 'Missing parameter';
-    }
+    if (data.blockNumber === undefined || data.blockNumber === null)
+        throw new Error('Missing blockNumber');
 
     let workspace;
 

--- a/run/tests/jobs/batchBlockSync.test.js
+++ b/run/tests/jobs/batchBlockSync.test.js
@@ -9,9 +9,8 @@ const batchBlockSync = require('../../jobs/batchBlockSync');
 beforeEach(() => jest.clearAllMocks());
 
 describe('batchBlockSync', () => {
-    it('Should return if missing parameters', async () => {
-        const result = await batchBlockSync({ data: {} });
-        expect(result).toEqual('Missing parameter.');
+    it('Should throw if missing parameters', async () => {
+        await expect(batchBlockSync({ data: {} })).rejects.toThrow('Missing parameter.');
         expect(bulkEnqueue).not.toHaveBeenCalled();
     });
 
@@ -23,11 +22,10 @@ describe('batchBlockSync', () => {
         expect(bulkEnqueue).not.toHaveBeenCalled();
     });
 
-    it('Should return if missing workspaceId', async () => {
-        const result = await batchBlockSync({
+    it('Should throw if missing workspaceId', async () => {
+        await expect(batchBlockSync({
             data: { userId: '123', workspace: 'My Workspace', from: 1, to: 5 }
-        });
-        expect(result).toEqual('Missing workspaceId.');
+        })).rejects.toThrow('Missing workspaceId.');
         expect(bulkEnqueue).not.toHaveBeenCalled();
     });
 

--- a/run/tests/jobs/blockSync.test.js
+++ b/run/tests/jobs/blockSync.test.js
@@ -534,12 +534,9 @@ describe('blockSync', () => {
             });
     });
 
-    it('Should return if workspaceId is missing', (done) => {
-        blockSync({ opts: { priority: 1 }, data: { blockNumber: 1 }})
-            .then(res => {
-                expect(res).toEqual('Missing workspaceId - all blockSync jobs must include workspaceId');
-                done();
-            });
+    it('Should throw if workspaceId is missing', async () => {
+        await expect(blockSync({ opts: { priority: 1 }, data: { blockNumber: 1 }}))
+            .rejects.toThrow('Missing workspaceId');
     });
 
     it('Should return if no subscription for non-api source', (done) => {
@@ -555,12 +552,9 @@ describe('blockSync', () => {
             });
     });
 
-    it('Should return Missing parameter on fast path when blockNumber is missing', (done) => {
-        blockSync({ opts: { priority: 1 }, data: { workspaceId: 1 }})
-            .then(res => {
-                expect(res).toEqual('Missing parameter');
-                done();
-            });
+    it('Should throw when blockNumber is missing', async () => {
+        await expect(blockSync({ opts: { priority: 1 }, data: { workspaceId: 1 }}))
+            .rejects.toThrow('Missing blockNumber');
     });
 
     it('Should fail if block cannot be found', (done) => {


### PR DESCRIPTION
## Summary
Jobs returning a string on invalid params (missing workspaceId, missing blockNumber) are marked as **completed** by BullMQ, hiding errors from Sentry and monitoring. This changes them to throw so they appear as **failed** jobs.

Affected jobs: `blockSync`, `batchBlockSync`

## Test plan
- [x] All blockSync tests pass
- [x] All batchBlockSync tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)