### PR TITLE
perf: tune connection pool to reduce blockSync latency

### DIFF
--- a/run/config/database.js
+++ b/run/config/database.js
@@ -29,11 +29,11 @@ module.exports = {
             logger.debug(sql, { instance: sequelizeObject.instance });
         },
         "pool": {
-            max: 400,
+            max: 100,
             min: 5,
             acquire: 10000,
-            idle: 10000,
-            evict: 1000
+            idle: 30000,
+            evict: 5000
         }
     }
 }


### PR DESCRIPTION
## Summary

- **Reduces Sequelize pool max from 400 to 100** per machine (still 900 total across 9 machines, well within PgBouncer's 2000 max_client_conn)
- **Increases idle timeout from 10s to 30s** to stop the kill-reconnect cycle that was causing 30+ simultaneous PgBouncer login attempts every 10s
- **Increases evict interval from 1s to 5s** for less aggressive idle connection scanning

**Companion change** (already pushed to k8s-iac): PgBouncer `default_pool_size` 15→30, PostgreSQL `max_connections` 160→200.

## Root Cause

Sentry issues #877 and #878 reported ~1800 slow DB query events/24h in `blockSync`. Investigation revealed connection establishment was the bottleneck (396ms), not the queries themselves (47ms).

The Sequelize pool (max: 400, idle: 10s, evict: 1s) was churning connections every ~10s. PgBouncer logs showed batches of 12+ connections closing simultaneously, followed by 30+ login attempts flooding in within 1 second. With only 15 server-side connections in PgBouncer, these queued up causing the 396ms delay.

Also ran `VACUUM ANALYZE orbit_chain_configs` (last autoanalyze was Jan 4, contributing to #877's 1.12s query on an empty table).

## Test plan

- [ ] Deploy and monitor Sentry events for #877/#878 over 24h
- [ ] Check PgBouncer logs for reduced connection churn
- [ ] Verify `pg_stat_activity` connection count stays stable (no more sawtooth pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)