### PR TITLE
Fix Sentry scanner false-incident storm + add RPC capability cache

### DIFF
--- a/.github/workflows/sentry-scanner.yml
+++ b/.github/workflows/sentry-scanner.yml
@@ -63,10 +63,10 @@ jobs:
 
             curl -s -o /tmp/be_err.json "$BASE/ethernal-backend/issues/?query=is:unresolved+issue.category:error&statsPeriod=24h&limit=100" -H "$AUTH"
             curl -s -o /tmp/be_perf.json "$BASE/ethernal-backend/issues/?query=is:unresolved+issue.category:performance&statsPeriod=24h&limit=100" -H "$AUTH"
-            curl -s -o /tmp/be_reg.json "$BASE/ethernal-backend/issues/?query=is:regressed&limit=50" -H "$AUTH"
+            curl -s -o /tmp/be_reg.json "$BASE/ethernal-backend/issues/?query=is:regressed&statsPeriod=24h&limit=50" -H "$AUTH"
             curl -s -o /tmp/fe_err.json "$BASE/ethernal-frontend/issues/?query=is:unresolved+issue.category:error&statsPeriod=24h&limit=100" -H "$AUTH"
             curl -s -o /tmp/fe_perf.json "$BASE/ethernal-frontend/issues/?query=is:unresolved+issue.category:performance&statsPeriod=24h&limit=100" -H "$AUTH"
-            curl -s -o /tmp/fe_reg.json "$BASE/ethernal-frontend/issues/?query=is:regressed&limit=50" -H "$AUTH"
+            curl -s -o /tmp/fe_reg.json "$BASE/ethernal-frontend/issues/?query=is:regressed&statsPeriod=24h&limit=50" -H "$AUTH"
 
             # ALWAYS project events_24h (rolling) — never use raw `count` (lifetime) for decisions or reports.
             PROJ='[.[] | {id, title, lifetime_count: (.count | tonumber), events_24h: ([.stats."24h"[]?[1]] | add // 0), lastSeen, shortId, isRegression: (.isRegression // false)}]'

--- a/.github/workflows/sentry-scanner.yml
+++ b/.github/workflows/sentry-scanner.yml
@@ -51,6 +51,7 @@ jobs:
             - Only `statsPeriod` values of `24h` and `14d` work. Do NOT use `1h`.
             - Always save curl output to a temp file first, then process with jq. Do NOT pipe curl directly to jq — it fails intermittently.
             - Pattern: `curl -s -o /tmp/resp.json "URL" -H "Authorization: Bearer $SENTRY_API_TOKEN" && jq '...' /tmp/resp.json`
