### PR TITLE
fix(security): prevent NFT image XSS in ERC721 views

### DIFF
--- a/src/components/ERC721TokenCard.vue
+++ b/src/components/ERC721TokenCard.vue
@@ -33,16 +33,24 @@
                     </div>
                 </template>
             </v-img>
-            <v-img v-else-if="!imageData.startsWith('<img')"
-                :src="getImageTag(imageData)"
+            <v-img v-else-if="imageSrc"
+                :src="imageSrc"
                 rounded="lg"
                 height="150"
                 cover
                 :style="`background-color: ${backgroundColor ? '#' + backgroundColor : ''};`">
             </v-img>
-            <div v-else class="image-container">
-                <span v-html="getImageTag(imageData)"></span>
-            </div>
+            <v-img v-else
+                height="150"
+                rounded="lg"
+                class="bg-grey-lighten-4"
+                cover>
+                <template v-slot:default>
+                    <div class="d-flex align-center justify-center fill-height">
+                        <v-icon size="150" color="grey-lighten-1">mdi-image-outline</v-icon>
+                    </div>
+                </template>
+            </v-img>
 
             <!-- Content Section -->
             <v-card-text class="pa-0 pt-2 d-flex flex-column card-content">
@@ -109,7 +117,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, inject } from 'vue';
+import { computed, ref, onMounted, inject } from 'vue';
 import { useRouter } from 'vue-router';
 import HashLink from './HashLink.vue';
 
@@ -136,21 +144,36 @@ const backgroundColor = ref(null);
 const loading = ref(false);
 
 // Methods
+const getSafeImageSrc = (image) => {
+    if (!image || typeof image !== 'string') return null;
+
+    if (image.startsWith('ipfs://')) {
+        return `https://gateway.pinata.cloud/ipfs/${image.slice(7, image.length)}`;
+    }
+
+    if (image.startsWith('<img')) {
+        const srcMatch = image.match(/\bsrc\s*=\s*["']([^"']+)["']/i);
+        if (!srcMatch || !srcMatch[1]) return null;
+        return getSafeImageSrc(srcMatch[1]);
+    }
+
+    if (
+        image.startsWith('http://') ||
+        image.startsWith('https://') ||
+        image.startsWith('data:image/')
+    ) {
+        return image;
+    }
+
+    return null;
+};
+
+const imageSrc = computed(() => getSafeImageSrc(imageData.value));
+
 const navigateToToken = () => {
     if (tokenId.value) {
         router.push(`/token/${props.contractAddress}/${tokenId.value}`);
     }
-};
-
-const getImageTag = (image) => {
-    if (!image) return null;
-    if (image.startsWith('ipfs://')) {
-        return `https://gateway.pinata.cloud/ipfs/${image.slice(7, image.length)}`;
-    }
-    if (image.startsWith('<img')) {
-        return '<img class="rounded-lg"' + image.slice(4, image.length);
-    }
-    return `<img rounded="lg" src="${image}" />`;
 };
 
 // Computed value for slot data

--- a/src/components/TokenTransfers.vue
+++ b/src/components/TokenTransfers.vue
@@ -137,16 +137,25 @@
                                 </div>
                             </template>
                         </v-img>
-                        <v-img v-else-if="!imageData(item).startsWith('<img')"
-                            :src="getImageTag(imageData(item))"
+                        <v-img v-else-if="getSafeImageSrc(imageData(item))"
+                            :src="getSafeImageSrc(imageData(item))"
                             rounded="lg"
                             max-height="50"
                             max-width="50"
                             cover>
                         </v-img>
-                        <div v-else class="image-container">
-                            <span v-html="getImageTag(imageData(item))"></span>
-                        </div>
+                        <v-img v-else
+                            max-height="50"
+                            max-width="50"
+                            rounded="lg"
+                            class="bg-grey-lighten-4"
+                            cover>
+                            <template v-slot:default>
+                                <div class="d-flex align-center justify-center fill-height">
+                                    <v-icon size="50" color="grey-lighten-1">mdi-image-outline</v-icon>
+                                </div>
+                            </template>
+                        </v-img>
                     </router-link>
                     <div class="ml-2 d-flex flex-column text-truncate">
                         <span v-tooltip="`${item.contract.tokenName || '- '} #${item.tokenId}`" class="text-truncate">
