### PR TITLE
fix: prevent database connection drops with keepAlive, retry, and graceful shutdown

### DIFF
--- a/run/config/database.js
+++ b/run/config/database.js
@@ -48,7 +48,7 @@ module.exports = {
         },
         "retry": {
             "match": [
-                /ConnectionError/,
+                (err) => err.name && /ConnectionError/i.test(err.name),
                 /connection terminated/i,
                 /ECONNRESET/,
                 /ETIMEDOUT/,

--- a/run/config/database.js
+++ b/run/config/database.js
@@ -30,17 +30,31 @@ module.exports = {
         "port": process.env.DB_PORT,
         "dialect": "postgres",
         "dialectOptions": {
-            "family": 4
+            "family": 4,
+            "keepAlive": true,
+            "keepAliveInitialDelayMillis": 10000,
+            "statement_timeout": 60000,
+            "idle_in_transaction_session_timeout": 30000
         },
         "logging": function(sql, sequelizeObject) {
             logger.debug(sql, { instance: sequelizeObject.instance });
         },
         "pool": {
-            max: 100,
-            min: 5,
+            max: 15,
+            min: 2,
             acquire: 30000,
-            idle: 30000,
+            idle: 10000,
             evict: 5000
+        },
+        "retry": {
+            "match": [
+                /ConnectionError/,
+                /connection terminated/i,
+                /ECONNRESET/,
+                /ETIMEDOUT/,
+                /ECONNREFUSED/
+            ],
+            "max": 3
         }
     }
 }

--- a/run/index.js
+++ b/run/index.js
@@ -14,6 +14,9 @@ function shutdown(signal) {
         db.sequelize.close().then(() => {
             logger.info('Database connections closed');
             process.exit(0);
+        }).catch((err) => {
+            logger.error('Error closing database connections', err);
+            process.exit(1);
         });
     });
     setTimeout(() => process.exit(1), 4000);

--- a/run/index.js
+++ b/run/index.js
@@ -1,8 +1,23 @@
 const logger = require('./lib/logger');
 const app = require('./app');
+const db = require('./models');
 
 const port = parseInt(process.env.PORT) || 6000;
-app.listen(port, '::', () => {
+const server = app.listen(port, '::', () => {
     console.log(process.env.NODE_ENV == 'development' ? process.env : `App started on port ${port}`);
     logger.info(`Listening on port ${port}`);
 });
+
+function shutdown(signal) {
+    logger.info(`${signal} received, draining connections...`);
+    server.close(() => {
+        db.sequelize.close().then(() => {
+            logger.info('Database connections closed');
+            process.exit(0);
+        });
+    });
+    setTimeout(() => process.exit(1), 4000);
+}
+
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));

--- a/run/workers/highPriority.js
+++ b/run/workers/highPriority.js
@@ -18,6 +18,9 @@ const { managedWorkerError } = require('../lib/errors');
 const { startHeartbeat } = require('../lib/heartbeat');
 startHeartbeat('highPriority');
 
+const db = require('../models');
+const workers = [];
+
 priorities['high'].forEach(jobName => {
     const worker = new Worker(
         jobName,
@@ -40,6 +43,18 @@ priorities['high'].forEach(jobName => {
         }
     );
     worker.on('failed', (job, error) => managedWorkerError(error, jobName, job.data, 'highPriority'));
+    workers.push(worker);
 
     logger.info(`Started worker "${jobName}" - Priority: high`);
 });
+
+function shutdown(signal) {
+    logger.info(`${signal} received in highPriority, closing workers...`);
+    Promise.all(workers.map(w => w.close()))
+        .then(() => db.sequelize.close())
+        .then(() => { logger.info('highPriority shutdown complete'); process.exit(0); })
+        .catch(() => process.exit(1));
+    setTimeout(() => process.exit(1), 4000);
+}
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));

--- a/run/workers/lowPriority.js
+++ b/run/workers/lowPriority.js
@@ -16,6 +16,9 @@ const { managedWorkerError } = require('../lib/errors');
 const { startHeartbeat } = require('../lib/heartbeat');
 startHeartbeat('lowPriority');
 
+const db = require('../models');
+const workers = [];
+
 priorities['low'].forEach(jobName => {
     const worker = new Worker(
         jobName,
@@ -38,6 +41,18 @@ priorities['low'].forEach(jobName => {
         }
     );
     worker.on('failed', (job, error) => managedWorkerError(error, jobName, job.data, 'lowPriority'));
+    workers.push(worker);
 
     logger.info(`Started worker "${jobName}" - Priority: low`);
 });
+
+function shutdown(signal) {
+    logger.info(`${signal} received in lowPriority, closing workers...`);
+    Promise.all(workers.map(w => w.close()))
+        .then(() => db.sequelize.close())
+        .then(() => { logger.info('lowPriority shutdown complete'); process.exit(0); })
+        .catch(() => process.exit(1));
+    setTimeout(() => process.exit(1), 4000);
+}
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));

