### PR TITLE
fix(blog): retry push with rebase when develop moves mid-pipeline

### DIFF
--- a/blog/pipeline/draft.sh
+++ b/blog/pipeline/draft.sh
@@ -316,12 +316,13 @@ PUSH_ATTEMPTS=0
 PUSH_MAX_ATTEMPTS=3
 until git push origin develop 2>&1 | tee -a "$LOG_FILE"; do
   PUSH_ATTEMPTS=$((PUSH_ATTEMPTS + 1))
-  log "Push rejected (attempt $PUSH_ATTEMPTS/$PUSH_MAX_ATTEMPTS) — rebasing onto latest develop..."
+  log "Push rejected (attempt $PUSH_ATTEMPTS/$PUSH_MAX_ATTEMPTS)."
   if [ "$PUSH_ATTEMPTS" -ge "$PUSH_MAX_ATTEMPTS" ]; then
     log "ERROR: push failed after $PUSH_MAX_ATTEMPTS attempts"
     report_failure "Git push (exhausted retries)"
     exit 1
   fi
+  log "Rebasing onto latest develop and retrying..."
   git fetch origin develop 2>&1 | tee -a "$LOG_FILE"
   git rebase origin/develop 2>&1 | tee -a "$LOG_FILE" || {
     log "ERROR: rebase failed — aborting to avoid a broken state"

--- a/blog/pipeline/draft.sh
+++ b/blog/pipeline/draft.sh
@@ -316,12 +316,12 @@ PUSH_ATTEMPTS=0
 PUSH_MAX_ATTEMPTS=3
 until git push origin develop 2>&1 | tee -a "$LOG_FILE"; do
   PUSH_ATTEMPTS=$((PUSH_ATTEMPTS + 1))
+  log "Push rejected (attempt $PUSH_ATTEMPTS/$PUSH_MAX_ATTEMPTS) — rebasing onto latest develop..."
   if [ "$PUSH_ATTEMPTS" -ge "$PUSH_MAX_ATTEMPTS" ]; then
     log "ERROR: push failed after $PUSH_MAX_ATTEMPTS attempts"
     report_failure "Git push (exhausted retries)"
     exit 1
   fi
-  log "Push rejected (attempt $PUSH_ATTEMPTS/$PUSH_MAX_ATTEMPTS) — rebasing onto latest develop..."
   git fetch origin develop 2>&1 | tee -a "$LOG_FILE"
   git rebase origin/develop 2>&1 | tee -a "$LOG_FILE" || {
     log "ERROR: rebase failed — aborting to avoid a broken state"

--- a/blog/pipeline/draft.sh
+++ b/blog/pipeline/draft.sh
@@ -309,7 +309,27 @@ git add "$ARTICLE_PATH" blog/public/llms.txt
 [ -f "blog/public/images/${SLUG}.png" ] && git add "blog/public/images/${SLUG}.png" "blog/public/images/${SLUG}-og.png"
 TITLE=$(head -5 "$ARTICLE_PATH" | grep '^title:' | sed 's/^title: *"//;s/"$//')
 git commit -m "blog: publish - ${TITLE}" 2>&1 | tee -a "$LOG_FILE"
-git push origin develop 2>&1 | tee -a "$LOG_FILE"
+
+# Push with retry: if develop moved while we were drafting, rebase and retry.
+# Pipeline runs can take 5-10 min; develop often advances via deploys/dependabot/etc.
+PUSH_ATTEMPTS=0
+PUSH_MAX_ATTEMPTS=3
+until git push origin develop 2>&1 | tee -a "$LOG_FILE"; do
+  PUSH_ATTEMPTS=$((PUSH_ATTEMPTS + 1))
+  if [ "$PUSH_ATTEMPTS" -ge "$PUSH_MAX_ATTEMPTS" ]; then
+    log "ERROR: push failed after $PUSH_MAX_ATTEMPTS attempts"
+    report_failure "Git push (exhausted retries)"
+    exit 1
+  fi
+  log "Push rejected (attempt $PUSH_ATTEMPTS/$PUSH_MAX_ATTEMPTS) — rebasing onto latest develop..."
+  git fetch origin develop 2>&1 | tee -a "$LOG_FILE"
+  git rebase origin/develop 2>&1 | tee -a "$LOG_FILE" || {
+    log "ERROR: rebase failed — aborting to avoid a broken state"
+    git rebase --abort 2>&1 | tee -a "$LOG_FILE" || true
+    report_failure "Git rebase"
+    exit 1
+  }
+done
 
 log "Pushed to develop."
 


### PR DESCRIPTION
## Summary
- Wrap the final \`git push\` in \`draft.sh\` with a 3-attempt retry that rebases onto the latest develop on rejection
- Pipeline takes 5-10 min between initial pull and final push; any commit landing on develop in that window currently kills the run
- See #1174 for an example failure (article was even built and llms.txt regenerated, just couldn't push)

## Test plan
- [x] \`bash -n draft.sh\` syntax check
- [x] \`set -o pipefail\` is on, so \`tee\` doesn't mask the push exit code
- [ ] Verify on next pipeline run that pushes succeed cleanly when develop is unchanged
- [ ] If it triggers, confirm rebase + retry path produces a clean push

Closes #1174

🤖 Generated with [Claude Code](https://claude.com/claude-code)