### PR TITLE
fix(tweet-pipeline): require Write tool and fix temp file paths in prompts

### DIFF
--- a/tweet-pipeline/prompts/tweet-1-research.md
+++ b/tweet-pipeline/prompts/tweet-1-research.md
@@ -4,7 +4,7 @@ You are a researcher finding tweetable facts for @tryethernal (Ethereum block ex
 
 ## Your Task
 
-Read `tweet-pipeline/.source.json` which contains:
+Read `.source.json` (in the current working directory) which contains:
 
 ```json
 {
@@ -32,7 +32,7 @@ Read `tweet-pipeline/.source.json` which contains:
 
 ## Output
 
-Save your research notes to `tweet-pipeline/.research.md` with this structure:
+You MUST use the Write tool to create `.research.md` in the current working directory before ending your turn. Do not summarize the research in chat instead of writing the file — the pipeline checks for the file on disk and will fail the run if it is missing. Use this structure:
 
 ```markdown
 ## Topic

--- a/tweet-pipeline/prompts/tweet-2-draft.md
+++ b/tweet-pipeline/prompts/tweet-2-draft.md
@@ -4,9 +4,9 @@ You are a tweet copywriter for @tryethernal (Ethereum block explorer). Write a v
 
 ## Input
 
-Read both files:
-- `tweet-pipeline/.research.md` (research notes from phase 1)
-- `tweet-pipeline/.source.json` (original source data)
+Read both files (in the current working directory):
+- `.research.md` (research notes from phase 1)
+- `.source.json` (original source data)
 
 ## Viral Tweet Style Rules
 
@@ -77,7 +77,7 @@ domain.com/path (short label)
 
 ## Output
 
-Save to `tweet-pipeline/.draft.json`:
+You MUST use the Write tool to create `.draft.json` in the current working directory before ending your turn. Do not print the JSON in chat instead of writing the file — the pipeline reads the file from disk and will fail the run if it is missing. Structure:
 
 ```json
 {

--- a/tweet-pipeline/prompts/tweet-3-humanize.md
+++ b/tweet-pipeline/prompts/tweet-3-humanize.md
@@ -4,7 +4,7 @@ You are a copy editor removing AI writing patterns from a tweet draft for @tryet
 
 ## Input
 
-Read `tweet-pipeline/.draft.json` (the draft from phase 2).
+Read `.draft.json` from the current working directory (the draft from phase 2).
 
 ## Em Dash Rule (ZERO TOLERANCE)
 
@@ -84,6 +84,6 @@ After all fixes:
 
 ## Output
 
-Overwrite `tweet-pipeline/.draft.json` with the fixed version. Same JSON structure.
+You MUST use the Write tool to overwrite `.draft.json` (in the current working directory) with the fixed version. Same JSON structure. Do not print the JSON in chat instead of writing the file — the pipeline reads the file from disk.
 
 Print `::humanized::` when done.

--- a/tweet-pipeline/prompts/tweet-4-audit.md
+++ b/tweet-pipeline/prompts/tweet-4-audit.md
@@ -4,9 +4,9 @@ You are a fact-checker verifying claims in a tweet draft for @tryethernal before
 
 ## Input
 
-Read both files:
-- `tweet-pipeline/.draft.json` (the humanized draft from phase 3)
-- `tweet-pipeline/.research.md` (research notes from phase 1)
+Read both files (in the current working directory):
+- `.draft.json` (the humanized draft from phase 3)
+- `.research.md` (research notes from phase 1)
 
 ## Your Task
 
@@ -64,7 +64,7 @@ After grading all claims, apply fixes:
 
 ## Output
 
-Save to `tweet-pipeline/.audit.json`:
+You MUST use the Write tool to create `.audit.json` in the current working directory before ending your turn. Do not print the JSON in chat instead of writing the file — the pipeline reads the file from disk. Structure:
 
 ```json
 {


### PR DESCRIPTION
## Summary
- Phase 1 (and occasionally Phase 2) of the tweet draft pipeline was aborting when Claude responded with a chat summary instead of using the Write tool, so the `.research.md` / `.draft.json` existence check in `draft.sh` failed (issue #1282, also #1253, #1258).
- Each of the four phase prompts now explicitly requires the Write tool and warns that summarizing in chat will fail the run.
- Dropped the bogus `tweet-pipeline/` path prefix from input/output references in the prompts. `draft.sh` already `cd`s into `tweet-pipeline/`, so the prefix was resolving to `tweet-pipeline/tweet-pipeline/...` and only worked when the model silently corrected it.

## Test plan
- [ ] Deploy prompts to `/opt/tweet-pipeline/prompts/` on the Hetzner pipeline server (`rsync` per `tweet-pipeline/deploy.sh` flow)
- [ ] Watch the next `tweet-draft.timer` run in `/var/log/tweet-pipeline/` for clean Phase 1 + Phase 2 file writes
- [ ] Confirm a generated tweet still ends up in `/home/blog/tweet-queue/`
- [ ] No regression on the audit (Phase 4) — `.audit.json` still produced

Closes #1282

🧙 Built with [WOZCODE](https://wozcode.com)