### PR TITLE
fix: remove FOR UPDATE lock in receiptSync to eliminate DB contention

### DIFF
--- a/run/jobs/receiptSync.js
+++ b/run/jobs/receiptSync.js
@@ -268,7 +268,7 @@ module.exports = async job => {
             };
         }
 
-        const savedReceipt = await transaction.safeCreateReceipt(processedReceipt);
+        const savedReceipt = await transaction.safeCreateReceipt(processedReceipt, { skipExistenceCheck: true });
 
         // Handle graceful failure when transaction was deleted during processing
         if (savedReceipt === 'Transaction no longer exists') {

--- a/run/lib/firebase.js
+++ b/run/lib/firebase.js
@@ -2457,7 +2457,7 @@ const storeTransactionReceipt = async (transactionId, receipt) => {
     if (!transaction)
         throw new Error('Cannot find transaction');
 
-    return transaction.safeCreateReceipt(receipt);
+    return transaction.safeCreateReceipt(receipt, { skipExistenceCheck: true });
 };
 
 /**

--- a/run/tests/jobs/receiptSync.test.js
+++ b/run/tests/jobs/receiptSync.test.js
@@ -244,7 +244,7 @@ describe('receiptSync', () => {
                         opConfig: null,
                         opChildConfigs: []
                     }
-                });
+                }, { skipExistenceCheck: true });
                 done();
             });
     });
@@ -277,7 +277,7 @@ describe('receiptSync', () => {
                     blockNumber: 1,
                     raw: { transactionHash: '0x123' },
                     workspace: { id: 1, orbitConfig: null, orbitChildConfigs: [], opConfig: null, opChildConfigs: [] }
-                });
+                }, { skipExistenceCheck: true });
                 done();
             });
     });

--- a/run/tests/lib/firebase.test.js
+++ b/run/tests/lib/firebase.test.js
@@ -1830,7 +1830,7 @@ describe('storeTransactionReceipt', () => {
     it('Should call the receipt creation function', (done) => {
         db.storeTransactionReceipt(1, { transactionHash: '0x123' })
             .then(() => {
-                expect(safeCreateReceipt).toHaveBeenCalledWith({ transactionHash: '0x123' });
+                expect(safeCreateReceipt).toHaveBeenCalledWith({ transactionHash: '0x123' }, { skipExistenceCheck: true });
                 done();
             });
     });


### PR DESCRIPTION
## Summary
- Skip the redundant `SELECT ... FOR UPDATE` lock in `safeCreateReceipt` when called from `receiptSync` and `firebase.storeTransactionReceipt`
- Both callers already verify transaction existence before calling `safeCreateReceipt`, making the lock unnecessary
- The `FOR UPDATE` was contending with `blockSync`'s transaction inserts on TimescaleDB hypertables, causing 60-90s commit stalls that blocked 40+ DB connections and prevented the blockSync queue from draining (~32K jobs backed up)

## Root Cause
`receiptSync` workers (60 concurrent) issue `SELECT ... FOR UPDATE` on transaction rows. When `blockSync` workers (60 concurrent) are inserting blocks+transactions in a Sequelize transaction, the COMMIT on TimescaleDB hypertables is slow. The `FOR UPDATE` queries pile up waiting for the COMMIT lock, creating cascading stalls across all DB connections.

## Test plan
- [x] `receiptSync.test.js` — 13/13 passing
- [x] `firebase.test.js` — 333/333 passing
- [x] `blockSync.test.js` — pre-existing failures unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)