### PR TITLE
Remove typing indicator cursor from terminal display

### DIFF
--- a/landing/src/components/LandingOpenSource.vue
+++ b/landing/src/components/LandingOpenSource.vue
@@ -54,7 +54,7 @@
                             <div><span class="prompt">$ </span><span class="command">cd ethernal</span></div>
                             <div><span class="prompt">$ </span><span class="command">make start</span></div>
                             <div class="mt-3"><span class="comment"># That's it. Your explorer is running.</span></div>
-                            <div class="cursor-line mt-2">
+                            <div class="cursor-line">
                                 <span class="prompt">█</span>
                             </div>
                         </div>

--- a/landing/src/components/LandingOpenSource.vue
+++ b/landing/src/components/LandingOpenSource.vue
@@ -54,9 +54,6 @@
                             <div><span class="prompt">$ </span><span class="command">cd ethernal</span></div>
                             <div><span class="prompt">$ </span><span class="command">make start</span></div>
                             <div class="mt-3"><span class="comment"># That's it. Your explorer is running.</span></div>
-                            <div class="cursor-line">
-                                <span class="prompt">█</span>
-                            </div>
                         </div>
                     </div>
                 </v-col>
@@ -87,24 +84,5 @@
     font-size: 12px;
     font-weight: 500;
     font-family: 'JetBrains Mono', 'Fira Code', monospace;
-}
-
-.blinking-cursor {
-    animation: blink 1.2s step-end infinite;
-}
-
-@keyframes blink {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0; }
-}
-
-.cursor-line {
-    line-height: 1;
-}
-
-@media (prefers-reduced-motion: reduce) {
-    .blinking-cursor {
-        animation: none;
-    }
 }
 </style>


### PR DESCRIPTION
## Changes

- Removed the blinking cursor line element from the terminal output in LandingOpenSource component
- Removed associated CSS styles:
  - `.blinking-cursor` animation class
  - `@keyframes blink` animation definition
  - `.cursor-line` styling
  - `prefers-reduced-motion` media query for cursor animation

## Rationale

Simplifies the terminal display by removing the animated typing indicator cursor, providing a cleaner, more minimal UI presentation.

## Files Modified

- `landing/src/components/LandingOpenSource.vue`

---
🔗 **Live preview**: https://9ea60502.preview.useronda.com/ _(active for ~4h after PR creation)_