@@ -308,19 +317,29 @@ const imageData = (item) => {
     return tokenMetadata.value[item.token] && tokenMetadata.value[item.token][item.tokenId] ? tokenMetadata.value[item.token][item.tokenId].metadata.image : null;
 };
 
-const getImageTag = (image) => {
+const getSafeImageSrc = (image) => {
     if (!image)
         return null;
-    else if (image.startsWith('ipfs://')) {
+
+    if (image.startsWith('ipfs://')) {
         return `https://gateway.pinata.cloud/ipfs/${image.slice(7, image.length)}`;
     }
-    else if (image.startsWith('<img')) {
+
+    if (image.startsWith('<img')) {
+        const srcMatch = image.match(/\bsrc\s*=\s*["']([^"']+)["']/i);
+        if (!srcMatch || !srcMatch[1]) return null;
+        return getSafeImageSrc(srcMatch[1]);
+    }
+
+    if (
+        image.startsWith('http://') ||
+        image.startsWith('https://') ||
+        image.startsWith('data:image/')
+    ) {
         return image;
     }
-    else if (image.startsWith('http')) {
-        return image;
-    }
-    return `<img width="50" height="50" src="${image}" />`;
+
+    return null;
 };
 
 // Methods

--- a/src/components/TokenTransfers.vue
+++ b/src/components/TokenTransfers.vue
@@ -318,25 +318,33 @@ const imageData = (item) => {
 };
 
 const getSafeImageSrc = (image) => {
-    if (!image)
+    if (typeof image !== 'string')
         return null;
 
-    if (image.startsWith('ipfs://')) {
-        return `https://gateway.pinata.cloud/ipfs/${image.slice(7, image.length)}`;
+    const normalized = image.trim();
+    if (!normalized)
+        return null;
+
+    if (normalized.startsWith('ipfs://')) {
+        return `https://gateway.pinata.cloud/ipfs/${normalized.slice(7, normalized.length)}`;
     }
 
-    if (image.startsWith('<img')) {
-        const srcMatch = image.match(/\bsrc\s*=\s*["']([^"']+)["']/i);
+    if (normalized.startsWith('<img')) {
+        const srcMatch = normalized.match(/\bsrc\s*=\s*["']([^"']+)["']/i);
         if (!srcMatch || !srcMatch[1]) return null;
         return getSafeImageSrc(srcMatch[1]);
     }
 
-    if (
-        image.startsWith('http://') ||
-        image.startsWith('https://') ||
-        image.startsWith('data:image/')
-    ) {
-        return image;
+    if (normalized.startsWith('http://') || normalized.startsWith('https://')) {
+        return normalized;
+    }
+
+    if (normalized.startsWith('data:image/')) {
+        const allowedDataImagePattern = /^data:image\/(png|jpe?g|gif|webp);/i;
+        if (allowedDataImagePattern.test(normalized)) {
+            return normalized;
+        }
+        return null;
     }
 
     return null;


### PR DESCRIPTION
## Summary
This PR fixes an XSS risk in NFT image rendering by removing `v-html` usage for untrusted token metadata.

## Security issue
`image_data`/`metadata.image` can come from untrusted NFT metadata. The previous implementation rendered HTML directly (`v-html`), allowing script/event injection.

## Fix
- Remove `v-html` rendering paths in:
  - `src/components/ERC721TokenCard.vue`
  - `src/components/TokenTransfers.vue`
- Add safe image parsing:
  - Supports `ipfs://` (converted to gateway URL)
  - Supports `http://`, `https://`, `data:image/`
  - If raw `<img ...>` is provided, extract only `src` and re-validate
- Unsafe/invalid values now fall back to placeholder image.

This preserves UX while preventing HTML/script injection from NFT metadata.

Signed-off-by: Phu Si On <phusi319@users.noreply.github.com>