### PR TITLE
Auto-close queue monitoring alerts and cap demo plans

### DIFF
--- a/run/jobs/queueMonitoring.js
+++ b/run/jobs/queueMonitoring.js
@@ -128,7 +128,7 @@ module.exports = async () => {
                 { alias: `queue-activity-${queueName}` }
             );
             incidentCreated = true;
-        } else {
+        } else if (latestJob) {
             await closeIncident(`queue-activity-${queueName}`, { note: 'Activity recovered: a recent job was enqueued.' });
         }
     }

--- a/run/jobs/queueMonitoring.js
+++ b/run/jobs/queueMonitoring.js
@@ -8,7 +8,7 @@
 const { Queue } = require('bullmq');
 const redis = require('../lib/redis');
 const logger = require('../lib/logger');
-const { createIncident } = require('../lib/opsgenie');
+const { createIncident, closeIncident } = require('../lib/opsgenie');
 const queueCaps = require('../lib/queueCaps');
 const { maxTimeWithoutEnqueuedJob, queueMonitoringMaxProcessingTime, queueMonitoringHighProcessingTimeThreshold, queueMonitoringHighWaitingJobCountThreshold, queueMonitoringMaxWaitingJobCount } = require('../lib/env');
 const priorities = require('../workers/priorities');
@@ -128,6 +128,8 @@ module.exports = async () => {
                 { alias: `queue-activity-${queueName}` }
             );
             incidentCreated = true;
+        } else {
+            await closeIncident(`queue-activity-${queueName}`, { note: 'Activity recovered: a recent job was enqueued.' });
         }
     }
 
@@ -165,20 +167,26 @@ module.exports = async () => {
                     { alias: `queue-performance-${queueName}` }
                 );
                 incidentCreated = true;
+            } else {
+                await closeIncident(`queue-performance-${queueName}`, {
+                    note: `Performance recovered. Waiting: ${waitingJobCount} - P95: ${p95ProcessingTime.toFixed(2)}s`
+                });
             }
 
-            if (failedJobCount > 0) {
-                const recentFailures = failedJobs.filter(j => j && j.finishedOn && j.finishedOn > Date.now() - 5 * 60 * 1000);
+            const recentFailures = failedJobs.filter(j => j && j.finishedOn && j.finishedOn > Date.now() - 5 * 60 * 1000);
 
-                if (recentFailures.length >= 10) {
-                    await createIncident(
-                        `${queueName} queue issue (failures)`,
-                        `${recentFailures.length} failed jobs in the last 5 minutes`,
-                        'P2',
-                        { alias: `queue-failures-${queueName}` }
-                    );
-                    incidentCreated = true;
-                }
+            if (recentFailures.length >= 10) {
+                await createIncident(
+                    `${queueName} queue issue (failures)`,
+                    `${recentFailures.length} failed jobs in the last 5 minutes`,
+                    'P2',
+                    { alias: `queue-failures-${queueName}` }
+                );
+                incidentCreated = true;
+            } else {
+                await closeIncident(`queue-failures-${queueName}`, {
+                    note: `Failures recovered. ${recentFailures.length} failed jobs in the last 5 minutes`
+                });
             }
         }
     }

--- a/run/lib/opsgenie.js
+++ b/run/lib/opsgenie.js
@@ -59,6 +59,42 @@ const createIncident = async (message, description, priority = 'P1', options = {
     }
 };
 
+/**
+ * Closes an OpsGenie alert by alias. Idempotent: closing an already-closed
+ * or non-existent alert is a no-op (OpsGenie returns 202 either way).
+ * Logs in dev mode instead of calling the API.
+ * @param {string} alias - Dedup alias of the alert to close
+ * @param {Object} [options]
+ * @param {string} [options.note] - Optional note to attach on close
+ * @returns {Promise<Object>|undefined} Axios response or undefined in dev/error mode
+ */
+const closeIncident = async (alias, options = {}) => {
+    if (getNodeEnv() === 'development' || !getOpsgenieApiKey()) {
+        logger.info('Development environment (no OpsGenie API key) - skipping OpsGenie close', { alias });
+        return;
+    }
+
+    try {
+        return await axios({
+            method: 'POST',
+            url: `https://api.opsgenie.com/v2/alerts/${encodeURIComponent(alias)}/close?identifierType=alias`,
+            headers: {
+                'Authorization': `GenieKey ${getOpsgenieApiKey()}`,
+            },
+            data: options.note ? { note: options.note, source: 'queueMonitoring' } : { source: 'queueMonitoring' }
+        });
+    } catch (error) {
+        logger.error('Failed to close OpsGenie incident', {
+            error: error.message,
+            status: error.response?.status,
+            statusText: error.response?.statusText,
+            alias
+        });
+        return undefined;
+    }
+};
+
 module.exports = {
-    createIncident
+    createIncident,
+    closeIncident
 };

