### PR TITLE
fix(tweet-pipeline): stop re-promoting old blog posts and uploading HTML as cover image

### DIFF
--- a/tweet-pipeline/draft.sh
+++ b/tweet-pipeline/draft.sh
@@ -245,7 +245,7 @@ log "Phase 2: Draft..."
 
 PHASE2_OUTPUT=$(claude -p "$(cat "$PROMPTS_DIR/tweet-2-draft.md")" \
   --dangerously-skip-permissions \
-  --max-turns 10 \
+  --max-turns 20 \
   2>&1)
 
 echo "$PHASE2_OUTPUT" | tee -a "$LOG_FILE"

--- a/tweet-pipeline/lib/cli/is-promoted.js
+++ b/tweet-pipeline/lib/cli/is-promoted.js
@@ -1,3 +1,24 @@
 #!/usr/bin/env node
-import { getDb } from '../db.js';
-process.exit(getDb().isPromoted(process.argv[2]) ? 0 : 1);
+/**
+ * Exits 0 (skip) if slug is already promoted OR if the dedup check itself fails.
+ *
+ * Fail-closed: a transient DB error (missing native binding, corrupt schema,
+ * SQLITE_BUSY, etc) must not cause a re-promotion. Better to miss a legitimate
+ * new article (recoverable on the next 10-minute cycle, once the underlying
+ * problem is fixed) than to spam X with stale posts. See issue #1254 + the
+ * 5-old-articles-re-promoted-in-one-day incident on 2026-04-26.
+ *
+ * Uses dynamic import so a failure resolving better-sqlite3 (which throws at
+ * link time) is caught here instead of escaping as an unhandled exit-1.
+ */
+const slug = process.argv[2];
+
+(async () => {
+    try {
+        const { getDb } = await import('../db.js');
+        process.exit(getDb().isPromoted(slug) ? 0 : 1);
+    } catch (err) {
+        process.stderr.write(`is-promoted: dedup check failed (${err.message}); treating "${slug}" as promoted\n`);
+        process.exit(0);
+    }
+})();

--- a/tweet-pipeline/promote-blog.sh
+++ b/tweet-pipeline/promote-blog.sh
@@ -53,8 +53,10 @@ while IFS= read -r FILENAME; do
   # Extract slug
   SLUG="${FILENAME%.md}"
 
-  # Skip if already promoted
-  if node lib/cli/is-promoted.js "$SLUG" 2>/dev/null; then
+  # Skip if already promoted. is-promoted.js fails-closed: any DB error returns
+  # exit 0 (skip) rather than re-promoting an old article. Forward stderr to our
+  # log so transient failures are visible instead of silenced into a re-tweet.
+  if node lib/cli/is-promoted.js "$SLUG" 2>>"$LOG_FILE"; then
     continue
   fi
 
@@ -102,11 +104,15 @@ full article →"
   TWEET_TEXT="${HOOK}
 ${BLOG_URL}"
 
-  # Download cover image from live site
+  # Download cover image from live site. Astro's SPA fallback returns 200 +
+  # text/html for missing assets, so curl -sf alone isn't enough — we must check
+  # the response Content-Type is actually an image, otherwise X rejects the
+  # upload as "media type unrecognized" (see issue #1254).
   COVER_IMAGE=""
   TMPIMG=$(mktemp /tmp/promo-cover-XXXXXX)
   for EXT in webp png jpg; do
-    if curl -sf "https://tryethernal.com/blog/images/${SLUG}.${EXT}" -o "$TMPIMG"; then
+    CTYPE=$(curl -sf -w '%{content_type}' "https://tryethernal.com/blog/images/${SLUG}.${EXT}" -o "$TMPIMG" 2>/dev/null) || continue
+    if [[ "$CTYPE" == image/* ]]; then
       COVER_IMAGE="$TMPIMG"
       break
     fi


### PR DESCRIPTION
## Summary
- **Fail-closed dedup** (`is-promoted.js`): a transient DB error during the promote loop used to escape as exit 1, which the caller read as "not promoted" and re-tweeted. On 2026-04-26 this re-promoted 5 stale articles to X in a single day. Now any error exits 0 (skip) with a stderr diagnostic. Uses dynamic import so a missing `better-sqlite3` is caught instead of escaping at link time.
- **Cover image content-type check** (`promote-blog.sh`, fixes #1254): Astro's SPA fallback returns 200 + `text/html` for missing assets, so `curl -sf` alone wasn't enough — the HTML body got uploaded to X and rejected as "media type unrecognized." Now we also check `%{content_type}` starts with `image/`.
- **Surface dedup failures** (`promote-blog.sh`): forward `is-promoted` stderr into the pipeline log instead of `/dev/null`. The incident was invisible precisely because we silenced the underlying error.
- **Phase 2 max-turns 10 → 20** (`draft.sh`, fixes #1253): the research-and-draft step occasionally needs more tool calls and was bouncing on the cap.

Closes #1253, closes #1254.

## Test plan
- [x] `bash -n` clean on `promote-blog.sh` and `draft.sh`
- [x] Manual: with `better-sqlite3` unresolvable, new `is-promoted.js` exits 0 with diagnostic; old version exited 1 (the bug). Reproduced both behaviours locally.
- [ ] After merge: deploy via `bash tweet-pipeline/deploy.sh`, watch next 2-3 publish cycles in `journalctl -u tweet-publish.service` to confirm no stale promotions and that new article promotions still record properly in `state.db`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)