--- a/run/workers/mediumPriority.js
+++ b/run/workers/mediumPriority.js
@@ -19,6 +19,9 @@ const { managedWorkerError } = require('../lib/errors');
 const { startHeartbeat } = require('../lib/heartbeat');
 startHeartbeat('mediumPriority');
 
+const db = require('../models');
+const workers = [];
+
 priorities['medium'].forEach(jobName => {
     const worker = new Worker(
         jobName,
@@ -41,6 +44,18 @@ priorities['medium'].forEach(jobName => {
         }
     );
     worker.on('failed', (job, error) => managedWorkerError(error, jobName, job.data, 'mediumPriority'));
+    workers.push(worker);
 
     logger.info(`Started worker "${jobName}" - Priority: medium`);
 });
+
+function shutdown(signal) {
+    logger.info(`${signal} received in mediumPriority, closing workers...`);
+    Promise.all(workers.map(w => w.close()))
+        .then(() => db.sequelize.close())
+        .then(() => { logger.info('mediumPriority shutdown complete'); process.exit(0); })
+        .catch(() => process.exit(1));
+    setTimeout(() => process.exit(1), 4000);
+}
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));

--- a/run/workers/processHistoricalBlocks.js
+++ b/run/workers/processHistoricalBlocks.js
@@ -27,10 +27,12 @@ const worker = new Worker(
 worker.on('failed', (job, error) => managedWorkerError(error, 'processHistoricalBlocks', job.data, 'highPriority'));
 
 const db = require('../models');
+const logger = require('../lib/logger');
 function shutdown(signal) {
+    logger.info(`${signal} received in processHistoricalBlocks, closing worker...`);
     worker.close()
         .then(() => db.sequelize.close())
-        .then(() => process.exit(0))
+        .then(() => { logger.info('processHistoricalBlocks shutdown complete'); process.exit(0); })
         .catch(() => process.exit(1));
     setTimeout(() => process.exit(1), 4000);
 }

--- a/run/workers/processHistoricalBlocks.js
+++ b/run/workers/processHistoricalBlocks.js
@@ -26,4 +26,15 @@ const worker = new Worker(
 );
 worker.on('failed', (job, error) => managedWorkerError(error, 'processHistoricalBlocks', job.data, 'highPriority'));
 
+const db = require('../models');
+function shutdown(signal) {
+    worker.close()
+        .then(() => db.sequelize.close())
+        .then(() => process.exit(0))
+        .catch(() => process.exit(1));
+    setTimeout(() => process.exit(1), 4000);
+}
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));
+
 module.exports = worker;


### PR DESCRIPTION
## Summary

- Add TCP `keepAlive` with 10s initial delay to prevent idle connections from being silently dropped by firewalls on the Fly→Hetzner internet path
- Add Sequelize `retry` config (3 retries) for transient connection errors (`ConnectionError`, `ECONNRESET`, `ETIMEDOUT`)
- Reduce production pool `max` from 100 to 15 per process — 15 machines × 15 = 225 max client connections, fitting within PgBouncer's 30 server connections
- Add `statement_timeout` (60s) and `idle_in_transaction_session_timeout` (30s) to prevent runaway queries
- Add graceful shutdown handlers (`SIGTERM`/`SIGINT`) to `run/index.js` and all 4 worker entry points to drain DB connections cleanly on Fly auto-stop

## Root Cause

The "Connection terminated unexpectedly" error (Sentry #89, 6 events/24h) was caused by:
1. **No TCP keepAlive** — idle connections crossing public internet (Fly→Hetzner) get dropped by intermediate firewalls
2. **Pool size mismatch** — 15 Fly machines × 100 max = 1,500 potential connections vs 30 PgBouncer server connections
3. **No retry logic** — transient drops weren't retried
4. **No graceful shutdown** — Fly sends SIGINT with 5s timeout but the app had no handler, severing connections abruptly

## Test plan

- [x] All 1321 existing tests pass (3 pre-existing failures from missing dev deps, unrelated)
- [ ] Monitor Sentry #89 for 48h after deploy — expect zero recurrence
- [ ] Check PgBouncer connection stats after deploy to verify pool pressure is reduced

Closes #1097

🤖 Generated with [Claude Code](https://claude.com/claude-code)