--- a/run/lib/opsgenie.js
+++ b/run/lib/opsgenie.js
@@ -60,9 +60,11 @@ const createIncident = async (message, description, priority = 'P1', options = {
 };
 
 /**
- * Closes an OpsGenie alert by alias. Idempotent: closing an already-closed
- * or non-existent alert is a no-op (OpsGenie returns 202 either way).
- * Logs in dev mode instead of calling the API.
+ * Closes an OpsGenie alert by alias. Idempotent: OpsGenie's close-by-alias
+ * endpoint returns 202 ("Request will be processed") for open alerts,
+ * already-closed alerts, and non-existent aliases alike — verified empirically
+ * with curl. Safe to call every monitoring tick on healthy queues without
+ * generating error log noise. Logs in dev mode instead of calling the API.
  * @param {string} alias - Dedup alias of the alert to close
  * @param {Object} [options]
  * @param {string} [options.note] - Optional note to attach on close

--- a/run/lib/queueCaps.js
+++ b/run/lib/queueCaps.js
@@ -76,7 +76,8 @@ const evaluateTier = async (workspaceId) => {
         if (!ws.explorer.stripeSubscription) return 'low';
         const NON_PAYING_STATUSES = ['trial', 'canceled', 'past_due', 'unpaid', 'incomplete_expired'];
         if (NON_PAYING_STATUSES.includes(ws.explorer.stripeSubscription.status)) return 'low';
-        if (ws.explorer.stripeSubscription.stripePlan?.slug === 'free') return 'low';
+        const LOW_TIER_PLAN_SLUGS = ['free', 'demo'];
+        if (LOW_TIER_PLAN_SLUGS.includes(ws.explorer.stripeSubscription.stripePlan?.slug)) return 'low';
         return 'normal';
     } catch (error) {
         logger.warn('evaluateTier failed, treating as normal-tier', { workspaceId, error: error.message });

--- a/run/tests/jobs/queueMonitoring.test.js
+++ b/run/tests/jobs/queueMonitoring.test.js
@@ -113,6 +113,17 @@ describe('queueMonitoring', () => {
         );
     });
 
+    it('Should not close the activity alert when no completed jobs are retained (queue could still be stalled)', async () => {
+        mockGetCompleted.mockResolvedValue([]);
+
+        await queueMonitoring();
+
+        expect(closeIncident).not.toHaveBeenCalledWith(
+            'queue-activity-blockSync',
+            expect.anything()
+        );
+    });
+
     it('Should create a performance incident with dedup alias when p95 exceeds max', async () => {
         const now = Date.now();
         mockGetCompleted.mockResolvedValue([

--- a/run/tests/jobs/queueMonitoring.test.js
+++ b/run/tests/jobs/queueMonitoring.test.js
@@ -9,7 +9,7 @@ jest.mock('../../lib/queueCaps', () => ({
     trimOldest: jest.fn(),
 }));
 
-const { createIncident } = require('../../lib/opsgenie');
+const { createIncident, closeIncident } = require('../../lib/opsgenie');
 const logger = require('../../lib/logger');
 const redis = require('../../lib/redis');
 
@@ -50,6 +50,7 @@ const queueMonitoring = require('../../jobs/queueMonitoring');
 
 beforeEach(() => {
     createIncident.mockClear();
+    closeIncident.mockClear();
     logger.info.mockClear();
     logger.error.mockClear();
     redis.get.mockClear().mockResolvedValue(null);
@@ -97,6 +98,19 @@ describe('queueMonitoring', () => {
         await queueMonitoring();
 
         expect(createIncident).not.toHaveBeenCalled();
+    });
+
+    it('Should close the activity alert when a recent job is enqueued', async () => {
+        mockGetCompleted.mockResolvedValue([{
+            timestamp: Date.now() - 10 * 1000
+        }]);
+
+        await queueMonitoring();
+
+        expect(closeIncident).toHaveBeenCalledWith(
+            'queue-activity-blockSync',
+            expect.objectContaining({ note: expect.any(String) })
+        );
     });
 
     it('Should create a performance incident with dedup alias when p95 exceeds max', async () => {
@@ -172,6 +186,49 @@ describe('queueMonitoring', () => {
         await queueMonitoring();
 
         expect(createIncident).not.toHaveBeenCalled();
+    });
+
+    it('Should close performance and failure alerts when metrics are healthy', async () => {
+        const now = Date.now();
+        mockGetCompleted.mockResolvedValue([
+            { processedOn: now - 2000, finishedOn: now },
+        ]);
+        mockGetWaitingCount.mockResolvedValue(5);
+        mockGetDelayedCount.mockResolvedValue(0);
+        mockGetFailedCount.mockResolvedValue(0);
+
+        await queueMonitoring();
+
+        expect(closeIncident).toHaveBeenCalledWith(
+            'queue-performance-blockSync',
+            expect.objectContaining({ note: expect.stringContaining('Performance recovered') })
+        );
+        expect(closeIncident).toHaveBeenCalledWith(
+            'queue-performance-receiptSync',
+            expect.objectContaining({ note: expect.stringContaining('Performance recovered') })
+        );
+        expect(closeIncident).toHaveBeenCalledWith(
+            'queue-failures-blockSync',
+            expect.objectContaining({ note: expect.stringContaining('Failures recovered') })
+        );
+        expect(closeIncident).toHaveBeenCalledWith(
+            'queue-failures-receiptSync',
+            expect.objectContaining({ note: expect.stringContaining('Failures recovered') })
+        );
+    });
+
+    it('Should not close performance alert while threshold is still breached', async () => {
+        mockGetCompleted.mockResolvedValue([]);
+        mockGetWaitingCount.mockResolvedValue(150);
+        mockGetDelayedCount.mockResolvedValue(0);
+        mockGetFailedCount.mockResolvedValue(0);
+
+        await queueMonitoring();
+
+        expect(closeIncident).not.toHaveBeenCalledWith(
+            'queue-performance-blockSync',
+            expect.anything()
+        );
     });
 
     it('Should create a failure incident with P2 when 10+ jobs fail in 5 minutes', async () => {

--- a/run/tests/lib/queueCaps.test.js
+++ b/run/tests/lib/queueCaps.test.js
@@ -124,6 +124,13 @@ describe('evaluateTier', () => {
         expect(await evaluateTier(1)).toBe('low');
     });
 
+    it('returns "low" when plan slug is demo', async () => {
+        Workspace.findByPk.mockResolvedValue(stub({
+            explorer: { isDemo: false, stripeSubscription: { status: 'active', stripePlan: { slug: 'demo' } } }
+        }));
+        expect(await evaluateTier(1)).toBe('low');
+    });
+
     it('returns "low" when explorer.isDemo is true', async () => {
         Workspace.findByPk.mockResolvedValue(stub({
             explorer: {

--- a/run/tests/mocks/lib/opsgenie.js
+++ b/run/tests/mocks/lib/opsgenie.js
@@ -1,3 +1,4 @@
 jest.mock('../../../lib/opsgenie', () => ({
-    createIncident: jest.fn().mockResolvedValue('OK')
+    createIncident: jest.fn().mockResolvedValue('OK'),
+    closeIncident: jest.fn().mockResolvedValue('OK')
 }));


### PR DESCRIPTION
## Summary

- **Auto-close OpsGenie alerts** in \`queueMonitoring\`. The job only ever created alerts; nothing closed them, so transient bursts (queues that drained naturally) left stale \`open\` alerts forever and the dedup alias prevented re-firing. Each branch (activity / performance / failures) now closes its alert when its trigger condition is no longer met.
- **Treat \`demo\` plan slug as low-tier** in \`queueCaps.evaluateTier\`. Demo plans were uncapped, so a single demo workspace pointing cli-light at a high-throughput chain (BSC) could flood blockSync/receiptSync via direct-Redis enqueue, bypassing the in-process cap.

## Context

Alert #1534 (blockSync) fired today at 10:45 UTC for workspace 17075 (a Demo plan explorer on chainId 56) created 2 minutes earlier. Queue drained on its own but the alert stayed open. Then alert #1535 (receiptSync) fired 12 min later because P95 lookback over the last 20 completed jobs caught the recovered backlog (jobs that waited 65s before being processed, even though the queue was empty by then).

Same root pattern as the 2026-04-28 queue-flood incident: an uncapped low-value workspace floods the queue via cli-light.

## Test plan

- [x] \`tests/jobs/queueMonitoring.test.js\` passes (added 3 tests covering close on activity recovery, close on healthy metrics, no-close while breaching)
- [x] \`tests/lib/queueCaps.test.js\` passes (added test for \`demo\` slug → low tier)
- [x] \`tests/lib/queue.test.js\` and \`tests/lib/queueCaps.cycle.test.js\` still green
- [ ] After deploy: confirm alert #1534/#1535-style transient alerts auto-close on the next 60s monitoring tick
- [ ] After deploy: confirm ws 17075 (or any future demo plan workspace) is now trimmed by the periodic sweep when it exceeds \`QUEUE_CAP_RECEIPT_SYNC\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)