+            - **CRITICAL — `count` is LIFETIME, not 24h.** The `count` field on each issue in the list response is the lifetime `times_seen` total, NOT the 24h rolling volume. Do NOT use it for thresholds or report it as "Events (24h)" — that caused a false-incident storm (issues #1218–#1232 were all closed as self-resolved because the scanner reported 6,000+ "24h events" when actual 24h volume was 2–16). The TRUE 24h volume is `([.stats."24h"[]?[1]] | add)` — sum of the hourly buckets in the `stats."24h"` array. Always compute and use this value.
 
             ## Step 1: Query Sentry for all unresolved issues
 
@@ -67,13 +68,17 @@ jobs:
             curl -s -o /tmp/fe_perf.json "$BASE/ethernal-frontend/issues/?query=is:unresolved+issue.category:performance&statsPeriod=24h&limit=100" -H "$AUTH"
             curl -s -o /tmp/fe_reg.json "$BASE/ethernal-frontend/issues/?query=is:regressed&limit=50" -H "$AUTH"
 
-            echo "=== Backend Errors ===" && jq '[.[] | {id, title, count, lastSeen, shortId}]' /tmp/be_err.json
-            echo "=== Backend Performance ===" && jq '[.[] | {id, title, count, lastSeen, shortId}]' /tmp/be_perf.json
-            echo "=== Backend Regressed ===" && jq '[.[] | {id, title, count, lastSeen, shortId}]' /tmp/be_reg.json
-            echo "=== Frontend Errors ===" && jq '[.[] | {id, title, count, lastSeen, shortId}]' /tmp/fe_err.json
-            echo "=== Frontend Performance ===" && jq '[.[] | {id, title, count, lastSeen, shortId}]' /tmp/fe_perf.json
-            echo "=== Frontend Regressed ===" && jq '[.[] | {id, title, count, lastSeen, shortId}]' /tmp/fe_reg.json
+            # ALWAYS project events_24h (rolling) — never use raw `count` (lifetime) for decisions or reports.
+            PROJ='[.[] | {id, title, lifetime_count: (.count | tonumber), events_24h: ([.stats."24h"[]?[1]] | add // 0), lastSeen, shortId, isRegression: (.isRegression // false)}]'
+            echo "=== Backend Errors ===" && jq "$PROJ" /tmp/be_err.json
+            echo "=== Backend Performance ===" && jq "$PROJ" /tmp/be_perf.json
+            echo "=== Backend Regressed ===" && jq "$PROJ" /tmp/be_reg.json
+            echo "=== Frontend Errors ===" && jq "$PROJ" /tmp/fe_err.json
+            echo "=== Frontend Performance ===" && jq "$PROJ" /tmp/fe_perf.json
+            echo "=== Frontend Regressed ===" && jq "$PROJ" /tmp/fe_reg.json
             ```
+
+            From this point on, **always use `events_24h` (computed above) for thresholds and reporting**. The `lifetime_count` is informational only — useful as context ("issue has fired 6,953 times total but only 2 in last 24h") but never a decision input.
 
             Deduplicate by `(project, id)` — regressed issues may appear in both the error/performance and regressed queries.
 
@@ -111,41 +116,53 @@ jobs:
             Then categorize into ONE of:
 
             ### AUTO-SKIP + RESOLVE in Sentry
-            - Connection/transient errors (SequelizeConnectionError, ECONNRESET, "Connection terminated unexpectedly") — UNLESS 30+ events in 24h
+            - **Any issue with `events_24h == 0`** (regardless of lifetime count) — it has self-resolved, mark resolved in Sentry
+            - Connection/transient errors (SequelizeConnectionError, ECONNRESET, "Connection terminated unexpectedly") — UNLESS `events_24h >= 30`
             - Rate limiting errors
             - Expected validation errors (user input)
             - Third-party service errors we can't control
             - Low-impact edge cases (deprecated browser, obscure user input)
             - Performance issues on endpoints that no longer exist
-            - Performance issues with 0 events in the last 24h that are stale
+            - Performance issues with `events_24h == 0` that are stale
 
             To resolve: `curl -s -X PUT "https://sentry.tryethernal.com/api/0/issues/{id}/" -H "Authorization: Bearer $SENTRY_API_TOKEN" -H "Content-Type: application/json" -d '{"status": "resolved"}'`
 
-            ### CREATE GITHUB ISSUE (prioritized)
+            ### CREATE GITHUB ISSUE (prioritized) — all event counts below are `events_24h`, NOT lifetime
             **Priority 1 — Regressions** (always create, regardless of event count):
-            - Any issue where `isRegression: true` — a previous fix didn't hold
+            - Any issue where `isRegression: true` AND `events_24h >= 1` — a previous fix didn't hold AND it's still firing
+            - Regressions with `events_24h == 0` go to AUTO-SKIP+RESOLVE — the regression flag is stale
             - Title prefix: "Sentry (regression):" for errors, "Perf (regression):" for performance
 
             **Priority 2 — High-impact errors**:
-            - Null/type errors, unhandled promise rejections with 2+ events
-            - Systematic issues with 5+ events in 24h
+            - Null/type errors, unhandled promise rejections with `events_24h >= 2`
+            - Systematic issues with `events_24h >= 5`
 
             **Priority 3 — High-impact performance** (user-facing hot paths only):
-            - N+1 queries with 50+ events AND on a user-facing endpoint or blockSync hot path
-            - Slow DB queries with 50+ events AND p95 > 2s
+            - N+1 queries with `events_24h >= 50` AND on a user-facing endpoint or blockSync hot path
+            - Slow DB queries with `events_24h >= 50` AND p95 > 2s
 
             **Priority 4 — Medium performance**:
-            - N+1 queries with 20-49 events on user-facing endpoints
-            - Background job performance issues with 100+ events (higher bar since they don't affect UX)
+            - N+1 queries with `events_24h` 20–49 on user-facing endpoints
+            - Background job performance issues with `events_24h >= 100` (higher bar since they don't affect UX)
 
             ### SKIP (leave unresolved in Sentry)
-            - Non-regressed issues with fewer than 2 events (might be one-off)
+            - Non-regressed issues with `events_24h < 2` (might be one-off)
             - Performance issues on admin/debug endpoints (e.g., /bull/*)
-            - Performance issues on background jobs with < 100 events
+            - Performance issues on background jobs with `events_24h < 100`
             - Performance issues where the slow span is < 2s on a background job
             - Issues where the slow span is an external API call we can't control
             - Issues that need more data to evaluate
             - Performance issues where multiple related Sentry issues point to the same code path — group them mentally and only create ONE issue for the root cause, not one per symptom
+
+            ### AUTO-SKIP — BullMQ Redis ops misclassified as N+1
+            Sentry's N+1 detector occasionally flags BullMQ's normal Lua-script Redis operations as N+1 query patterns. These are NOT real N+1 bugs and should be auto-resolved.
+
+            **Detection — auto-resolve in Sentry without creating a GH issue if ALL of:**
+            1. Issue type is `N+1 Query` (or `issue.category:performance` with N+1 fingerprint)
+            2. The repeated span is a Redis op — `db.redis`, `cache.get`, or the span description contains `evalsha` / `evalSha`
+            3. The span description references a BullMQ key — matches `bull:`, `bullmq:`, or one of the BullMQ Lua script SHAs (`840cf612b9e4155aeb79853f3502814792769274` and similar 40-char hex SHAs paired with `bull:` keys)
+
+            Resolve these in Sentry with a short comment ("BullMQ Redis ops are not N+1 — scanner filter") and skip creating a GitHub issue. Issue #1221 was a recent example.
 
             ## Step 5: Create GitHub issues
 
@@ -159,7 +176,8 @@ jobs:
 
             **Project:** [ethernal-backend|ethernal-frontend]
             **Level:** [error|warning]
-            **Events (24h):** [count]
+            **Events (24h):** [events_24h]   ← rolling, used for thresholds
+            **Lifetime events:** [lifetime_count]
             **Regression:** [Yes/No]
             **Link:** https://sentry.tryethernal.com/organizations/sentry/issues/[ID]/
 
@@ -186,7 +204,8 @@ jobs:
 
             **Project:** [ethernal-backend|ethernal-frontend]
             **Type:** [N+1 Query | Slow DB | Slow Transaction | Regression | ...]
-            **Impact:** [events in 24h] events
+            **Impact (24h):** [events_24h] events   ← rolling, used for thresholds
+            **Lifetime events:** [lifetime_count]
             **Regression:** [Yes/No]
             **Transaction:** \`[transaction name]\`
             **Link:** https://sentry.tryethernal.com/organizations/sentry/issues/[ID]/
@@ -229,7 +248,7 @@ jobs:
                 \"sentryProject\": \"PROJECT\",
                 \"sentryTitle\": \"TITLE\",
                 \"sentryLevel\": \"LEVEL\",
-                \"sentryEventCount\": COUNT,
+                \"sentryEventCount\": EVENTS_24H,
                 \"sentryLink\": \"https://sentry.tryethernal.com/organizations/sentry/issues/SENTRY_ID/\",
                 \"status\": \"discovered\",
                 \"currentStep\": \"Discovered by scanner\"

--- a/run/lib/rpc.js
+++ b/run/lib/rpc.js
@@ -14,6 +14,7 @@ const { bulkEnqueue } = require('./queue');
 const logger = require('./logger');
 const { withTimeout, sanitize } = require('../lib/utils');
 const abiChecker = require('../lib/contract');
+const rpcCapabilityCache = require('./rpcCapabilityCache');
 
 /** Module-level bytecode cache shared across Tracer instances (immutable data) */
 const bytecodeCache = new LRUCache({ max: 5000, ttl: 3600000 });
@@ -452,6 +453,7 @@ class Tracer {
 
     constructor(server, db, type = 'other') {
         if (!server) throw '[Tracer] Missing parameter';
+        this.server = server;
         this.provider = getProvider(server);
         this.traceProvider = getProvider(server, 30000); // Separate provider with 30s timeout for trace operations
         this.db = db;
@@ -530,10 +532,20 @@ class Tracer {
             innerMessage.includes('debug_traceTransaction is not enabled') ||
             innerMessage.includes('debug_traceTransaction not supported') ||
             (errorMessage.includes('failed response') && errorMessage.includes('debug_traceTransaction'))) {
+            // Cache the unsupported verdict at the host level so other workspaces
+            // sharing this RPC stop hammering it for 24h. Self-heals via TTL.
+            rpcCapabilityCache.markTraceUnsupported(this.server).catch(() => {});
             return this.error = {
                 message: 'RPC endpoint does not support debug_traceTransaction or is unreachable',
                 error: error
             };
+        }
+
+        // Withtimeout/AbortError surfaces as a timeout — count it toward the
+        // host's slowness budget. After N consecutive timeouts the host gets
+        // marked slow for 1h and we short-circuit subsequent calls.
+        if (errorMessage.includes('timeout') || errorMessage.includes('Timed out') || error.code === 'TIMEOUT') {
+            rpcCapabilityCache.recordTraceTimeout(this.server).catch(() => {});
         }
 
         throw error;
@@ -571,7 +583,12 @@ class Tracer {
     async processGeth(transaction) {
         try {
             this.transaction = transaction;
+            if (await rpcCapabilityCache.isTraceDisabled(this.server)) {
+                this.error = { message: 'RPC endpoint does not support debug_traceTransaction or is unreachable' };
+                return;
+            }
             const rawTrace = await withTimeout(this.traceProvider.send('debug_traceTransaction', [transaction.hash, { "tracer": "callTracer", "tracerConfig": { "withLog": true }}]), 30000);
+            await rpcCapabilityCache.recordTraceSuccess(this.server);
             if (!rawTrace.calls)
                 return;
             for (let call of rawTrace.calls)
@@ -584,7 +601,12 @@ class Tracer {
     async processOther(transaction) {
         try {
             this.transaction = transaction;
+            if (await rpcCapabilityCache.isTraceDisabled(this.server)) {
+                this.error = { message: 'RPC endpoint does not support debug_traceTransaction or is unreachable' };
+                return;
+            }
             const rawTrace = await withTimeout(this.traceProvider.send('debug_traceTransaction', [transaction.hash, {}]), 30000);
+            await rpcCapabilityCache.recordTraceSuccess(this.server);
             if (!rawTrace)
                 return null;
             this.parsedTrace = await parseTrace(transaction.from, rawTrace, this.provider);

--- a/run/lib/rpcCapabilityCache.js
+++ b/run/lib/rpcCapabilityCache.js
@@ -1,0 +1,137 @@
+/**
+ * @fileoverview Redis-backed cache of RPC host capabilities.
+ * Avoids re-calling debug_traceTransaction against hosts that have been
+ * observed to not support it, or that are chronically too slow to respond
+ * within our timeout budget. Self-healing via TTLs — no manual flag flipping
+ * and no per-workspace state, so all workspaces sharing an RPC benefit.
+ * @module lib/rpcCapabilityCache
+ */
+
+const redis = require('./redis');
+const logger = require('./logger');
+
+const KEY_PREFIX = 'rpc:cap:';
+
+const UNSUPPORTED_TTL_SEC = 24 * 60 * 60;
+const SLOW_TTL_SEC = 60 * 60;
+const TIMEOUT_WINDOW_SEC = 5 * 60;
+const TIMEOUT_THRESHOLD = 5;
+
+/**
+ * Extracts the host portion (host:port) from an RPC server URL.
+ * Falls back to the raw input if the URL is unparseable so a malformed
+ * server still gets a stable cache key instead of crashing the caller.
+ * @param {string} rpcServer
+ * @returns {string|null}
+ */
+function getHost(rpcServer) {
+    if (!rpcServer || typeof rpcServer !== 'string')
+        return null;
+    try {
+        return new URL(rpcServer).host.toLowerCase();
+    } catch (_) {
+        return rpcServer.toLowerCase();
+    }
+}
+
+function disabledKey(host) { return `${KEY_PREFIX}${host}:debug_trace:disabled`; }
+function timeoutsKey(host) { return `${KEY_PREFIX}${host}:debug_trace:timeouts`; }
+
+/**
+ * Returns true if debug_traceTransaction calls to the given host should be skipped.
+ * On Redis errors, returns false (fail-open) so a Redis blip never silently
+ * disables tracing across the fleet.
+ * @param {string} rpcServer
+ * @returns {Promise<boolean>}
+ */
+async function isTraceDisabled(rpcServer) {
+    const host = getHost(rpcServer);
+    if (!host) return false;
+    try {
+        const value = await redis.get(disabledKey(host));
+        return value !== null;
+    } catch (error) {
+        logger.error('rpcCapabilityCache.isTraceDisabled', { error: error.message, host });
+        return false;
+    }
+}
+
+/**
+ * Marks the host as not supporting debug_traceTransaction for UNSUPPORTED_TTL_SEC.
+ * Use when the RPC explicitly returns "Method not enabled" / "does not exist".
+ * @param {string} rpcServer
+ * @returns {Promise<void>}
+ */
+async function markTraceUnsupported(rpcServer) {
+    const host = getHost(rpcServer);
+    if (!host) return;
+    try {
+        await redis.set(disabledKey(host), 'unsupported', 'EX', UNSUPPORTED_TTL_SEC);
+    } catch (error) {
+        logger.error('rpcCapabilityCache.markTraceUnsupported', { error: error.message, host });
+    }
+}
+
+/**
+ * Marks the host as too slow to trace for SLOW_TTL_SEC. Use when consecutive
+ * timeouts have exceeded the threshold — shorter TTL than unsupported because
+ * slowness is more often transient.
+ * @param {string} rpcServer
+ * @returns {Promise<void>}
+ */
+async function markTraceSlow(rpcServer) {
+    const host = getHost(rpcServer);
+    if (!host) return;
+    try {
+        await redis.set(disabledKey(host), 'slow', 'EX', SLOW_TTL_SEC);
+        await redis.del(timeoutsKey(host));
+    } catch (error) {
+        logger.error('rpcCapabilityCache.markTraceSlow', { error: error.message, host });
+    }
+}
+
+/**
+ * Records a timeout against the host. Once TIMEOUT_THRESHOLD timeouts occur
+ * within TIMEOUT_WINDOW_SEC, the host is marked slow. The counter resets on
+ * any successful trace via {@link recordTraceSuccess}.
+ * @param {string} rpcServer
+ * @returns {Promise<void>}
+ */
+async function recordTraceTimeout(rpcServer) {
+    const host = getHost(rpcServer);
+    if (!host) return;
+    try {
+        const count = await redis.incr(timeoutsKey(host));
+        if (count === 1)
+            await redis.expire(timeoutsKey(host), TIMEOUT_WINDOW_SEC);
+        if (count >= TIMEOUT_THRESHOLD)
+            await markTraceSlow(rpcServer);
+    } catch (error) {
+        logger.error('rpcCapabilityCache.recordTraceTimeout', { error: error.message, host });
+    }
+}
+
+/**
+ * Resets the consecutive-timeout counter for the host. Call after any
+ * successful trace so transient blips don't accumulate into a slow-mark.
+ * @param {string} rpcServer
+ * @returns {Promise<void>}
+ */
+async function recordTraceSuccess(rpcServer) {
+    const host = getHost(rpcServer);
+    if (!host) return;
+    try {
+        await redis.del(timeoutsKey(host));
+    } catch (error) {
+        logger.error('rpcCapabilityCache.recordTraceSuccess', { error: error.message, host });
+    }
+}
+
+module.exports = {
+    isTraceDisabled,
+    markTraceUnsupported,
+    markTraceSlow,
+    recordTraceTimeout,
+    recordTraceSuccess,
+    _internals: { getHost, disabledKey, timeoutsKey, UNSUPPORTED_TTL_SEC, SLOW_TTL_SEC, TIMEOUT_WINDOW_SEC, TIMEOUT_THRESHOLD },
+};

--- a/run/lib/rpcCapabilityCache.js
+++ b/run/lib/rpcCapabilityCache.js
@@ -49,7 +49,10 @@ async function isTraceDisabled(rpcServer) {
     if (!host) return false;
     try {
         const value = await redis.get(disabledKey(host));
-        return value !== null;
+        // ioredis returns null for missing keys, but auto-mocks/stubs may
+        // return undefined — treat both as "not disabled" so the predicate
+        // is robust to mock implementations and never accidentally trips.
+        return value != null;
     } catch (error) {
         logger.error('rpcCapabilityCache.isTraceDisabled', { error: error.message, host });
         return false;

--- a/run/lib/rpcCapabilityCache.js
+++ b/run/lib/rpcCapabilityCache.js
@@ -102,8 +102,11 @@ async function recordTraceTimeout(rpcServer) {
     if (!host) return;
     try {
         const count = await redis.incr(timeoutsKey(host));
-        if (count === 1)
-            await redis.expire(timeoutsKey(host), TIMEOUT_WINDOW_SEC);
+        // Refresh the window TTL on every timeout. Doing it only when count===1
+        // races with a concurrent recordTraceSuccess: if it DELs the key between
+        // our INCR and EXPIRE, the new key created by INCR would have no TTL
+        // and accumulate forever. Refreshing unconditionally is cheap and safe.
+        await redis.expire(timeoutsKey(host), TIMEOUT_WINDOW_SEC);
         if (count >= TIMEOUT_THRESHOLD)
             await markTraceSlow(rpcServer);
     } catch (error) {

--- a/run/tests/lib/rpc.test.js
+++ b/run/tests/lib/rpc.test.js
@@ -1,9 +1,19 @@
 require('../mocks/lib/trace');
 require('../mocks/lib/ethers');
 require('../mocks/lib/queue');
+
+jest.mock('../../lib/rpcCapabilityCache', () => ({
+    isTraceDisabled: jest.fn().mockResolvedValue(false),
+    markTraceUnsupported: jest.fn().mockResolvedValue(undefined),
+    markTraceSlow: jest.fn().mockResolvedValue(undefined),
+    recordTraceTimeout: jest.fn().mockResolvedValue(undefined),
+    recordTraceSuccess: jest.fn().mockResolvedValue(undefined),
+}));
+
 const ethers = require('ethers');
 const { processTrace, parseTrace } = require('../../lib/trace');
 const { bulkEnqueue } = require('../../lib/queue');
+const rpcCapabilityCache = require('../../lib/rpcCapabilityCache');
 const { ContractConnector, Tracer, ERC721Connector } = require('../../lib/rpc');
 
 afterEach(() => jest.clearAllMocks());
@@ -148,6 +158,73 @@ describe('Tracer', () => {
         await expect(tracer.process({ hash: '0x123' })).rejects.toMatchObject({
             code: 'TRANSIENT_RPC_ERROR',
             message: 'Transient RPC error (failed response)'
+        });
+    });
+
+    describe('rpcCapabilityCache integration', () => {
+        it('Should short-circuit and not call the RPC when the host is cached as disabled (other tracer)', async () => {
+            rpcCapabilityCache.isTraceDisabled.mockResolvedValueOnce(true);
+            const tracer = new Tracer('http://localhost:8545', {});
+            const sendSpy = jest.spyOn(tracer.traceProvider, 'send');
+
+            await tracer.process({ hash: '0x123' });
+
+            expect(sendSpy).not.toHaveBeenCalled();
+            expect(tracer.error).toEqual({
+                message: 'RPC endpoint does not support debug_traceTransaction or is unreachable',
+            });
+        });
+
+        it('Should short-circuit and not call the RPC when the host is cached as disabled (geth tracer)', async () => {
+            rpcCapabilityCache.isTraceDisabled.mockResolvedValueOnce(true);
+            const tracer = new Tracer('http://localhost:8545', {}, 'geth');
+            const sendSpy = jest.spyOn(tracer.traceProvider, 'send');
+
+            await tracer.process({ hash: '0x123' });
+
+            expect(sendSpy).not.toHaveBeenCalled();
+            expect(tracer.error).toEqual({
+                message: 'RPC endpoint does not support debug_traceTransaction or is unreachable',
+            });
+        });
+
+        it('Should mark the host unsupported when the RPC returns "Method not enabled"', async () => {
+            const tracer = new Tracer('https://pre-rpc.bt.io/', {});
+            const error = new Error('debug_traceTransaction is not enabled');
+            jest.spyOn(tracer.traceProvider, 'send').mockRejectedValueOnce(error);
+
+            await tracer.process({ hash: '0x123' });
+
+            expect(rpcCapabilityCache.markTraceUnsupported).toHaveBeenCalledWith('https://pre-rpc.bt.io/');
+        });
+
+        it('Should mark the host unsupported when the inner error message says "does not exist"', async () => {
+            const tracer = new Tracer('https://pre-rpc.bt.io/', {});
+            const error = { error: { message: 'debug_traceTransaction does not exist' } };
+            jest.spyOn(tracer.traceProvider, 'send').mockRejectedValueOnce(error);
+
+            await tracer.process({ hash: '0x123' });
+
+            expect(rpcCapabilityCache.markTraceUnsupported).toHaveBeenCalledWith('https://pre-rpc.bt.io/');
+        });
+
+        it('Should record a timeout against the host when withTimeout fires', async () => {
+            const tracer = new Tracer('https://pre-rpc.bt.io/', {});
+            const error = new Error('Timed out after 30000 ms.');
+            jest.spyOn(tracer.traceProvider, 'send').mockRejectedValueOnce(error);
+
+            await expect(tracer.process({ hash: '0x123' })).rejects.toBeDefined();
+
+            expect(rpcCapabilityCache.recordTraceTimeout).toHaveBeenCalledWith('https://pre-rpc.bt.io/');
+            expect(rpcCapabilityCache.markTraceUnsupported).not.toHaveBeenCalled();
+        });
+
+        it('Should record a successful trace so the timeout counter resets', async () => {
+            const tracer = new Tracer('http://localhost:8545', {});
+
+            await tracer.process({ hash: '0x123' });
+
+            expect(rpcCapabilityCache.recordTraceSuccess).toHaveBeenCalledWith('http://localhost:8545');
         });
     });
 });

--- a/run/tests/lib/rpcCapabilityCache.test.js
+++ b/run/tests/lib/rpcCapabilityCache.test.js
@@ -49,6 +49,11 @@ describe('isTraceDisabled', () => {
         expect(redis.get).toHaveBeenCalledWith('rpc:cap:rpc.example.com:debug_trace:disabled');
     });
 
+    it('returns false when redis.get resolves to undefined (auto-mock behavior)', async () => {
+        redis.get.mockResolvedValueOnce(undefined);
+        await expect(cache.isTraceDisabled('https://rpc.example.com')).resolves.toBe(false);
+    });
+
     it('returns true when key exists', async () => {
         redis.get.mockResolvedValueOnce('unsupported');
         await expect(cache.isTraceDisabled('https://rpc.example.com')).resolves.toBe(true);

--- a/run/tests/lib/rpcCapabilityCache.test.js
+++ b/run/tests/lib/rpcCapabilityCache.test.js
@@ -112,10 +112,13 @@ describe('recordTraceTimeout', () => {
         expect(redis.set).not.toHaveBeenCalled();
     });
 
-    it('does not re-set the TTL on subsequent timeouts', async () => {
+    it('refreshes the window TTL on every timeout (avoids race with concurrent recordTraceSuccess)', async () => {
         redis.incr.mockResolvedValueOnce(2);
         await cache.recordTraceTimeout('https://rpc.example.com');
-        expect(redis.expire).not.toHaveBeenCalled();
+        expect(redis.expire).toHaveBeenCalledWith(
+            'rpc:cap:rpc.example.com:debug_trace:timeouts',
+            _internals.TIMEOUT_WINDOW_SEC,
+        );
     });
 
     it('marks the host slow when threshold is reached', async () => {

--- a/run/tests/lib/rpcCapabilityCache.test.js
+++ b/run/tests/lib/rpcCapabilityCache.test.js
@@ -1,0 +1,143 @@
+require('../mocks/lib/logger');
+
+jest.mock('../../lib/redis', () => ({
+    get: jest.fn(),
+    set: jest.fn(),
+    del: jest.fn(),
+    incr: jest.fn(),
+    expire: jest.fn(),
+}));
+
+const redis = require('../../lib/redis');
+const cache = require('../../lib/rpcCapabilityCache');
+const { _internals } = cache;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    redis.get.mockResolvedValue(null);
+    redis.set.mockResolvedValue('OK');
+    redis.del.mockResolvedValue(1);
+    redis.incr.mockResolvedValue(1);
+    redis.expire.mockResolvedValue(1);
+});
+
+describe('getHost', () => {
+    it('extracts host:port from a URL', () => {
+        expect(_internals.getHost('https://pre-rpc.bt.io/')).toBe('pre-rpc.bt.io');
+        expect(_internals.getHost('http://130.60.144.77:8554/foo')).toBe('130.60.144.77:8554');
+    });
+
+    it('lowercases the host', () => {
+        expect(_internals.getHost('https://RPC.Example.COM/')).toBe('rpc.example.com');
+    });
+
+    it('falls back to the raw input when the URL is unparseable', () => {
+        expect(_internals.getHost('not a url at all')).toBe('not a url at all');
+    });
+
+    it('returns null for empty input', () => {
+        expect(_internals.getHost('')).toBeNull();
+        expect(_internals.getHost(null)).toBeNull();
+        expect(_internals.getHost(undefined)).toBeNull();
+    });
+});
+
+describe('isTraceDisabled', () => {
+    it('returns false when no key exists', async () => {
+        redis.get.mockResolvedValueOnce(null);
+        await expect(cache.isTraceDisabled('https://rpc.example.com')).resolves.toBe(false);
+        expect(redis.get).toHaveBeenCalledWith('rpc:cap:rpc.example.com:debug_trace:disabled');
+    });
+
+    it('returns true when key exists', async () => {
+        redis.get.mockResolvedValueOnce('unsupported');
+        await expect(cache.isTraceDisabled('https://rpc.example.com')).resolves.toBe(true);
+    });
+
+    it('returns true regardless of cached value (slow vs unsupported both disable)', async () => {
+        redis.get.mockResolvedValueOnce('slow');
+        await expect(cache.isTraceDisabled('https://rpc.example.com')).resolves.toBe(true);
+    });
+
+    it('fails open when Redis errors so a Redis blip never disables tracing', async () => {
+        redis.get.mockRejectedValueOnce(new Error('redis down'));
+        await expect(cache.isTraceDisabled('https://rpc.example.com')).resolves.toBe(false);
+    });
+
+    it('returns false for unparseable empty input', async () => {
+        await expect(cache.isTraceDisabled('')).resolves.toBe(false);
+        expect(redis.get).not.toHaveBeenCalled();
+    });
+});
+
+describe('markTraceUnsupported', () => {
+    it('sets the disabled key with 24h TTL', async () => {
+        await cache.markTraceUnsupported('https://rpc.example.com');
+        expect(redis.set).toHaveBeenCalledWith(
+            'rpc:cap:rpc.example.com:debug_trace:disabled',
+            'unsupported',
+            'EX',
+            _internals.UNSUPPORTED_TTL_SEC,
+        );
+    });
+
+    it('swallows Redis errors', async () => {
+        redis.set.mockRejectedValueOnce(new Error('redis down'));
+        await expect(cache.markTraceUnsupported('https://rpc.example.com')).resolves.toBeUndefined();
+    });
+});
+
+describe('markTraceSlow', () => {
+    it('sets the disabled key with 1h TTL and clears the timeout counter', async () => {
+        await cache.markTraceSlow('https://rpc.example.com');
+        expect(redis.set).toHaveBeenCalledWith(
+            'rpc:cap:rpc.example.com:debug_trace:disabled',
+            'slow',
+            'EX',
+            _internals.SLOW_TTL_SEC,
+        );
+        expect(redis.del).toHaveBeenCalledWith('rpc:cap:rpc.example.com:debug_trace:timeouts');
+    });
+});
+
+describe('recordTraceTimeout', () => {
+    it('increments and sets the window TTL on first timeout', async () => {
+        redis.incr.mockResolvedValueOnce(1);
+        await cache.recordTraceTimeout('https://rpc.example.com');
+        expect(redis.incr).toHaveBeenCalledWith('rpc:cap:rpc.example.com:debug_trace:timeouts');
+        expect(redis.expire).toHaveBeenCalledWith(
+            'rpc:cap:rpc.example.com:debug_trace:timeouts',
+            _internals.TIMEOUT_WINDOW_SEC,
+        );
+        expect(redis.set).not.toHaveBeenCalled();
+    });
+
+    it('does not re-set the TTL on subsequent timeouts', async () => {
+        redis.incr.mockResolvedValueOnce(2);
+        await cache.recordTraceTimeout('https://rpc.example.com');
+        expect(redis.expire).not.toHaveBeenCalled();
+    });
+
+    it('marks the host slow when threshold is reached', async () => {
+        redis.incr.mockResolvedValueOnce(_internals.TIMEOUT_THRESHOLD);
+        await cache.recordTraceTimeout('https://rpc.example.com');
+        expect(redis.set).toHaveBeenCalledWith(
+            'rpc:cap:rpc.example.com:debug_trace:disabled',
+            'slow',
+            'EX',
+            _internals.SLOW_TTL_SEC,
+        );
+    });
+
+    it('swallows Redis errors', async () => {
+        redis.incr.mockRejectedValueOnce(new Error('redis down'));
+        await expect(cache.recordTraceTimeout('https://rpc.example.com')).resolves.toBeUndefined();
+    });
+});
+
+describe('recordTraceSuccess', () => {
+    it('clears the timeout counter so transient blips do not accumulate', async () => {
+        await cache.recordTraceSuccess('https://rpc.example.com');
+        expect(redis.del).toHaveBeenCalledWith('rpc:cap:rpc.example.com:debug_trace:timeouts');
+    });
+});


### PR DESCRIPTION
## Summary

Two related fixes that came out of triaging an apparent Sentry incident storm (issues #1218–#1232):

- **Scanner bug (root cause of the storm):** the scanner was reading the issues-list \`count\` field — which is the lifetime \`times_seen\` total — and reporting it as "Events (24h)". Most of those issues were already self-resolved, just with a high lifetime count. Switched to summing the per-issue \`stats.\"24h\"\` hourly buckets so thresholds and reports use the actual rolling window. Also auto-skip BullMQ Lua-script Redis ops misclassified as N+1 (#1221 root cause).

- **RPC capability cache (follow-up to #1232):** the only issue still firing meaningfully (\`pre-rpc.bt.io\` slow on \`debug_traceTransaction\`, ~126 events/24h). New \`run/lib/rpcCapabilityCache.js\` short-circuits trace calls against hosts that have explicitly returned "Method not enabled" (24h TTL) or that have racked up 5 consecutive timeouts in 5 min (1h TTL). Operates at the host level so all workspaces sharing an RPC benefit, self-heals via TTL, fails open on Redis errors so a Redis blip never silently disables tracing fleet-wide.

## Verification

Confirmed scanner bug via direct Sentry DB query — sample:

| Sentry Issue | GH issue claim ("Events 24h") | Actual rolling 24h | Last 6h |
|---|---|---|---|
| 34 (15s timeouts) | 6,953 | 2 | 0 |
| 26 (Method not enabled) | 3,898 | 8 | 0 |
| 154 (slow workspace) | 1,589 | 0 | 0 |
| 197 (DB conn timeout) | 1,964 | 2 | 0 |

## Test plan

- [x] \`docker compose -f docker-compose.dev.yml exec backend npm test -- --testPathPattern=\"rpcCapabilityCache|rpc.test\"\` — 41 tests pass
- [x] YAML parses (\`ruby -ryaml\`)
- [ ] Watch the next scanner run after merge to confirm \`events_24h\` is reported correctly and the BullMQ filter triggers
- [ ] Spot-check Redis after an unsupported-RPC trace attempt to confirm \`rpc:cap:{host}:debug_trace:disabled\` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)