### PR TITLE
test: catch up tests with constants tuned in b9ba20cd

### DIFF
--- a/run/tests/jobs/batchBlockSync.test.js
+++ b/run/tests/jobs/batchBlockSync.test.js
@@ -145,7 +145,7 @@ describe('batchBlockSync', () => {
         expect(enqueued[0].data.blockNumber).toBe(1);
         expect(enqueued[4999].data.blockNumber).toBe(5000);
 
-        // Should self-re-enqueue for remaining range with 3s delay
+        // Should self-re-enqueue for remaining range with the rechunk backpressure delay
         expect(enqueue).toHaveBeenCalledWith(
             'batchBlockSync',
             'batchBlockSync-123-My Workspace-5001-10000',
@@ -157,7 +157,7 @@ describe('batchBlockSync', () => {
                 to: 10000,
                 source: 'batchSync'
             },
-            null, null, 3000
+            null, null, 15000
         );
     });
 

--- a/run/tests/jobs/blockSync.test.js
+++ b/run/tests/jobs/blockSync.test.js
@@ -60,10 +60,10 @@ describe('blockSync', () => {
             });
     });
 
-    it('Should queue receipt processing with cached workspace for large blocks (>10 transactions)', (done) => {
-        // Create 11 transactions to exceed threshold
+    it('Should queue receipt processing with cached workspace for large blocks (>INLINE_RECEIPT_THRESHOLD transactions)', (done) => {
+        // Generate 30 transactions to exceed INLINE_RECEIPT_THRESHOLD (25) and force the queueing path
         const transactions = [];
-        for (let i = 0; i < 11; i++) {
+        for (let i = 0; i < 30; i++) {
             transactions.push({ id: i + 1, hash: `0x${i.toString(16).padStart(3, '0')}` });
         }
         mockSafeCreatePartialBlock.mockResolvedValue({ transactions });
@@ -108,9 +108,9 @@ describe('blockSync', () => {
     });
 
     it('Should not cache workspace for orbit workspaces', (done) => {
-        // Create 11 transactions to exceed threshold
+        // Generate 30 transactions to exceed INLINE_RECEIPT_THRESHOLD (25) and force the queueing path
         const transactions = [];
-        for (let i = 0; i < 11; i++) {
+        for (let i = 0; i < 30; i++) {
             transactions.push({ id: i + 1, hash: `0x${i.toString(16).padStart(3, '0')}` });
         }
         mockSafeCreatePartialBlock.mockResolvedValue({ transactions });


### PR DESCRIPTION
## Summary
- Commit b9ba20cd raised \`INLINE_RECEIPT_THRESHOLD\` from 10 to 25 and \`batchBlockSync\` rechunk delay from 3s to 15s, but didn't update the tests that hard-coded those values
- 2 tests were silently failing on every develop CI run since
- Mechanical fix: bump test transaction count (11 → 30) and update delay assertion (3000 → 15000)

## Test plan
- [x] All 113 backend test suites pass locally (1345 passed, 3 skipped)
- [x] Specifically the previously-failing \`blockSync\` and \`batchBlockSync\` suites pass
- [ ] CI green on develop after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)