### PR TITLE
fix(seo): emit real newlines in tenant robots.txt via heredoc

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -137,7 +137,13 @@ blog.tryethernal.com {
     }
     handle @tenantRobots {
         header Content-Type "text/plain; charset=utf-8"
-        respond "User-agent: *\nAllow: /\n\n# Noindex enforced via X-Robots-Tag header on every response.\n# Crawling is allowed so existing indexed URLs can be re-visited and dropped.\n" 200
+        respond <<ROBOTS
+			User-agent: *
+			Allow: /
+
+			# Noindex enforced via X-Robots-Tag header on every response.
+			# Crawling is allowed so existing indexed URLs can be re-visited and dropped.
+			ROBOTS 200
     }
 
     @landing host tryethernal.com www.tryethernal.com


### PR DESCRIPTION
## Summary

Follow-up to PR #1233. Post-deploy verification on `ethernal-caddy v227` caught that the tenant `/robots.txt` body was served with literal `\n` characters instead of real newlines:

```
$ curl -s https://cypherium.tryethernal.com/robots.txt
User-agent: *\nAllow: /\n\n# Noindex enforced via X-Robots-Tag header...
```

Caddy's `respond` directive does not interpret `\n` escape sequences in quoted strings. Crawlers that parse only robots.txt would see a malformed `User-agent` line and silently ignore the file.

The `X-Robots-Tag: noindex, nofollow` header is doing the actual deindexation work, so this is cosmetic — but robots.txt should still be valid.

## Fix

Use Caddy's heredoc syntax (`<<ROBOTS ... ROBOTS`) which preserves actual newlines. Caddy strips leading indentation based on the closing delimiter's indentation, so the tab-indented content in the Caddyfile renders flush-left in the output.

## Validation

Spun up a standalone `caddy:2.9.1-alpine` container locally with just the tenant-robots block on `:8199`. `od -c` on the response confirms real `\n` bytes:

```
$ curl -s http://localhost:8199/robots.txt | od -c | head -2
0000000    U   s   e   r   -   a   g   e   n   t   :       *  \n   A   l
0000020    l   o   w   :       /  \n  \n   #       N   o   i   n   d   e
```

## Test plan

- [ ] Merge and deploy Caddy
- [ ] Verify `curl -s https://cypherium.tryethernal.com/robots.txt` returns multi-line output with real newlines
- [ ] Verify `X-Robots-Tag: noindex, nofollow` is still present on tenant responses
- [ ] Verify `www.tryethernal.com/robots.txt` still returns the real sitemap (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)