### PR TITLE
fix: correct issues in auto-merged Sentry pipeline PRs

### DIFF
--- a/run/jobs/finalizePendingOpBatches.js
+++ b/run/jobs/finalizePendingOpBatches.js
@@ -9,84 +9,61 @@ const { OpBatch, OpChainConfig, Workspace } = require('../models');
 const { Op } = require('sequelize');
 const { withTimeout } = require('../lib/utils');
 
-// Simple in-memory job overlap prevention
-let isJobRunning = false;
-
 module.exports = async () => {
-    // Prevent overlapping job executions
-    if (isJobRunning) {
-        logger.debug('OP batch finalization job already running, skipping this execution');
-        return 'Skipped - job already running';
-    }
+    const opConfigs = await withTimeout(
+        OpChainConfig.findAll({
+            include: [{
+                model: Workspace,
+                as: 'parentWorkspace',
+                required: true
+            }]
+        }),
+        20000
+    );
 
-    isJobRunning = true;
     let totalConfirmed = 0;
 
-    try {
-        // Find all OP child configs with timeout protection (20s timeout, well under job frequency)
-        const opConfigs = await withTimeout(
-            OpChainConfig.findAll({
-                include: [{
-                    model: Workspace,
-                    as: 'parentWorkspace',
-                    required: true
-                }]
-            }),
-            20000 // 20 second timeout
-        );
+    for (const opConfig of opConfigs) {
+        try {
+            const parentWorkspace = opConfig.parentWorkspace;
+            if (!parentWorkspace || !parentWorkspace.rpcServer) continue;
 
-        for (const opConfig of opConfigs) {
-            try {
-                const parentWorkspace = opConfig.parentWorkspace;
-                if (!parentWorkspace || !parentWorkspace.rpcServer) continue;
+            const client = parentWorkspace.getViemPublicClient();
+            const safeBlock = await withTimeout(
+                client.getBlock({ blockTag: 'safe' }),
+                15000
+            );
 
-                // Add timeout for external RPC calls (15s timeout)
-                const client = parentWorkspace.getViemPublicClient();
-                const safeBlock = await withTimeout(
-                    client.getBlock({ blockTag: 'safe' }),
-                    15000
-                );
+            logger.info(`Validating OP batches for workspace ${opConfig.workspaceId} against safe block ${safeBlock.number}`);
 
-                logger.info(`Validating OP batches for workspace ${opConfig.workspaceId} against safe block ${safeBlock.number}`);
-
-                // Add timeout for database update operation (10s timeout)
-                const [confirmedCount] = await withTimeout(
-                    OpBatch.update(
-                        { status: 'confirmed' },
-                        {
-                            where: {
-                                workspaceId: opConfig.workspaceId,
-                                status: 'pending',
-                                l1BlockNumber: {
-                                    [Op.lte]: Number(safeBlock.number)
-                                }
+            const [confirmedCount] = await withTimeout(
+                OpBatch.update(
+                    { status: 'confirmed' },
+                    {
+                        where: {
+                            workspaceId: opConfig.workspaceId,
+                            status: 'pending',
+                            l1BlockNumber: {
+                                [Op.lte]: Number(safeBlock.number)
                             }
                         }
-                    ),
-                    10000
-                );
+                    }
+                ),
+                10000
+            );
 
-                if (confirmedCount > 0)
-                    logger.info(`Confirmed ${confirmedCount} OP batches for workspace ${opConfig.workspaceId}`);
+            if (confirmedCount > 0)
+                logger.info(`Confirmed ${confirmedCount} OP batches for workspace ${opConfig.workspaceId}`);
 
-                totalConfirmed += confirmedCount;
-            } catch (error) {
-                logger.error(`Error finalizing OP batches for config ${opConfig.id}: ${error.message}`, {
-                    location: 'jobs.finalizePendingOpBatches',
-                    error,
-                    configId: opConfig.id
-                });
-            }
+            totalConfirmed += confirmedCount;
+        } catch (error) {
+            logger.error(`Error finalizing OP batches for config ${opConfig.id}: ${error.message}`, {
+                location: 'jobs.finalizePendingOpBatches',
+                error,
+                configId: opConfig.id
+            });
         }
-
-        return `Confirmed ${totalConfirmed} OP batches`;
-    } catch (error) {
-        logger.error(`Critical error in OP batch finalization job: ${error.message}`, {
-            location: 'jobs.finalizePendingOpBatches',
-            error
-        });
-        throw error; // Re-throw to let BullMQ handle retries
-    } finally {
-        isJobRunning = false; // Always reset the flag
     }
+
+    return `Confirmed ${totalConfirmed} OP batches`;
 };

--- a/run/jobs/processTransactionTrace.js
+++ b/run/jobs/processTransactionTrace.js
@@ -5,7 +5,7 @@
  */
 
 const db = require('../lib/firebase');
-const { Transaction, Workspace, Explorer, RpcHealthCheck, StripeSubscription, sequelize } = require('../models');
+const { Transaction, Workspace, Explorer, RpcHealthCheck, StripeSubscription } = require('../models');
 const { Tracer } = require('../lib/rpc');
 
 module.exports = async job => {
@@ -14,66 +14,51 @@ module.exports = async job => {
     if (!data.transactionId)
         return 'Missing parameter';
 
-    // Use a transaction to ensure database queries reuse the same connection
-    // This reduces connection pool pressure under high load
-    const result = await sequelize.transaction(async (t) => {
-        // Fetch transaction with minimal workspace data to avoid expensive multi-table joins
-        const transaction = await Transaction.findByPk(data.transactionId, {
-            include: [
-                {
-                    model: Workspace,
-                    as: 'workspace',
-                    attributes: ['id', 'public', 'rpcHealthCheckEnabled', 'rpcServer', 'tracing', 'name']
-                }
-            ],
-            transaction: t
-        });
-
-        if (!transaction)
-            return { error: 'Cannot find transaction' };
-
-        if (!transaction.workspace.public)
-            return { error: 'Not allowed on private workspaces' };
-
-        // Load explorer data with targeted query (much faster than complex nested joins)
-        const explorer = await Explorer.findOne({
-            where: { workspaceId: transaction.workspace.id },
-            attributes: ['id', 'shouldSync'],
-            include: {
-                model: StripeSubscription,
-                as: 'stripeSubscription',
-                attributes: ['id'],
-                required: false
-            },
-            transaction: t
-        });
-
-        if (!explorer)
-            return { error: 'Inactive explorer' };
-
-        if (!explorer.shouldSync)
-            return { error: 'Sync is disabled' };
-
-        // Load RPC health check separately if enabled (only when needed)
-        if (transaction.workspace.rpcHealthCheckEnabled) {
-            const healthCheck = await RpcHealthCheck.findOne({
-                where: { workspaceId: transaction.workspace.id },
-                attributes: ['isReachable'],
-                transaction: t
-            });
-
-            if (healthCheck && !healthCheck.isReachable)
-                return { error: 'RPC is not reachable' };
-        }
-
-        return { transaction, explorer };
+    // Fetch transaction with minimal workspace data to avoid expensive multi-table joins
+    const transaction = await Transaction.findByPk(data.transactionId, {
+        include: [
+            {
+                model: Workspace,
+                as: 'workspace',
+                attributes: ['id', 'public', 'rpcHealthCheckEnabled', 'rpcServer', 'tracing', 'name']
+            }
+        ]
     });
 
-    // Handle early returns from transaction block
-    if (result.error)
-        return result.error;
+    if (!transaction)
+        return 'Cannot find transaction';
 
-    const { transaction, explorer } = result;
+    if (!transaction.workspace.public)
+        return 'Not allowed on private workspaces';
+
+    // Load explorer data with targeted query (much faster than complex nested joins)
+    const explorer = await Explorer.findOne({
+        where: { workspaceId: transaction.workspace.id },
+        attributes: ['id', 'shouldSync'],
+        include: {
+            model: StripeSubscription,
+            as: 'stripeSubscription',
+            attributes: ['id'],
+            required: false
+        }
+    });
+
+    if (!explorer)
+        return 'Inactive explorer';
+
+    if (!explorer.shouldSync)
+        return 'Sync is disabled';
+
+    // Load RPC health check separately if enabled (only when needed)
+    if (transaction.workspace.rpcHealthCheckEnabled) {
+        const healthCheck = await RpcHealthCheck.findOne({
+            where: { workspaceId: transaction.workspace.id },
+            attributes: ['isReachable']
+        });
+
+        if (healthCheck && !healthCheck.isReachable)
+            return 'RPC is not reachable';
+    }
 
     if (!explorer.stripeSubscription)
         return 'No active subscription';
@@ -108,4 +93,3 @@ module.exports = async job => {
         return error;
     }
 };
-

--- a/run/models/workspace.js
+++ b/run/models/workspace.js
@@ -22,7 +22,7 @@ const {
 } = require('sequelize');
 const { defineChain, createPublicClient, http, webSocket } = require('viem');
 const moment = require('moment');
-const { sanitize, slugify, processRawRpcObject, withTimeout } = require('../lib/utils');
+const { sanitize, slugify, processRawRpcObject } = require('../lib/utils');
 const { getTransactionMethodDetails } = require('../lib/abi');
 const { ProviderConnector } = require('../lib/rpc');
 const logger = require('../lib/logger');
@@ -2022,27 +2022,18 @@ module.exports = (sequelize, DataTypes) => {
         if (isReachable === null || isReachable === undefined)
             throw new Error('Missing parameter');
 
-        try {
-            const rpcHealthCheck = await withTimeout(this.getRpcHealthCheck(), 5000);
+        const rpcHealthCheck = await this.getRpcHealthCheck();
 
-            if (rpcHealthCheck) {
-                // This is necessary otherwise Sequelize won't update the value with no other changes
-                rpcHealthCheck.changed('updatedAt', true);
+        if (rpcHealthCheck) {
+            // This is necessary otherwise Sequelize won't update the value with no other changes
+            rpcHealthCheck.changed('updatedAt', true);
 
-                // If rpc is reachable we reset failed attempts as well
-                const fields = isReachable ? { isReachable, failedAttempts: 0, updatedAt: new Date() } : { isReachable, updatedAt: new Date() }
-                return rpcHealthCheck.update(fields);
-            }
-            else
-                return this.createRpcHealthCheck({ isReachable });
-        } catch (error) {
-            if (error.message?.includes('Timed out')) {
-                logger.error(`RPC health check query timed out for workspace ${this.id}`, { error });
-                // If query times out, create a new record instead of failing the entire job
-                return this.createRpcHealthCheck({ isReachable });
-            }
-            throw error;
+            // If rpc is reachable we reset failed attempts as well
+            const fields = isReachable ? { isReachable, failedAttempts: 0, updatedAt: new Date() } : { isReachable, updatedAt: new Date() }
+            return rpcHealthCheck.update(fields);
         }
+        else
+            return this.createRpcHealthCheck({ isReachable });
     }
 
     async safeCreateOrUpdateIntegrityCheck({ blockId, status }) {


### PR DESCRIPTION
## Summary

Fixes three issues introduced by the overnight Sentry auto-fix batch (PRs #1007-#1020) during the postgres connection pool exhaustion incident:

- **PR #1020 bug (workspace.js):** safeCreateOrUpdateRpcHealthCheck timeout fallback called createRpcHealthCheck() which throws UniqueConstraintError since the record already exists (just slow to query). Reverted to the original simple lookup.

- **PR #1018 regression (processTransactionTrace.js):** Wrapping 3 sequential read-only queries in sequelize.transaction() holds a single connection locked for the entire duration, making pool exhaustion worse under contention. Reverted to individual queries.

- **PR #1012 misleading guard (finalizePendingOpBatches.js):** Removed module-level isJobRunning flag. It is per-process and does not prevent overlap across BullMQ worker instances. Kept the useful withTimeout wrappers.

## Test plan

- [x] processTransactionTrace tests pass (5/5)
- [x] rpcHealthCheck tests pass (5/5)
- [x] receiptSync tests pass (13/13)
- [x] firebase tests pass (331/331)