### PR TITLE
fix(lpworker): serialize cascade-delete jobs to prevent lock storms

### DIFF
--- a/run/workers/lowPriority.js
+++ b/run/workers/lowPriority.js
@@ -16,6 +16,18 @@ const { managedWorkerError } = require('../lib/errors');
 const { startHeartbeat } = require('../lib/heartbeat');
 startHeartbeat('lowPriority');
 
+const DEFAULT_CONCURRENCY = 10;
+
+// Cascade-delete jobs that fan out from workspaceReset run at concurrency 1.
+// Each batch holds a single transaction with deferred FK constraints across
+// many shared rows (transaction_logs, token_transfers, ...). Running them in
+// parallel deadlocks on row locks and drains the per-machine Sequelize pool.
+// See incident 2026-04-24 (issues #1236-#1239, #1243).
+const PER_JOB_CONCURRENCY = {
+    batchContractDelete: 1,
+    batchBlockDelete: 1,
+};
+
 const workers = [];
 
 priorities['low'].forEach(jobName => {
@@ -30,7 +42,7 @@ priorities['low'].forEach(jobName => {
             }
         }, () => jobs[jobName](job)),
         {
-            concurrency: 10,
+            concurrency: PER_JOB_CONCURRENCY[jobName] ?? DEFAULT_CONCURRENCY,
             maxStalledCount: 5,
             lockDuration: 300000,
             connection,
@@ -42,7 +54,7 @@ priorities['low'].forEach(jobName => {
     worker.on('failed', (job, error) => managedWorkerError(error, jobName, job.data, 'lowPriority'));
     workers.push(worker);
 
-    logger.info(`Started worker "${jobName}" - Priority: low`);
+    logger.info(`Started worker "${jobName}" - Priority: low - Concurrency: ${PER_JOB_CONCURRENCY[jobName] ?? DEFAULT_CONCURRENCY}`);
 });
 
 function shutdown(signal) {


### PR DESCRIPTION
## Summary
- Set `batchContractDelete` and `batchBlockDelete` to concurrency 1 on the lpworker; other jobs keep concurrency 10.
- Closes #1243.

## Why
On 2026-04-24 12:02 UTC a `workspaceReset` for workspace 17049 (~3000 contracts, ~400 blocks) triggered a postgres lock storm that drained the lpworker's per-machine Sequelize pool (max 20) on Fly machine `286ed96a673208`. The infraHealthCheck `SELECT 1` started timing out and paged a false `postgres-connectivity` alert (#1236) plus 3 unrelated Sentry timeouts (#1237/#1238/#1239) — but the DB cluster itself was healthy throughout.

Each `safeDestroyContracts` call wraps 50 contracts in a single transaction with deferred FK constraints, doing ~7 sequential queries per contract (sources, verifications, tokens, V2DexPair lookups, etc.). With 10 of these running in parallel, FK cascades collide on shared rows in `transaction_logs`, `token_transfers`, `v2_dex_pool_reserves`, and the transactions deadlock waiting on each other's row locks. The same pattern applies to `batchBlockDelete`.

Serializing the two delete jobs eliminates the contention without changing job semantics. Other low-priority jobs (`integrityCheck`, `processUser`, `rpcHealthCheck`, etc.) keep concurrency 10.

## Operational follow-up after merge & deploy
The two queues are currently **paused in production** to stop the storm rebuilding. After this ships:

1. SSH into a backend machine: `flyctl ssh console -a ethernal --machine 2861625c725de8`
2. Resume both queues:
   ```js
   const { Queue } = require('bullmq');
   const c = require('./lib/redis');
   await Promise.all([
     new Queue('batchContractDelete', { connection: c }).resume(),
     new Queue('batchBlockDelete', { connection: c }).resume(),
   ]);
   ```
3. Watch workspace 17049 drain (~6 contract batches + 45 block batches, now serialized so should take a while but not lock)

## Test plan
- [ ] `node --check run/workers/lowPriority.js` (already verified locally)
- [ ] Deploy to prod, resume queues per above, confirm workspace 17049 drains without re-paging postgres-connectivity
- [ ] Confirm other lpworker jobs (integrityCheck, etc.) still run at full concurrency

🤖 Generated with [Claude Code](https://claude.com/claude-code)