### PR TITLE
chore(security): add CODEOWNERS to gate PR approvals

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Global code owner — only @antoinedc reviews count toward required approval.
+# Combined with branch protection "require review from Code Owners", this ensures
+# no PR can be merged based on approvals from random GitHub users.
+* @antoinedc


### PR DESCRIPTION
## Summary
- Add \`.github/CODEOWNERS\` with \`* @antoinedc\` so only my reviews count toward required approvals
- Paired with branch protection updates applied directly via API: \`require_code_owner_reviews\`, \`restrictions: [antoinedc]\`, \`require_last_push_approval\`, \`dismiss_stale_reviews\`, disabled \`allow_force_pushes\` — on both \`develop\` and \`master\`

## Context
External user \`khan7546jsn-afk\` (association: NONE) submitted an "Approve" review on #1206 and then opened revert PR #1209. No harm, but the approval technically satisfied the required-review count. These changes ensure:
1. Only approvals from CODEOWNERS (i.e., @antoinedc) count
2. Only @antoinedc can push/merge to develop or master
3. No force pushes to develop

## Test plan
- [ ] Confirm PR cannot be merged by anyone except @antoinedc
- [ ] Confirm external "Approve" reviews no longer satisfy the required-approval gate