### PR TITLE
fix(test): drop requireActual on queueCaps in queue.test.js

### DIFF
--- a/run/tests/lib/queue.test.js
+++ b/run/tests/lib/queue.test.js
@@ -13,7 +13,11 @@ jest.mock('../../lib/queueCaps', () => ({
     isLowTierWorkspace: jest.fn(),
     countWaitingForWorkspace: jest.fn(),
     shouldLogDrop: jest.fn(),
-    parseWorkspaceFromJobName: jest.requireActual('../../lib/queueCaps').parseWorkspaceFromJobName,
+    // parseWorkspaceFromJobName is exported by queueCaps but not used by queue.js,
+    // so we don't need it here. Avoid jest.requireActual on queueCaps because that
+    // triggers a real models/index.js init which fails under NODE_ENV=test in CI
+    // (no 'test' key in run/config/database.js).
+    parseWorkspaceFromJobName: jest.fn(),
 }));
 
 jest.mock('../../lib/logger', () => ({


### PR DESCRIPTION
## Summary

Test_back failed in CI run [25053174974](https://github.com/tryethernal/ethernal/actions/runs/25053174974), blocking v5.17.188 deploy. Root cause: `tests/lib/queue.test.js` mock pulled `parseWorkspaceFromJobName` via `jest.requireActual('../../lib/queueCaps')`, which transitively loads `models/index.js` at module-init. Under `NODE_ENV=test` (CI default), `run/config/database.js` has no `test` key, so the model loader throws.

`queue.js` doesn't call `parseWorkspaceFromJobName` — the mock can be a plain `jest.fn()`.

The local Docker run masked this because the dev container defaults to `NODE_ENV=development`, which has a config entry.

## Test plan
- [x] Reproduced locally with `docker compose ... exec -e NODE_ENV=test backend npx jest tests/lib/queue.test.js` — fails on master, passes after fix.
- [x] Full suite under NODE_ENV=test: 1433/1433 passing.
- [ ] Post-merge: confirm next auto-deploy run goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)