### PR TITLE
feat: Hetzner maintenance banner and page (April 1)

### DIFF
--- a/scripts/maintenance.sh
+++ b/scripts/maintenance.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+case "$1" in
+  on)
+    echo "Stopping workers (jobs will queue in Redis)..."
+    flyctl scale count hworker=0 mworker=0 lpworker=0 phworker=0 -a ethernal
+    echo "Workers stopped. API still running."
+    flyctl status -a ethernal
+    ;;
+  off)
+    echo "Starting workers (will drain queued jobs)..."
+    flyctl scale count hworker=3 mworker=1 lpworker=2 phworker=1 -a ethernal
+    echo "Workers restored."
+    flyctl status -a ethernal
+    ;;
+  *)
+    echo "Usage: $0 {on|off}"
+    echo "  on  - Stop workers for maintenance (jobs queue in Redis)"
+    echo "  off - Restart workers (drain backlog)"
+    exit 1
+    ;;
+esac

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,17 +1,40 @@
 <template>
     <v-app :style="styles">
-        <v-overlay persistent class="d-flex justify-center align-center" :model-value="isOverlayActive" scrim="primary" :opacity="0.2">
-            <v-progress-circular
-                indeterminate
-                size="64"
-                color="primary"
-            ></v-progress-circular>
-        </v-overlay>
+        <!-- Maintenance page: shown during the maintenance window -->
+        <template v-if="isMaintenanceWindow">
+            <v-container class="fill-height d-flex align-center justify-center">
+                <v-card max-width="500" class="text-center pa-8" variant="outlined">
+                    <v-icon size="48" color="warning" class="mb-4">mdi-wrench</v-icon>
+                    <v-card-title class="text-h5 mb-2">Scheduled Maintenance</v-card-title>
+                    <v-card-text class="text-body-1">
+                        <p>We're performing scheduled maintenance and the app is temporarily unavailable.</p>
+                        <v-chip color="warning" variant="tonal" class="mt-4 mb-2">
+                            April 1, 7:45 &ndash; 8:45 AM UTC
+                        </v-chip>
+                        <p class="mt-4">We'll be back shortly.</p>
+                    </v-card-text>
+                </v-card>
+            </v-container>
+        </template>
 
-        <v-overlay persistent class="d-flex justify-center align-center" :model-value="isWalletConnecting" scrim="primary" :opacity="0.2">
-        </v-overlay>
+        <!-- Normal app: shown outside the maintenance window -->
+        <template v-else>
+            <v-overlay persistent class="d-flex justify-center align-center" :model-value="isOverlayActive" scrim="primary" :opacity="0.2">
+                <v-progress-circular
+                    indeterminate
+                    size="64"
+                    color="primary"
+                ></v-progress-circular>
+            </v-overlay>
 
-        <v-system-bar height="40" v-html="banner" v-if="banner" class="d-flex justify-start font-weight-bold" color="primary"></v-system-bar>
+            <v-overlay persistent class="d-flex justify-center align-center" :model-value="isWalletConnecting" scrim="primary" :opacity="0.2">
+            </v-overlay>
+
+            <v-system-bar height="40" v-if="showMaintenanceBanner" class="d-flex justify-center font-weight-bold" color="warning">
+                Scheduled maintenance on April 1, 7:45 &ndash; 8:45 AM UTC. The app may be temporarily unavailable during this window.
+            </v-system-bar>
+
+            <v-system-bar height="40" v-html="banner" v-if="banner" class="d-flex justify-start font-weight-bold" color="primary"></v-system-bar>
 
             <component :is="appBarComponent" :styles="styles" @toggleMenu="toggleMenu" v-if="canDisplaySides"></component>
 
@@ -34,12 +57,13 @@
                 <component :is="routerComponent"></component>
             </v-main>
 
-        <component :is="isPrivateExplorer ? PrivateExplorerFooter : PublicExplorerFooter" v-if="canDisplaySides" />
+            <component :is="isPrivateExplorer ? PrivateExplorerFooter : PublicExplorerFooter" v-if="canDisplaySides" />
+        </template>
     </v-app>
 </template>
 
 <script setup>
-import { ref, shallowRef, computed, defineComponent, onMounted, onBeforeUnmount, inject } from 'vue';
+import { ref, shallowRef, computed, watch, defineComponent, onMounted, onBeforeUnmount, onUnmounted, inject } from 'vue';
 import { useTheme } from 'vuetify';
 import WebFont from 'webfontloader';
 import detectEthereumProvider from '@metamask/detect-provider';
@@ -86,6 +110,19 @@ const browserSyncExplainerModal = ref();
 
 const $server = inject('$server');
 const $pusher = inject('$pusher');
+
+// Maintenance window: April 1, 2026 7:45-8:45 AM UTC (temporary, remove after April 1)
+const MAINTENANCE_START = new Date('2026-04-01T07:45:00Z').getTime();
+const MAINTENANCE_END = new Date('2026-04-01T08:45:00Z').getTime();
+const now = ref(Date.now());
+let maintenanceTimer;
+onMounted(() => { maintenanceTimer = setInterval(() => { now.value = Date.now(); }, 30000); });
+onUnmounted(() => { clearInterval(maintenanceTimer); });
+const showMaintenanceBanner = computed(() => now.value < MAINTENANCE_START);
+const isMaintenanceWindow = computed(() => now.value >= MAINTENANCE_START && now.value < MAINTENANCE_END);
+watch(isMaintenanceWindow, (inMaintenance, wasMaintenance) => {
+    if (wasMaintenance && !inMaintenance) window.location.reload();
+});
 
 // Computed properties
 const isAuthPage = computed(() => {
@@ -344,6 +381,9 @@ function lightenColor(hex, percent) {
 }
 
 onMounted(() => {
+    // Skip all app initialization during maintenance window
+    if (isMaintenanceWindow.value) return;
+
     document.addEventListener('click', handleClickEvent);
     detectEthereumProvider().then(provider => {
         if (!provider || provider !== window.ethereum) return;


### PR DESCRIPTION
## Summary
- Warning banner shown to all users before the maintenance window
- Full-screen maintenance page during April 1, 7:45-8:45 AM UTC
- Auto-reload when maintenance ends so the app recovers automatically
- Worker scale script (`scripts/maintenance.sh on/off`) for stopping/starting Fly workers

Same approach as PR #508 (March 10 maintenance). Temporary, remove after April 1.

## Test plan
- [ ] Verify banner shows on the dashboard
- [ ] Verify maintenance page renders during the window (can test by temporarily adjusting dates)
- [ ] Verify auto-reload triggers when window ends

Generated with [Claude Code](https://claude.com/claude-code)