### PR TITLE
feat(emails): redesign demo drip email sequence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@
 | Sentry pipeline | `run/api/sentryPipeline.js`, `run/webhooks/githubActions.js` | [SENTRY.md](.claude/references/SENTRY.md) |
 | Landing/marketing | `landing/` | [LANDING.md](.claude/references/LANDING.md) |
 | Blog pipeline | `blog/pipeline/`, `.github/workflows/blog-trend-scan.yml` | [MARKETING.md](.claude/references/MARKETING.md) |
-| Drip emails | `run/jobs/sendDripEmail.js`, `run/jobs/processDripEmails.js`, `run/emails/drip-content.js` | [MARKETING.md](.claude/references/MARKETING.md) |
+| Drip emails | `run/jobs/sendDripEmail.js`, `run/jobs/processDripEmails.js`, `run/emails/drip-content.js`, `run/emails/drip-base.html` | [MARKETING.md](.claude/references/MARKETING.md) |
 | Demo enrichment | `run/jobs/enrichDemoProfile.js`, `run/lib/enrichment.js` | [MARKETING.md](.claude/references/MARKETING.md) |
 | Twitter pipeline | `tweet-pipeline/` (standalone, Hetzner server) | [MARKETING.md](.claude/references/MARKETING.md) |
 | Analytics (PostHog) | `blog/src/layouts/BaseLayout.astro` (snippet), `landing/src/main.js` (init), `run/lib/analytics.js` (backend) | PostHog personal API key in `.credentials.local` |

--- a/run/emails/drip-base.html
+++ b/run/emails/drip-base.html
@@ -5,34 +5,53 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>{{subject}}</title>
 <style>
