### PR TITLE
perf: cache activeWalletCount result in Redis

### DIFF
--- a/run/lib/firebase.js
+++ b/run/lib/firebase.js
@@ -11,9 +11,13 @@
 const Sequelize = require('sequelize');
 const { getDemoUserId, getMaxBlockForSyncReset } = require('./env');
 const models = require('../models');
+const redis = require('./redis');
+const logger = require('./logger');
 const { firebaseHash }  = require('./crypto');
 const { ORBIT_L2_TO_L1_LOG_TOPIC } = require('../constants/orbit');
 const { sanitize } = require('./utils');
+
+const ACTIVE_WALLET_COUNT_CACHE_TTL_SECONDS = 300;
 
 const Op = Sequelize.Op;
 const User = models.User;
@@ -3776,17 +3780,34 @@ const getTransactionVolume = async (workspaceId, from, to) => {
 
 /**
  * Gets count of active wallets in workspace.
+ * Result is cached in Redis for 5 minutes to avoid repeated full scans of transaction_events.
  * @param {number} workspaceId - The workspace ID
  * @returns {Promise<number>} Active wallet count
  */
 const getActiveWalletCount = async (workspaceId) => {
     if (!workspaceId) throw new Error('Missing parameter.');
 
+    const cacheKey = `active-wallet-count:${workspaceId}`;
+    try {
+        const cached = await redis.get(cacheKey);
+        if (cached != null) return JSON.parse(cached);
+    } catch (error) {
+        logger.warn({ message: 'active-wallet-count cache read failed', workspaceId, error: error.message });
+    }
+
     const workspace = await Workspace.findByPk(workspaceId);
     if (!workspace)
         throw new Error('Could not find workspace');
 
-    return workspace.countActiveWallets();
+    const count = await workspace.countActiveWallets();
+
+    try {
+        await redis.set(cacheKey, JSON.stringify(count), 'EX', ACTIVE_WALLET_COUNT_CACHE_TTL_SECONDS);
+    } catch (error) {
+        logger.warn({ message: 'active-wallet-count cache write failed', workspaceId, error: error.message });
+    }
+
+    return count;
 };
 
 /**

--- a/run/lib/firebase.js
+++ b/run/lib/firebase.js
@@ -15,9 +15,13 @@ const redis = require('./redis');
 const logger = require('./logger');
 const { firebaseHash }  = require('./crypto');
 const { ORBIT_L2_TO_L1_LOG_TOPIC } = require('../constants/orbit');
-const { sanitize } = require('./utils');
+const { sanitize, withTimeout } = require('./utils');
 
 const ACTIVE_WALLET_COUNT_CACHE_TTL_SECONDS = 300;
+// Shared Redis client uses maxRetriesPerRequest: null, so commands queue indefinitely
+// during a connection outage instead of rejecting. Cap each cache op so the DB fallback
+// stays reachable.
+const ACTIVE_WALLET_COUNT_CACHE_TIMEOUT_MS = 500;
 
 const Op = Sequelize.Op;
 const User = models.User;
@@ -3789,7 +3793,7 @@ const getActiveWalletCount = async (workspaceId) => {
 
     const cacheKey = `active-wallet-count:${workspaceId}`;
     try {
-        const cached = await redis.get(cacheKey);
+        const cached = await withTimeout(redis.get(cacheKey), ACTIVE_WALLET_COUNT_CACHE_TIMEOUT_MS);
         if (cached != null) return JSON.parse(cached);
     } catch (error) {
         logger.warn({ message: 'active-wallet-count cache read failed', workspaceId, error: error.message });
@@ -3802,7 +3806,10 @@ const getActiveWalletCount = async (workspaceId) => {
     const count = await workspace.countActiveWallets();
 
     try {
-        await redis.set(cacheKey, JSON.stringify(count), 'EX', ACTIVE_WALLET_COUNT_CACHE_TTL_SECONDS);
+        await withTimeout(
+            redis.set(cacheKey, JSON.stringify(count), 'EX', ACTIVE_WALLET_COUNT_CACHE_TTL_SECONDS),
+            ACTIVE_WALLET_COUNT_CACHE_TIMEOUT_MS
+        );
     } catch (error) {
         logger.warn({ message: 'active-wallet-count cache write failed', workspaceId, error: error.message });
     }

--- a/run/tests/lib/firebase.test.js
+++ b/run/tests/lib/firebase.test.js
@@ -7,9 +7,14 @@ jest.mock('sequelize', () => ({
 }));
 require('../mocks/lib/env');
 require('../mocks/lib/queue');
+jest.mock('../../lib/redis', () => ({
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn().mockResolvedValue('OK')
+}));
 const { ORBIT_L2_TO_L1_LOG_TOPIC } = require('../../constants/orbit');
 const { ExplorerV2Dex, ExplorerFaucet, Workspace, Block, User, workspace, Explorer, ExplorerDomain, StripePlan, Transaction, StripeSubscription, Contract, OrbitBatch, OrbitWithdrawal, OrbitChainConfig, TokenTransfer } = require('../mocks/models');
 const db = require('../../lib/firebase');
+const redis = require('../../lib/redis');
 const env = require('../../lib/env');
 
 beforeEach(() => jest.clearAllMocks());
@@ -2974,14 +2979,46 @@ describe('getTransactionVolume', () => {
 });
 
 describe('getActiveWalletCount', () => {
-    it('Should return active wallet count', done => {
-        const countActiveWallets = jest.fn().mockResolvedValueOnce([{ timestamp: '2024-01-01', count: 1 }]);
-        jest.spyOn(Workspace, 'findByPk').mockResolvedValueOnce({
-            countActiveWallets
-        })
+    beforeEach(() => {
+        redis.get.mockResolvedValue(null);
+        redis.set.mockResolvedValue('OK');
+    });
+
+    it('Should return active wallet count on cache miss and populate cache', done => {
+        const countActiveWallets = jest.fn().mockResolvedValueOnce(42);
+        jest.spyOn(Workspace, 'findByPk').mockResolvedValueOnce({ countActiveWallets });
+
         db.getActiveWalletCount(1)
             .then(res => {
-                expect(res).toEqual([{ timestamp: '2024-01-01', count: 1 }]);
+                expect(res).toEqual(42);
+                expect(redis.get).toHaveBeenCalledWith('active-wallet-count:1');
+                expect(redis.set).toHaveBeenCalledWith('active-wallet-count:1', '42', 'EX', 300);
+                expect(countActiveWallets).toHaveBeenCalled();
+                done();
+            });
+    });
+
+    it('Should return cached count without hitting the database', done => {
+        redis.get.mockResolvedValueOnce('7');
+        const findByPkSpy = jest.spyOn(Workspace, 'findByPk');
+
+        db.getActiveWalletCount(1)
+            .then(res => {
+                expect(res).toEqual(7);
+                expect(findByPkSpy).not.toHaveBeenCalled();
+                expect(redis.set).not.toHaveBeenCalled();
+                done();
+            });
+    });
+
+    it('Should fall through to DB when cache read fails', done => {
+        redis.get.mockRejectedValueOnce(new Error('redis down'));
+        const countActiveWallets = jest.fn().mockResolvedValueOnce(5);
+        jest.spyOn(Workspace, 'findByPk').mockResolvedValueOnce({ countActiveWallets });
+
+        db.getActiveWalletCount(1)
+            .then(res => {
+                expect(res).toEqual(5);
                 done();
             });
     });

--- a/run/tests/lib/firebase.test.js
+++ b/run/tests/lib/firebase.test.js
@@ -3023,6 +3023,18 @@ describe('getActiveWalletCount', () => {
             });
     });
 
+    it('Should return count even when cache write fails', done => {
+        redis.set.mockRejectedValueOnce(new Error('redis write error'));
+        const countActiveWallets = jest.fn().mockResolvedValueOnce(10);
+        jest.spyOn(Workspace, 'findByPk').mockResolvedValueOnce({ countActiveWallets });
+
+        db.getActiveWalletCount(1)
+            .then(res => {
+                expect(res).toEqual(10);
+                done();
+            });
+    });
+
     it('Should return an error if no workspace', (done) => {
         jest.spyOn(Workspace, 'findByPk').mockResolvedValueOnce(null);
 


### PR DESCRIPTION
## Summary
- Cache `getActiveWalletCount` result in Redis for 5 minutes (keyed by workspaceId)
- Endpoint hit 512 times in 24h per Sentry; each call ran a full GROUP BY scan over `transaction_events`
- Cache failures (read or write) log a warning and fall through to the DB — stale cache data preferred over request failures

## Test plan
- [x] Unit tests added for cache hit, cache miss, cache error paths, missing workspace
- [x] Existing API + lib tests pass
- [ ] Validate in prod: first request after deploy populates cache, subsequent requests return in ~1ms

Closes #1157

🤖 Generated with [Claude Code](https://claude.com/claude-code)