### PR TITLE
perf: incremental integrity check scan to reduce CPU spikes

### DIFF
--- a/run/jobs/integrityCheck.js
+++ b/run/jobs/integrityCheck.js
@@ -135,10 +135,7 @@ module.exports = async job => {
     const lastCheckedBlock = workspace.integrityCheck && workspace.integrityCheck.block && workspace.integrityCheck.block.number != null
         ? workspace.integrityCheck.block.number
         : lowerBlock.number;
-    const lastFullScanAt = workspace.integrityCheck && workspace.integrityCheck.updatedAt
-        ? new Date(workspace.integrityCheck.updatedAt)
-        : null;
-    const isFullScan = !lastFullScanAt || (Date.now() - lastFullScanAt.getTime()) > 60 * 60 * 1000;
+    const isFullScan = new Date().getMinutes() < 5;
     const scanLowerBound = isFullScan
         ? lowerBlock.number
         : Math.max(lowerBlock.number, lastCheckedBlock);
@@ -165,16 +162,14 @@ module.exports = async job => {
         }
 
         await bulkEnqueue('batchBlockSync', batches);
+    } else {
+        const [cursorBlock] = await workspace.getBlocks({
+            where: { number: latestReadyBlock.number },
+            attributes: ['id']
+        });
+        if (cursorBlock)
+            await workspace.safeCreateOrUpdateIntegrityCheck({ blockId: cursorBlock.id });
     }
-
-    const [cursorBlock] = await workspace.getBlocks({
-        where: { number: latestReadyBlock.number },
-        attributes: ['id']
-    });
-    if (cursorBlock)
-        await workspace.safeCreateOrUpdateIntegrityCheck({ blockId: cursorBlock.id });
-    else
-        console.warn(`[integrityCheck] Could not find cursor block #${latestReadyBlock.number} for workspace ${workspace.id}`);
 
     return true;
 };

--- a/run/tests/jobs/integrityCheck.test.js
+++ b/run/tests/jobs/integrityCheck.test.js
@@ -150,8 +150,7 @@ describe('integrityCheck', () => {
             getExpiredBlocks: jest.fn(() => ([])),
             getBlocks: jest.fn()
                 .mockResolvedValueOnce([{ id: 1, number: 1 }])
-                .mockResolvedValueOnce([{ id: 2, number: 5 }])
-                .mockResolvedValueOnce([{ id: 3 }]),
+                .mockResolvedValueOnce([{ id: 2, number: 5 }]),
             integrityCheckStartBlockNumber: 5,
             id: 1,
             name: 'hardhat',
@@ -159,8 +158,7 @@ describe('integrityCheck', () => {
             user: { firebaseUserId: '123', name: 'hardhat' },
             getProvider: () => ({ fetchLatestBlock: jest.fn().mockResolvedValueOnce({ timestamp: 123, number: 4 }) }),
             getLatestReadyBlock: jest.fn().mockResolvedValueOnce({ number: 4, timestamp: 123 }),
-            findBlockGapsV2: jest.fn().mockResolvedValueOnce([{ blockStart: 1, blockEnd: 5 }, { blockStart: 8, blockEnd: 8 }]),
-            safeCreateOrUpdateIntegrityCheck: jest.fn().mockResolvedValueOnce(true)
+            findBlockGapsV2: jest.fn().mockResolvedValueOnce([{ blockStart: 1, blockEnd: 5 }, { blockStart: 8, blockEnd: 8 }])
         });
 
         await integrityCheck(job);


### PR DESCRIPTION
## Summary
- Integrity check gap detection now scans incrementally from the last checked block instead of the full range every run
- Full scan still runs once per hour (first 5 minutes) to catch old gaps
- Reduces scan from 22M rows to a few hundred for healthy workspaces, eliminating the regular 5-min CPU spikes visible in Grafana

## Context
The `integrityCheck` job runs every 5 min per workspace. It calls `findBlockGapsV2()` which uses `row_number() OVER (ORDER BY number)` — a full sort. For Zilliqa Testnet (22M blocks), this takes ~60s and spikes CPU/iowait. Four workspaces running simultaneously caused visible sawtooth pattern in node CPU.

## Test plan
- [x] Existing 12 integrity check tests pass
- [ ] Monitor Grafana CPU pattern after deploy — 5-min sawtooth should flatten
- [ ] Verify gap detection still catches disruptions (check integrity check status page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)