-  body { margin: 0; padding: 0; background-color: #0f0f1a; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
-  .container { max-width: 600px; margin: 0 auto; background-color: #1a1a2e; }
-  .header { padding: 24px 32px; border-bottom: 1px solid #2a2a3e; }
-  .header .logo { color: #ffffff; font-size: 22px; font-weight: 700; letter-spacing: -0.5px; text-decoration: none; }
-  .body { padding: 32px; color: #e0e0e0; font-size: 15px; line-height: 1.6; }
-  .body h2 { color: #ffffff; font-size: 20px; margin: 0 0 16px 0; }
+  body { margin: 0; padding: 0; background-color: #eef1f5; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #0f172a; }
+  .wrapper { width: 100%; background-color: #eef1f5; padding: 32px 16px; }
+  .container { max-width: 560px; margin: 0 auto; background-color: #ffffff; border-radius: 10px; box-shadow: 0 2px 8px rgba(15,23,42,0.06); overflow: hidden; }
+  .header { padding: 22px 32px; border-bottom: 1px solid #eef1f5; }
+  .header .brand-row { display: inline-block; }
+  .header .logo-mark { display: inline-block; width: 22px; height: 22px; border-radius: 6px; background-color: #3D95CE; color: #ffffff; font-weight: 800; font-size: 12px; line-height: 22px; text-align: center; vertical-align: middle; }
+  .header .brand { display: inline-block; font-weight: 700; font-size: 15px; color: #0f172a; letter-spacing: -0.2px; margin-left: 10px; vertical-align: middle; text-decoration: none; }
+  .body { padding: 36px 32px 32px; color: #334155; font-size: 15px; line-height: 1.65; }
+  .body h1 { font-size: 22px; line-height: 1.3; margin: 0 0 14px 0; color: #0f172a; font-weight: 700; letter-spacing: -0.4px; }
   .body p { margin: 0 0 16px 0; }
   .body a { color: #3D95CE; text-decoration: none; }
-  .cta-wrap { text-align: center; margin: 16px 0; }
-  .cta { display: inline-block; background-color: #3D95CE; color: #ffffff !important; padding: 12px 28px; border-radius: 6px; font-weight: 600; text-decoration: none !important; }
-  .feature-table { width: 100%; border-collapse: collapse; margin: 16px 0; }
-  .feature-table th { text-align: left; padding: 8px 12px; background-color: #2a2a3e; color: #ffffff; font-size: 13px; }
-  .feature-table td { padding: 8px 12px; border-bottom: 1px solid #2a2a3e; color: #c0c0c0; font-size: 13px; }
-  .footer { padding: 24px 32px; border-top: 1px solid #2a2a3e; color: #666; font-size: 12px; text-align: center; }
-  .footer a { color: #888; text-decoration: none; }
+  .body code { background-color: #f1f5f9; padding: 2px 6px; border-radius: 4px; font-size: 13px; font-family: 'SF Mono', Monaco, Consolas, monospace; color: #0f172a; }
+  .cta-wrap { margin: 24px 0 8px 0; }
+  .cta { display: inline-block; background-color: #3D95CE; color: #ffffff !important; padding: 12px 22px; border-radius: 8px; font-weight: 600; font-size: 14px; text-decoration: none !important; }
+  .panel { background-color: #f8fafc; border: 1px solid #eef1f5; border-radius: 8px; padding: 18px 20px; margin: 18px 0; }
+  .alert { background-color: #fef9e7; border-left: 3px solid #eab308; padding: 14px 16px; border-radius: 6px; margin: 16px 0; font-size: 14px; color: #713f12; }
+  .urgent { background-color: #fef2f2; border-left: 3px solid #ef4444; padding: 14px 16px; border-radius: 6px; margin: 16px 0; font-size: 14px; color: #7f1d1d; }
+  .divider { height: 1px; background-color: #eef1f5; margin: 24px 0; border: none; }
+  .sig { font-size: 14px; color: #334155; margin: 4px 0 0 0; }
+  .sig-name { font-weight: 600; color: #0f172a; }
+  .fineprint { font-size: 12px; color: #94a3b8; margin-top: 10px; }
+  .compare { width: 100%; border-collapse: collapse; margin: 18px 0; font-size: 13px; }
+  .compare th { text-align: left; padding: 10px 12px; background-color: #f8fafc; color: #64748b; font-weight: 600; font-size: 12px; text-transform: uppercase; letter-spacing: 0.6px; border-bottom: 1px solid #eef1f5; }
+  .compare th.mark, .compare td.mark { width: 24px; text-align: center; padding-left: 0; padding-right: 0; }
+  .compare td { padding: 11px 12px; border-bottom: 1px solid #f1f5f9; color: #0f172a; vertical-align: middle; }
+  .compare td.dim { color: #94a3b8; }
+  .compare td.strong { color: #0f172a; font-weight: 600; }
+  .compare .check { color: #3D95CE; font-weight: 700; }
+  .compare .dash { color: #cbd5e1; }
+  .footer { padding: 20px 32px 24px; border-top: 1px solid #eef1f5; color: #94a3b8; font-size: 12px; text-align: center; }
+  .footer a { color: #64748b; text-decoration: none; }
 </style>
 </head>
 <body>
-<div class="container">
-  <div class="header">
-    <a href="https://{{appDomain}}" class="logo">Ethernal</a>
-  </div>
-  <div class="body">
-    {{content}}
-  </div>
-  <div class="footer">
-    <p><a href="{{unsubscribeUrl}}">Unsubscribe</a> from demo emails</p>
-    <p>&copy; Ethernal &middot; <a href="https://{{appDomain}}">{{appDomain}}</a></p>
+<div class="wrapper">
+  <div class="container">
+    <div class="header">
+      <a href="https://{{appDomain}}" class="brand-row" style="text-decoration:none;">
+        <span class="logo-mark">E</span><span class="brand">Ethernal</span>
+      </a>
+    </div>
+    <div class="body">
+      {{content}}
+    </div>
+    <div class="footer">
+      <a href="{{unsubscribeUrl}}">Unsubscribe</a> &middot; <a href="https://{{appDomain}}">Ethernal</a>
+    </div>
   </div>
 </div>
 </body>

--- a/run/emails/drip-content.js
+++ b/run/emails/drip-content.js
@@ -43,7 +43,7 @@ function wrapInTemplate(content, subject, unsubscribeUrl, appDomain) {
     return getBaseTemplate()
         .replace('{{content}}', () => content)
         .replace('{{subject}}', () => escapeHtml(subject))
-        .replace('{{unsubscribeUrl}}', () => unsubscribeUrl)
+        .replace('{{unsubscribeUrl}}', () => escapeHtml(unsubscribeUrl))
         .replace(/\{\{appDomain\}\}/g, () => appDomain);
 }
 
@@ -53,7 +53,7 @@ const steps = {
         const content = `
             <h1>Your Ethernal demo is live</h1>
             <p>Your demo explorer is up and syncing. Deploy a contract or send a transaction and it'll show up in a few seconds.</p>
-            <div class="cta-wrap"><a href="${data.explorerLink}" class="cta">Open explorer &rarr;</a></div>
+            <div class="cta-wrap"><a href="${escapeHtml(data.explorerLink)}" class="cta">Open explorer &rarr;</a></div>
             <hr class="divider" />
             <p class="sig">Reply if something looks off.</p>
             <p class="sig"><span class="sig-name">Antoine</span><br>Ethernal</p>
@@ -71,7 +71,7 @@ const steps = {
         const content = `
             <h1>${escapeHtml(summary)} synced on your demo</h1>
             <p>Your demo <code>${escapeHtml(data.explorerSlug)}</code> has indexed ${escapeHtml(summary)}. You can already poke at decoded transaction inputs, verified contract source, and token transfers per address.</p>
-            <div class="cta-wrap"><a href="${data.explorerLink}" class="cta">Open explorer &rarr;</a></div>
+            <div class="cta-wrap"><a href="${escapeHtml(data.explorerLink)}" class="cta">Open explorer &rarr;</a></div>
         `;
         return {
             subject,
@@ -98,7 +98,7 @@ const steps = {
                 <tr><td>API access</td><td class="dim">Limited</td><td class="mark"><span class="check">&#10003;</span></td><td class="strong">Full</td></tr>
                 <tr><td>Explorer lifetime</td><td class="dim">7 days</td><td class="mark"><span class="check">&#10003;</span></td><td class="strong">Permanent</td></tr>
             </table>
-            <div class="cta-wrap"><a href="${data.migrateUrl}" class="cta">Start free trial &rarr;</a></div>
+            <div class="cta-wrap"><a href="${escapeHtml(data.migrateUrl)}" class="cta">Start free trial &rarr;</a></div>
         `;
         return {
             subject,
@@ -116,7 +116,7 @@ const steps = {
             <h1>Who else is running Ethernal</h1>
             ${teamIntro}
             <p>Ethernal runs as the block explorer for production L2s, appchains, and private networks. Same product, any EVM chain.</p>
-            <div class="cta-wrap"><a href="${data.migrateUrl}" class="cta">Start free trial &rarr;</a></div>
+            <div class="cta-wrap"><a href="${escapeHtml(data.migrateUrl)}" class="cta">Start free trial &rarr;</a></div>
         `;
         return {
             subject,
@@ -134,7 +134,7 @@ const steps = {
             <h1>Your demo expires in 2 days</h1>
             <p><code>${escapeHtml(data.explorerSlug)}</code> shuts down in 2 days.</p>
             <div class="alert">${alertBody}</div>
-            <div class="cta-wrap"><a href="${data.migrateUrl}" class="cta">Start free trial &rarr;</a></div>
+            <div class="cta-wrap"><a href="${escapeHtml(data.migrateUrl)}" class="cta">Start free trial &rarr;</a></div>
             <p class="fineprint">After that, the explorer and its data are deleted.</p>
         `;
         return {
@@ -153,7 +153,7 @@ const steps = {
             <h1>Your demo expired, 48h to recover</h1>
             <p><code>${escapeHtml(data.explorerSlug)}</code> expired.</p>
             <div class="urgent">${urgentBody}</div>
-            <div class="cta-wrap"><a href="${data.migrateUrl}" class="cta">Restore explorer &rarr;</a></div>
+            <div class="cta-wrap"><a href="${escapeHtml(data.migrateUrl)}" class="cta">Restore explorer &rarr;</a></div>
             <p class="fineprint">After 48 hours, it's deleted for good.</p>
         `;
         return {

--- a/run/emails/drip-content.js
+++ b/run/emails/drip-content.js
@@ -44,7 +44,7 @@ function wrapInTemplate(content, subject, unsubscribeUrl, appDomain) {
         content,
         subject: escapeHtml(subject),
         unsubscribeUrl: escapeHtml(unsubscribeUrl),
-        appDomain
+        appDomain: escapeHtml(appDomain)
     };
     return getBaseTemplate().replace(/\{\{(\w+)\}\}/g, (_, key) =>
         Object.prototype.hasOwnProperty.call(replacements, key) ? replacements[key] : ''

--- a/run/emails/drip-content.js
+++ b/run/emails/drip-content.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview Per-step content generators for the demo drip email sequence.
- * Step 1 is plain text (personal feel). Steps 2-6 use branded HTML template.
+ * All steps emit a plain-text fallback and branded HTML via the shared template.
  * Steps 1-2 link to the explorer. Steps 3-6 link to the migration flow.
  * @module emails/drip-content
  */
@@ -41,7 +41,7 @@ function getBaseTemplate() {
 function wrapInTemplate(content, subject, unsubscribeUrl, appDomain) {
     return getBaseTemplate()
         .replace('{{content}}', content)
-        .replace('{{subject}}', subject)
+        .replace('{{subject}}', escapeHtml(subject))
         .replace('{{unsubscribeUrl}}', unsubscribeUrl)
         .replace(/\{\{appDomain\}\}/g, appDomain);
 }

--- a/run/emails/drip-content.js
+++ b/run/emails/drip-content.js
@@ -40,11 +40,15 @@ function getBaseTemplate() {
  * @returns {string} Complete HTML email
  */
 function wrapInTemplate(content, subject, unsubscribeUrl, appDomain) {
-    return getBaseTemplate()
-        .replace('{{content}}', () => content)
-        .replace('{{subject}}', () => escapeHtml(subject))
-        .replace('{{unsubscribeUrl}}', () => escapeHtml(unsubscribeUrl))
-        .replace(/\{\{appDomain\}\}/g, () => appDomain);
+    const replacements = {
+        content,
+        subject: escapeHtml(subject),
+        unsubscribeUrl: escapeHtml(unsubscribeUrl),
+        appDomain
+    };
+    return getBaseTemplate().replace(/\{\{(\w+)\}\}/g, (_, key) =>
+        Object.prototype.hasOwnProperty.call(replacements, key) ? replacements[key] : ''
+    );
 }
 
 const steps = {

--- a/run/emails/drip-content.js
+++ b/run/emails/drip-content.js
@@ -41,10 +41,10 @@ function getBaseTemplate() {
  */
 function wrapInTemplate(content, subject, unsubscribeUrl, appDomain) {
     return getBaseTemplate()
-        .replace('{{content}}', content)
-        .replace('{{subject}}', escapeHtml(subject))
-        .replace('{{unsubscribeUrl}}', unsubscribeUrl)
-        .replace(/\{\{appDomain\}\}/g, appDomain);
+        .replace('{{content}}', () => content)
+        .replace('{{subject}}', () => escapeHtml(subject))
+        .replace('{{unsubscribeUrl}}', () => unsubscribeUrl)
+        .replace(/\{\{appDomain\}\}/g, () => appDomain);
 }
 
 const steps = {

--- a/run/emails/drip-content.js
+++ b/run/emails/drip-content.js
@@ -47,116 +47,117 @@ function wrapInTemplate(content, subject, unsubscribeUrl, appDomain) {
 }
 
 const steps = {
-    1: (data) => ({
-        subject: 'Your Ethernal demo explorer is ready',
-        textPart: `Hello,\n\nYour Ethernal demo explorer is ready: ${data.explorerLink}\n\nYour explorer will sync blocks, transactions, and contract interactions in real-time. Try deploying a contract or sending a transaction to see it appear.\n\nFeel free to reply to this email if you have any questions!\n\nRegards,\n\nAntoine`,
-        htmlPart: null
-    }),
-
-    2: (data) => {
-        const summary = data.activitySummary || 'new blocks';
-        const subject = `Your explorer synced ${summary}`;
+    1: (data) => {
+        const subject = 'Your Ethernal demo is live';
         const content = `
-            <h2>Your explorer is active</h2>
-            <p>Your demo explorer <strong>${data.explorerSlug}</strong> has synced ${summary} so far.</p>
-            <p>Here is what you can explore right now:</p>
-            <ul>
-                <li>View decoded transaction inputs and outputs</li>
-                <li>Inspect contract source code and ABI</li>
-                <li>Track token transfers and balances</li>
-            </ul>
-            <div class="cta-wrap"><a href="${data.explorerLink}" class="cta">Open Explorer</a></div>
+            <h1>Your Ethernal demo is live</h1>
+            <p>Your demo explorer is up and syncing. Deploy a contract or send a transaction and it'll show up in a few seconds.</p>
+            <div class="cta-wrap"><a href="${data.explorerLink}" class="cta">Open explorer &rarr;</a></div>
+            <hr class="divider" />
+            <p class="sig">Reply if something looks off.</p>
+            <p class="sig"><span class="sig-name">Antoine</span><br>Ethernal</p>
         `;
         return {
             subject,
-            textPart: `Your demo explorer ${data.explorerSlug} has synced ${summary}. Open it at ${data.explorerLink}\n\nUnsubscribe: ${data.unsubscribeUrl}`,
+            textPart: `Your Ethernal demo explorer is up and syncing: ${data.explorerLink}\n\nDeploy a contract or send a transaction and it'll show up in a few seconds.\n\nReply if something looks off.\n\nAntoine, Ethernal`,
+            htmlPart: wrapInTemplate(content, subject, data.unsubscribeUrl, data.appDomain)
+        };
+    },
+
+    2: (data) => {
+        const summary = data.activitySummary || 'new blocks';
+        const subject = `${summary} synced on your demo`;
+        const content = `
+            <h1>${escapeHtml(summary)} synced on your demo</h1>
+            <p>Your demo <code>${escapeHtml(data.explorerSlug)}</code> has indexed ${escapeHtml(summary)}. You can already poke at decoded transaction inputs, verified contract source, and token transfers per address.</p>
+            <div class="cta-wrap"><a href="${data.explorerLink}" class="cta">Open explorer &rarr;</a></div>
+        `;
+        return {
+            subject,
+            textPart: `Your demo ${data.explorerSlug} has indexed ${summary}. Open it: ${data.explorerLink}\n\nUnsubscribe: ${data.unsubscribeUrl}`,
             htmlPart: wrapInTemplate(content, subject, data.unsubscribeUrl, data.appDomain)
         };
     },
 
     3: (data) => {
-        const subject = "Here's what you're missing on your chain";
+        const subject = 'What the paid plan adds';
         const benefitsIntro = data.tailoredBenefits
             ? `<p>${escapeHtml(data.tailoredBenefits)}</p>`
             : '';
         const content = `
-            <h2>Demo vs. Paid: what you unlock</h2>
+            <h1>What the paid plan adds</h1>
             ${benefitsIntro}
-            <p>Your demo explorer gives you a taste. Here is what a paid plan adds:</p>
-            <table class="feature-table">
-                <tr><th>Feature</th><th>Demo</th><th>Paid</th></tr>
-                <tr><td>Data retention</td><td style="color: #e57373;">7 days</td><td style="color: #81c784;">Unlimited</td></tr>
-                <tr><td>Custom branding</td><td style="color: #e57373;">&#10007;</td><td style="color: #81c784;">&#10003;</td></tr>
-                <tr><td>Custom domain</td><td style="color: #e57373;">&#10007;</td><td style="color: #81c784;">&#10003;</td></tr>
-                <tr><td>Historical sync</td><td style="color: #e57373;">&#10007;</td><td style="color: #81c784;">&#10003;</td></tr>
-                <tr><td>API access</td><td style="color: #e57373;">Limited</td><td style="color: #81c784;">Full</td></tr>
-                <tr><td>Explorer lifetime</td><td style="color: #e57373;">7 days</td><td style="color: #81c784;">Permanent</td></tr>
+            <p>The demo is capped at 7 days and runs with Ethernal branding. Paid plans drop both, plus a few things you probably want once the chain is real:</p>
+            <table class="compare">
+                <tr><th>Feature</th><th>Demo</th><th class="mark"></th><th>Paid</th></tr>
+                <tr><td>Data retention</td><td class="dim">7 days</td><td class="mark"><span class="check">&#10003;</span></td><td class="strong">Unlimited</td></tr>
+                <tr><td>Custom branding</td><td class="dim"><span class="dash">&mdash;</span></td><td class="mark"><span class="check">&#10003;</span></td><td class="strong">Included</td></tr>
+                <tr><td>Custom domain</td><td class="dim"><span class="dash">&mdash;</span></td><td class="mark"><span class="check">&#10003;</span></td><td class="strong">Included</td></tr>
+                <tr><td>Historical sync</td><td class="dim"><span class="dash">&mdash;</span></td><td class="mark"><span class="check">&#10003;</span></td><td class="strong">Included</td></tr>
+                <tr><td>API access</td><td class="dim">Limited</td><td class="mark"><span class="check">&#10003;</span></td><td class="strong">Full</td></tr>
+                <tr><td>Explorer lifetime</td><td class="dim">7 days</td><td class="mark"><span class="check">&#10003;</span></td><td class="strong">Permanent</td></tr>
             </table>
-            <div class="cta-wrap"><a href="${data.migrateUrl}" class="cta">Start Free Trial</a></div>
+            <div class="cta-wrap"><a href="${data.migrateUrl}" class="cta">Start free trial &rarr;</a></div>
         `;
         return {
             subject,
-            textPart: `Your demo explorer has limited features. See what a paid plan unlocks: data retention, custom domain, historical sync, and more. Start your free trial: ${data.migrateUrl}\n\nUnsubscribe: ${data.unsubscribeUrl}`,
+            textPart: `The demo is capped at 7 days and runs with Ethernal branding. Paid plans drop both, plus unlimited retention, custom domain, historical sync, and full API access. Start a free trial: ${data.migrateUrl}\n\nUnsubscribe: ${data.unsubscribeUrl}`,
             htmlPart: wrapInTemplate(content, subject, data.unsubscribeUrl, data.appDomain)
         };
     },
 
     4: (data) => {
-        const subject = 'Teams building on chains like yours use Ethernal';
-        const teamContext = data.teamContext || 'Teams building EVM-based chains use Ethernal as their primary block explorer for debugging, monitoring, and sharing chain data with their community.';
+        const subject = 'Who else is running Ethernal';
+        const teamIntro = data.teamContext
+            ? `<p>${escapeHtml(data.teamContext)}</p>`
+            : '';
         const content = `
-            <h2>You are not alone</h2>
-            <p>${escapeHtml(teamContext)}</p>
-            <p>Ethernal works out of the box with any EVM chain: L2s, L3s, appchains, testnets, and private networks.</p>
-            <div class="cta-wrap"><a href="${data.migrateUrl}" class="cta">Start Free Trial</a></div>
+            <h1>Who else is running Ethernal</h1>
+            ${teamIntro}
+            <p>Ethernal runs as the block explorer for production L2s, appchains, and private networks. Same product, any EVM chain.</p>
+            <div class="cta-wrap"><a href="${data.migrateUrl}" class="cta">Start free trial &rarr;</a></div>
         `;
         return {
             subject,
-            textPart: `${teamContext}\n\nStart your free trial: ${data.migrateUrl}\n\nUnsubscribe: ${data.unsubscribeUrl}`,
+            textPart: `Ethernal runs as the block explorer for production L2s, appchains, and private networks. Same product, any EVM chain.\n\nStart a free trial: ${data.migrateUrl}\n\nUnsubscribe: ${data.unsubscribeUrl}`,
             htmlPart: wrapInTemplate(content, subject, data.unsubscribeUrl, data.appDomain)
         };
     },
 
     5: (data) => {
-        const subject = 'Your explorer expires in 2 days';
-        const urgencyHtml = data.expirationWarning
-            ? `<p>${escapeHtml(data.expirationWarning)}</p><p>Start your 7-day free trial now to keep your explorer running. Your existing configuration transfers automatically.</p>`
-            : `<p>Start your 7-day free trial now to keep your explorer running. Your existing configuration transfers automatically.</p>`;
-        const urgencyText = data.expirationWarning
-            ? `${data.expirationWarning}\n\nStart your 7-day free trial to keep it running: ${data.migrateUrl}`
-            : `Your demo explorer ${data.explorerSlug} expires in 2 days. Start your 7-day free trial to keep it running: ${data.migrateUrl}`;
+        const subject = 'Your demo expires in 2 days';
+        const alertBody = data.expirationWarning
+            ? escapeHtml(data.expirationWarning)
+            : "Start the trial before then and your config carries over, no re-adding the chain.";
         const content = `
-            <h2>Your demo is ending soon</h2>
-            <p>Your explorer <strong>${data.explorerSlug}</strong> expires in 2 days.</p>
-            ${urgencyHtml}
-            <div class="cta-wrap"><a href="${data.migrateUrl}" class="cta">Start Free Trial</a></div>
-            <p style="color: #888; font-size: 13px; margin-top: 16px;">After expiration, your explorer and its data will be removed.</p>
+            <h1>Your demo expires in 2 days</h1>
+            <p><code>${escapeHtml(data.explorerSlug)}</code> shuts down in 2 days.</p>
+            <div class="alert">${alertBody}</div>
+            <div class="cta-wrap"><a href="${data.migrateUrl}" class="cta">Start free trial &rarr;</a></div>
+            <p class="fineprint">After that, the explorer and its data are deleted.</p>
         `;
         return {
             subject,
-            textPart: `${urgencyText}\n\nUnsubscribe: ${data.unsubscribeUrl}`,
+            textPart: `${data.explorerSlug} shuts down in 2 days. Start the trial before then and your config carries over: ${data.migrateUrl}\n\nAfter that, the explorer and its data are deleted.\n\nUnsubscribe: ${data.unsubscribeUrl}`,
             htmlPart: wrapInTemplate(content, subject, data.unsubscribeUrl, data.appDomain)
         };
     },
 
     6: (data) => {
-        const subject = "Your demo expired, but your data doesn't have to";
-        const restoreHtml = data.recoveryHook
-            ? `<p>${escapeHtml(data.recoveryHook)}</p><p>Start a free trial now and we will restore your explorer instantly.</p>`
-            : `<p>We are keeping your configuration for 48 hours. Start a free trial now and we will restore your explorer instantly.</p>`;
-        const restoreText = data.recoveryHook
-            ? `${data.recoveryHook}\n\nStart a free trial to restore it: ${data.migrateUrl}`
-            : `Your demo explorer ${data.explorerSlug} has expired. We're keeping your configuration for 48 hours. Start a free trial to restore it: ${data.migrateUrl}`;
+        const subject = 'Your demo expired, 48h to recover';
+        const urgentBody = data.recoveryHook
+            ? escapeHtml(data.recoveryHook)
+            : "We're holding your config for 48 hours. Start a trial and it comes back with the same setup.";
         const content = `
-            <h2>Your demo has ended</h2>
-            <p>Your explorer <strong>${data.explorerSlug}</strong> has expired.</p>
-            ${restoreHtml}
-            <div class="cta-wrap"><a href="${data.migrateUrl}" class="cta">Restore Explorer</a></div>
-            <p style="color: #888; font-size: 13px; margin-top: 16px;">After 48 hours, your explorer and its data will be permanently deleted.</p>
+            <h1>Your demo expired, 48h to recover</h1>
+            <p><code>${escapeHtml(data.explorerSlug)}</code> expired.</p>
+            <div class="urgent">${urgentBody}</div>
+            <div class="cta-wrap"><a href="${data.migrateUrl}" class="cta">Restore explorer &rarr;</a></div>
+            <p class="fineprint">After 48 hours, it's deleted for good.</p>
         `;
         return {
             subject,
-            textPart: `${restoreText}\n\nUnsubscribe: ${data.unsubscribeUrl}`,
+            textPart: `${data.explorerSlug} expired. We're holding your config for 48 hours. Start a trial and it comes back with the same setup: ${data.migrateUrl}\n\nAfter 48 hours, it's deleted for good.\n\nUnsubscribe: ${data.unsubscribeUrl}`,
             htmlPart: wrapInTemplate(content, subject, data.unsubscribeUrl, data.appDomain)
         };
     }

--- a/run/emails/drip-content.js
+++ b/run/emails/drip-content.js
@@ -22,7 +22,7 @@ let baseTemplate;
 
 /**
  * Loads and caches the base HTML template.
- * @returns {string} HTML template string with {{content}} and {{unsubscribeUrl}} placeholders
+ * @returns {string} HTML template string with {{subject}}, {{content}}, {{unsubscribeUrl}}, and {{appDomain}} placeholders
  */
 function getBaseTemplate() {
     if (!baseTemplate) {
@@ -34,8 +34,9 @@ function getBaseTemplate() {
 /**
  * Wraps content in the branded HTML template.
  * @param {string} content - Inner HTML content
- * @param {string} subject - Email subject for title tag
+ * @param {string} subject - Email subject for title tag (will be HTML-escaped)
  * @param {string} unsubscribeUrl - Unsubscribe link
+ * @param {string} appDomain - App domain for header/footer brand links
  * @returns {string} Complete HTML email
  */
 function wrapInTemplate(content, subject, unsubscribeUrl, appDomain) {
@@ -172,12 +173,13 @@ const steps = {
  * @param {string} data.migrateUrl - Migration URL with JWT token (steps 3-6)
  * @param {string} data.email - Recipient email
  * @param {string} data.unsubscribeUrl - Unsubscribe URL
+ * @param {string} data.appDomain - App domain for header/footer brand links
  * @param {string} [data.activitySummary] - Activity summary for step 2
  * @param {string} [data.teamContext] - Team/company context for step 4 (enrichment: companyContext)
  * @param {string} [data.tailoredBenefits] - Personalized benefits for step 3
  * @param {string} [data.expirationWarning] - Personalized "about to lose" message for step 5
  * @param {string} [data.recoveryHook] - Personalized "still recoverable" message for step 6
- * @returns {{ subject: string, textPart: string, htmlPart: string|null }}
+ * @returns {{ subject: string, textPart: string, htmlPart: string }}
  * @throws {Error} If step is not 1-6
  */
 function getEmailContent(step, data) {

--- a/run/tests/emails/drip-content.test.js
+++ b/run/tests/emails/drip-content.test.js
@@ -4,54 +4,107 @@ describe('drip-content', () => {
     const baseData = {
         explorerSlug: 'my-chain',
         explorerLink: 'https://my-chain.app.tryethernal.com',
+        migrateUrl: 'https://app.tryethernal.com/?explorerToken=xyz',
         email: 'dev@example.com',
-        unsubscribeUrl: 'https://app.tryethernal.com/api/demo/unsubscribe?token=abc'
+        unsubscribeUrl: 'https://app.tryethernal.com/api/demo/unsubscribe?token=abc',
+        appDomain: 'tryethernal.com'
     };
 
-    it('Should return content for step 1', () => {
+    it('Should return branded HTML content for step 1', () => {
         const content = getEmailContent(1, baseData);
-        expect(content.subject).toEqual('Your Ethernal demo explorer is ready');
-        expect(content.textPart).toContain('my-chain');
-        expect(content.htmlPart).toBeNull(); // Step 1 is plain text only
+        expect(content.subject).toEqual('Your Ethernal demo is live');
+        expect(content.textPart).toContain('my-chain.app.tryethernal.com');
+        expect(content.htmlPart).toContain('Your Ethernal demo is live');
+        expect(content.htmlPart).toContain('Antoine');
+        expect(content.htmlPart).toContain('Open explorer');
     });
 
-    it('Should return content for step 2', () => {
-        const content = getEmailContent(2, { ...baseData, activitySummary: '12 token transfers synced' });
-        expect(content.subject).toContain('synced');
-        expect(content.htmlPart).toContain('12 token transfers synced');
+    it('Should return content for step 2 with activity summary in subject and body', () => {
+        const content = getEmailContent(2, { ...baseData, activitySummary: '12 token transfers' });
+        expect(content.subject).toEqual('12 token transfers synced on your demo');
+        expect(content.htmlPart).toContain('12 token transfers');
+        expect(content.htmlPart).toContain('my-chain');
     });
 
-    it('Should return content for step 3', () => {
+    it('Should return content for step 3 with comparison table', () => {
         const content = getEmailContent(3, baseData);
-        expect(content.subject).toContain('missing');
+        expect(content.subject).toEqual('What the paid plan adds');
         expect(content.htmlPart).toContain('Demo');
         expect(content.htmlPart).toContain('Paid');
+        expect(content.htmlPart).toContain('Data retention');
+        expect(content.htmlPart).toContain('Start free trial');
+    });
+
+    it('Should render tailoredBenefits when provided on step 3', () => {
+        const content = getEmailContent(3, { ...baseData, tailoredBenefits: 'Faster debugging for your rollup.' });
+        expect(content.htmlPart).toContain('Faster debugging for your rollup.');
     });
 
     it('Should return content for step 4 with custom team context', () => {
         const content = getEmailContent(4, { ...baseData, teamContext: 'Acme builds on Base L2' });
-        expect(content.subject).toContain('Teams');
+        expect(content.subject).toEqual('Who else is running Ethernal');
         expect(content.htmlPart).toContain('Acme builds on Base L2');
     });
 
-    it('Should return content for step 4 with default fallback', () => {
+    it('Should return content for step 4 without custom team context', () => {
         const content = getEmailContent(4, baseData);
-        expect(content.htmlPart).toContain('EVM');
+        expect(content.htmlPart).toContain('production L2s');
     });
 
-    it('Should return content for step 5', () => {
+    it('Should return content for step 5 with default alert body', () => {
         const content = getEmailContent(5, baseData);
-        expect(content.subject).toContain('expires');
+        expect(content.subject).toEqual('Your demo expires in 2 days');
         expect(content.htmlPart).toContain('2 days');
+        expect(content.htmlPart).toContain('config carries over');
+        expect(content.htmlPart).toContain('my-chain');
     });
 
-    it('Should return content for step 6', () => {
+    it('Should render expirationWarning override on step 5', () => {
+        const content = getEmailContent(5, { ...baseData, expirationWarning: 'You have 1,200 tx worth keeping.' });
+        expect(content.htmlPart).toContain('You have 1,200 tx worth keeping.');
+    });
+
+    it('Should return content for step 6 with default recovery body', () => {
         const content = getEmailContent(6, baseData);
-        expect(content.subject).toContain('expired');
-        expect(content.htmlPart).toContain('48');
+        expect(content.subject).toEqual('Your demo expired, 48h to recover');
+        expect(content.htmlPart).toContain('48 hours');
+        expect(content.htmlPart).toContain('Restore explorer');
+    });
+
+    it('Should render recoveryHook override on step 6', () => {
+        const content = getEmailContent(6, { ...baseData, recoveryHook: 'Your 1,200 tx are still here.' });
+        expect(content.htmlPart).toContain('Your 1,200 tx are still here.');
     });
 
     it('Should throw for invalid step', () => {
         expect(() => getEmailContent(7, baseData)).toThrow('Invalid drip step');
+    });
+
+    it('Should not contain AI-tell phrases in any step', () => {
+        const forbidden = [
+            'gives you a taste',
+            'feel free to',
+            'enduring',
+            'testament',
+            'Here is what you',
+            'journey',
+            'unlock',
+            'pivotal'
+        ];
+        const dataWithAllHooks = {
+            ...baseData,
+            activitySummary: '1,247 blocks',
+            teamContext: 'Team X',
+            tailoredBenefits: 'Benefit',
+            expirationWarning: 'Warning',
+            recoveryHook: 'Recovery'
+        };
+        for (let step = 1; step <= 6; step++) {
+            const content = getEmailContent(step, dataWithAllHooks);
+            const haystack = `${content.subject}\n${content.textPart}\n${content.htmlPart || ''}`;
+            for (const phrase of forbidden) {
+                expect(haystack.toLowerCase()).not.toContain(phrase.toLowerCase());
+            }
+        }
     });
 });

--- a/run/tests/emails/drip-content.test.js
+++ b/run/tests/emails/drip-content.test.js
@@ -33,6 +33,7 @@ describe('drip-content', () => {
         expect(content.htmlPart).toContain('Paid');
         expect(content.htmlPart).toContain('Data retention');
         expect(content.htmlPart).toContain('Start free trial');
+        expect(content.htmlPart).toContain(baseData.migrateUrl);
     });
 
     it('Should render tailoredBenefits when provided on step 3', () => {
@@ -44,6 +45,7 @@ describe('drip-content', () => {
         const content = getEmailContent(4, { ...baseData, teamContext: 'Acme builds on Base L2' });
         expect(content.subject).toEqual('Who else is running Ethernal');
         expect(content.htmlPart).toContain('Acme builds on Base L2');
+        expect(content.htmlPart).toContain(baseData.migrateUrl);
     });
 
     it('Should return content for step 4 without custom team context', () => {
@@ -57,6 +59,7 @@ describe('drip-content', () => {
         expect(content.htmlPart).toContain('2 days');
         expect(content.htmlPart).toContain('config carries over');
         expect(content.htmlPart).toContain('my-chain');
+        expect(content.htmlPart).toContain(baseData.migrateUrl);
     });
 
     it('Should render expirationWarning override on step 5', () => {
@@ -69,6 +72,7 @@ describe('drip-content', () => {
         expect(content.subject).toEqual('Your demo expired, 48h to recover');
         expect(content.htmlPart).toContain('48 hours');
         expect(content.htmlPart).toContain('Restore explorer');
+        expect(content.htmlPart).toContain(baseData.migrateUrl);
     });
 
     it('Should render recoveryHook override on step 6', () => {
@@ -78,6 +82,13 @@ describe('drip-content', () => {
 
     it('Should throw for invalid step', () => {
         expect(() => getEmailContent(7, baseData)).toThrow('Invalid drip step');
+    });
+
+    it('Should fully substitute template placeholders', () => {
+        const content = getEmailContent(1, baseData);
+        expect(content.htmlPart).toContain(baseData.unsubscribeUrl);
+        expect(content.htmlPart).toContain(baseData.appDomain);
+        expect(content.htmlPart).not.toContain('{{');
     });
 
     it('Should not contain AI-tell phrases in any step', () => {

--- a/run/tests/emails/drip-content.test.js
+++ b/run/tests/emails/drip-content.test.js
@@ -6,7 +6,7 @@ describe('drip-content', () => {
         explorerLink: 'https://my-chain.app.tryethernal.com',
         migrateUrl: 'https://app.tryethernal.com/?explorerToken=xyz',
         email: 'dev@example.com',
-        unsubscribeUrl: 'https://app.tryethernal.com/api/demo/unsubscribe?token=abc',
+        unsubscribeUrl: 'https://app.tryethernal.com/api/demo/unsubscribe?token=abc&src=drip',
         appDomain: 'tryethernal.com'
     };
 
@@ -85,9 +85,11 @@ describe('drip-content', () => {
     });
 
     it('Should fully substitute template placeholders', () => {
+        // unsubscribeUrl contains `&` which gets encoded to `&amp;` in the rendered HTML,
+        // so assert on a unique substring that survives escaping.
         for (let step = 1; step <= 6; step++) {
             const content = getEmailContent(step, baseData);
-            expect(content.htmlPart).toContain(baseData.unsubscribeUrl);
+            expect(content.htmlPart).toContain('api/demo/unsubscribe?token=abc&amp;src=drip');
             expect(content.htmlPart).toContain(baseData.appDomain);
             expect(content.htmlPart).not.toContain('{{');
         }

--- a/run/tests/emails/drip-content.test.js
+++ b/run/tests/emails/drip-content.test.js
@@ -85,10 +85,12 @@ describe('drip-content', () => {
     });
 
     it('Should fully substitute template placeholders', () => {
-        const content = getEmailContent(1, baseData);
-        expect(content.htmlPart).toContain(baseData.unsubscribeUrl);
-        expect(content.htmlPart).toContain(baseData.appDomain);
-        expect(content.htmlPart).not.toContain('{{');
+        for (let step = 1; step <= 6; step++) {
+            const content = getEmailContent(step, baseData);
+            expect(content.htmlPart).toContain(baseData.unsubscribeUrl);
+            expect(content.htmlPart).toContain(baseData.appDomain);
+            expect(content.htmlPart).not.toContain('{{');
+        }
     });
 
     it('Should not contain AI-tell phrases in any step', () => {

--- a/run/tests/emails/drip-content.test.js
+++ b/run/tests/emails/drip-content.test.js
@@ -93,6 +93,17 @@ describe('drip-content', () => {
         }
     });
 
+    it('Should HTML-escape the subject in the title tag', () => {
+        const content = getEmailContent(2, { ...baseData, activitySummary: '<b>alert</b>' });
+        expect(content.htmlPart).toContain('<title>&lt;b&gt;alert&lt;/b&gt; synced on your demo</title>');
+        expect(content.htmlPart).not.toContain('<title><b>alert</b>');
+    });
+
+    it('Should not re-substitute placeholders injected via enriched content', () => {
+        const content = getEmailContent(3, { ...baseData, tailoredBenefits: 'Visit {{appDomain}} for more.' });
+        expect(content.htmlPart).toContain('Visit {{appDomain}} for more.');
+    });
+
     it('Should not contain AI-tell phrases in any step', () => {
         const forbidden = [
             'gives you a taste',


### PR DESCRIPTION
## Summary

- Replace cramped dark email template with a light theme (white cards on soft gray, Linear/Stripe feel) for the 6-step demo explorer drip sequence
- Humanize all copy to remove AI-tells (rule-of-three chains, "gives you a taste", "testament", etc.); add a Jest guard test against regressions
- Convert step 1 from plain-text-only to branded HTML while preserving the personal Antoine/Ethernal signature
- Harden `wrapInTemplate()` to HTML-escape the subject (prevents `<title>` injection if `activitySummary` ever carries markup)
- Comparison table rebuilt with a separate checkmark column and dim/bold text styling, no red/green colors

## Visual

Before: narrow dark navy card, 15px text crammed into 32px padding, red ✗ / green ✓ in feature table, plain-text step 1.
After: 560px white card on `#eef1f5` bg, 22px h1, blue `#3D95CE` CTA, 4-column comparison table (Feature | Demo | ✓ | Paid), consistent branding across all 6 steps.

## Test plan

- [x] All 13 unit tests in `run/tests/emails/drip-content.test.js` pass (added: enrichment-hook branches, migrateUrl presence, placeholder substitution guard, AI-tell forbidden-phrase scan)
- [x] `sendDripEmail` and `processDripEmails` job tests still pass (no interface change)
- [x] Visual smoke test: rendered all 6 emails from production code, verified against approved mockup
- [ ] Post-merge: monitor the next round of drip sends (Mailjet delivery, open/click rates) to confirm no rendering regressions in the wild

🤖 Generated with [Claude Code](https://claude.com/claude-code)