### PR TITLE
fix(queueCaps): lazy-require models to break circular import

### DIFF
--- a/run/lib/queueCaps.js
+++ b/run/lib/queueCaps.js
@@ -40,7 +40,6 @@ const parseWorkspaceFromJobName = (queueName, jobName) => {
 };
 
 const logger = require('./logger');
-const { Workspace } = require('../models');
 
 /**
  * Evaluates the tier of a workspace by reading from the database.
@@ -50,6 +49,10 @@ const { Workspace } = require('../models');
  * @returns {Promise<'low'|'normal'>}
  */
 const evaluateTier = async (workspaceId) => {
+    // Lazy-require models to avoid a load-time cycle: queueCaps is reached via
+    // models/block.js → lib/queue → lib/queueCaps, and a top-level require here
+    // would resolve to the partially-initialized models object.
+    const { Workspace } = require('../models');
     try {
         const ws = await Workspace.findByPk(workspaceId, {
             attributes: ['id'],

--- a/run/tests/lib/queueCaps.cycle.test.js
+++ b/run/tests/lib/queueCaps.cycle.test.js
@@ -1,0 +1,66 @@
+/**
+ * Regression test for the lib/queue ↔ models circular dependency.
+ *
+ * Production load chain that broke before the fix:
+ *   jobs/blockSync.js → lib/rpc → lib/queue → lib/queueCaps → models/index → models/block
+ *   block.js destructures `{ enqueue, bulkEnqueue }` from lib/queue while queue.js
+ *   is still mid-load, so it captured `undefined` and the afterCreate hook crashed
+ *   with `TypeError: enqueue is not a function`.
+ *
+ * The fix moves `require('../models')` from queueCaps top-level into evaluateTier,
+ * so models is no longer pulled in during the queue.js → queueCaps.js init phase.
+ */
+
+jest.mock('../../lib/env', () => ({
+    queueCapBlockSync: () => 200,
+    queueCapReceiptSync: () => 5000,
+    queueCapTierCacheTtlSeconds: () => 60,
+}));
+
+jest.mock('../../lib/logger', () => ({ warn: jest.fn(), info: jest.fn(), error: jest.fn() }));
+
+jest.mock('../../lib/redis', () => ({ get: jest.fn(), set: jest.fn() }));
+
+describe('lib/queue ↔ models circular import', () => {
+    it('does not pull models into queueCaps during initial load', () => {
+        jest.isolateModules(() => {
+            jest.doMock('../../queues', () => ({}));
+            jest.doMock('@sentry/node', () => ({
+                startSpan: jest.fn((_, cb) => cb()),
+                addBreadcrumb: jest.fn(),
+            }));
+
+            // Sentinel that fails the test if models/index runs eagerly while
+            // queueCaps initializes (which is what the old top-level require did).
+            const modelsLoad = jest.fn(() => {
+                throw new Error('models/index loaded eagerly during queueCaps init');
+            });
+            jest.doMock('../../models', modelsLoad);
+
+            // Loads the full queue ↔ queueCaps graph. Must NOT touch models.
+            require('../../lib/queueCaps');
+            require('../../lib/queue');
+
+            expect(modelsLoad).not.toHaveBeenCalled();
+        });
+    });
+
+    it('exposes enqueue as a function after the full module graph loads', () => {
+        jest.isolateModules(() => {
+            jest.doMock('../../queues', () => ({
+                blockSync: { add: jest.fn(), addBulk: jest.fn() },
+            }));
+            jest.doMock('@sentry/node', () => ({
+                startSpan: jest.fn((_, cb) => cb()),
+                addBreadcrumb: jest.fn(),
+            }));
+            jest.doMock('../../models', () => ({
+                Workspace: { findByPk: jest.fn() },
+            }));
+
+            const queue = require('../../lib/queue');
+            expect(typeof queue.enqueue).toBe('function');
+            expect(typeof queue.bulkEnqueue).toBe('function');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Hotfix for the production blockSync backlog (20K prioritized + 43K delayed and growing on prod, all `enqueue is not a function` failures).

PR #1268 introduced `lib/queue → lib/queueCaps` and queueCaps had a top-level `require('../models')`. Together with the existing `jobs/blockSync → lib/rpc → lib/queue` chain, that creates a load-time cycle:

```
jobs/blockSync.js
  → lib/rpc.js (line 13: require('./queue'))
    → lib/queue.js (line 10: require('./queueCaps'))
      → lib/queueCaps.js (line 43: require('../models'))
        → models/index.js (iterates files)
          → models/block.js (line 28: const { enqueue, bulkEnqueue } = require('../lib/queue'))
            ← queue.js is mid-load, module.exports still {}
            ← enqueue / bulkEnqueue captured as `undefined`
```

`Block.afterCreate` then crashes with `TypeError: enqueue is not a function` at `models/block.js:157`, the blockSync job fails after the row is committed, BullMQ retries it (up to 50× for cli-light), and the prioritized + delayed lists explode.

The fix moves the models require into `evaluateTier`, so models is only resolved once the full graph is loaded.

## Test plan

- [x] New regression test `run/tests/lib/queueCaps.cycle.test.js`:
  - Mocks `models` with a throwing factory and loads `lib/queue` + `lib/queueCaps`. Asserts the factory is never called (i.e. queueCaps does not pull in models at init time).
  - Verified the test correctly **fails** on the pre-fix code (throws at `queueCaps.js:43`) and passes on the fix.
- [x] All existing queue/queueCaps/queueMonitoring tests still pass (70 tests).
- [ ] After merge + auto-deploy, drain the blockSync prioritized + delayed backlog and verify counts return to ≤ 50 (per `memory/queue-health-targets.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)