### PR TITLE
Wire signup attribution, UTM tag every outbound link, and improve blog/chain CTAs

### DIFF
--- a/blog/src/components/Footer.astro
+++ b/blog/src/components/Footer.astro
@@ -27,7 +27,7 @@ const appUrl = import.meta.env.PUBLIC_APP_URL || 'https://app.tryethernal.com';
           <a href="/pricing" class="footer-link">Pricing</a>
           <a href="/transaction-tracing" class="footer-link">Transaction Tracing</a>
           <a href="https://doc.tryethernal.com" target="_blank" rel="noopener noreferrer" class="footer-link">Docs</a>
-          <a href={`${appUrl}/auth`} class="footer-link">Sign In</a>
+          <a href={`${appUrl}/auth?utm_source=blog&utm_medium=footer&utm_campaign=signin`} class="footer-link">Sign In</a>
         </div>
       </div>
 

--- a/blog/src/layouts/PostLayout.astro
+++ b/blog/src/layouts/PostLayout.astro
@@ -39,6 +39,57 @@ const relatedPosts = allPosts
   .filter(p => p.id !== post.id && p.data.tags.some(t => tags.includes(t)))
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
   .slice(0, 3);
+
+// Topic-aware CTA: pick destination + headline based on article tags.
+// Order matters — first match wins so more specific tags should come first.
+const appUrl = import.meta.env.PUBLIC_APP_URL || 'https://app.tryethernal.com';
+const tagSet = new Set(tags.map(t => t.toLowerCase()));
+function has(...keys) { return keys.some(k => tagSet.has(k.toLowerCase())); }
+
+let ctaVariant;
+if (has('Comparison') || /alternative|vs |best/i.test(title)) {
+  ctaVariant = {
+    headline: 'See how Ethernal compares',
+    body: 'Side-by-side with Etherscan, Blockscout, and Routescan — what they miss, what we add.',
+    primary: { label: 'Compare plans', href: 'https://tryethernal.com/pricing?utm_source=blog&utm_medium=cta&utm_campaign=' + post.id },
+    secondary: { label: 'Etherscan alternative', href: 'https://tryethernal.com/etherscan-alternative?utm_source=blog&utm_medium=cta&utm_campaign=' + post.id }
+  };
+} else if (has('Security', 'Auditing', 'MEV', 'DeFi')) {
+  ctaVariant = {
+    headline: 'Trace any transaction in your explorer',
+    body: 'Decoded calls, state diffs, internal transfers. Free for any EVM chain — connect your RPC and go.',
+    primary: { label: 'Get a free explorer', href: `${appUrl}/auth?flow=public&utm_source=blog&utm_medium=cta&utm_campaign=${post.id}` },
+    secondary: { label: 'See tracing in action', href: 'https://tryethernal.com/blog/transaction-tracing-with-ethernal?utm_source=blog&utm_medium=cta&utm_campaign=' + post.id }
+  };
+} else if (has('L2', 'Infrastructure', 'Blobs')) {
+  ctaVariant = {
+    headline: 'Run a block explorer for your L2',
+    body: 'Custom branding, custom domain, full historical sync. Used by appchains and rollups in production.',
+    primary: { label: 'Get started free', href: `${appUrl}/auth?flow=public&utm_source=blog&utm_medium=cta&utm_campaign=${post.id}` },
+    secondary: { label: 'View pricing', href: 'https://tryethernal.com/pricing?utm_source=blog&utm_medium=cta&utm_campaign=' + post.id }
+  };
+} else if (has('Ethernal', 'Developer Tools')) {
+  ctaVariant = {
+    headline: 'Try Ethernal on your chain',
+    body: 'Connect any EVM RPC and get a fully working explorer in under 5 minutes. Free tier, no credit card.',
+    primary: { label: 'Get started free', href: `${appUrl}/auth?flow=public&utm_source=blog&utm_medium=cta&utm_campaign=${post.id}` },
+    secondary: { label: 'See features', href: 'https://tryethernal.com/features?utm_source=blog&utm_medium=cta&utm_campaign=' + post.id }
+  };
+} else if (has('EVM', 'Smart Contracts', 'Ethereum', 'Account Abstraction', 'ZK', 'NFT', 'Payments', 'AI Agents', 'State', 'Privacy')) {
+  ctaVariant = {
+    headline: 'Need an explorer that understands modern EVM?',
+    body: 'Decoded transactions, verified contracts, token transfers, traces — for any EVM chain you point it at.',
+    primary: { label: 'Try it free', href: `${appUrl}/auth?flow=public&utm_source=blog&utm_medium=cta&utm_campaign=${post.id}` },
+    secondary: { label: 'Browse a live explorer', href: 'https://tryethernal.com/blog/public-explorers?utm_source=blog&utm_medium=cta&utm_campaign=' + post.id }
+  };
+} else {
+  ctaVariant = {
+    headline: 'Need a block explorer for your chain?',
+    body: 'Connect your RPC and get a fully working explorer in under 5 minutes.',
+    primary: { label: 'Get started free', href: `${appUrl}/auth?flow=public&utm_source=blog&utm_medium=cta&utm_campaign=${post.id}` },
+    secondary: null
+  };
+}
 ---
 
 <BaseLayout title={title} description={description} image={image} ogImage={ogImage} plainBg ogType="article">
@@ -128,9 +179,31 @@ const relatedPosts = allPosts
     </header>
 
     <!-- Article body -->
-    <div class="prose prose-lg max-w-none mb-16" id="article-body">
+    <div class="prose prose-lg max-w-none mb-12" id="article-body">
       <slot />
     </div>
+
+    <!-- End-of-article CTA (always rendered, topic-aware) -->
+    <section class="not-prose mb-16">
+      <div class="rounded-2xl border border-primary/20 bg-gradient-to-br from-primary/10 via-primary/5 to-transparent p-8 sm:p-10">
+        <h2 class="font-heading text-2xl sm:text-3xl font-semibold text-text-primary mb-3">{ctaVariant.headline}</h2>
+        <p class="text-text-secondary text-base mb-6 max-w-2xl">{ctaVariant.body}</p>
+        <div class="flex flex-col sm:flex-row gap-3">
+          <a href={ctaVariant.primary.href.replace('utm_medium=cta', 'utm_medium=end_article_cta')}
+             class="end-cta-primary inline-flex items-center gap-2 px-6 py-3 rounded-full font-semibold text-sm tracking-wide transition-all duration-200 hover:opacity-90 hover:shadow-lg hover:shadow-primary/30"
+             style="background: linear-gradient(90deg, #2670A5, #3D95CE); color: #ffffff;">
+            {ctaVariant.primary.label}
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+          </a>
+          {ctaVariant.secondary && (
+            <a href={ctaVariant.secondary.href.replace('utm_medium=cta', 'utm_medium=end_article_cta')}
+               class="end-cta-secondary inline-flex items-center gap-2 px-6 py-3 rounded-full font-semibold text-sm tracking-wide transition-all duration-200 border border-border-subtle text-text-primary hover:border-primary/40 hover:bg-primary/5">
+              {ctaVariant.secondary.label}
+            </a>
+          )}
+        </div>
+      </div>
+    </section>
   </article>
 
   <!-- Related posts -->
@@ -195,13 +268,13 @@ const relatedPosts = allPosts
     </div>
   </section>
 
-  <!-- Mid-article CTA (injected via JS after ~40% of content) -->
+  <!-- Mid-article CTA (injected via JS after ~40% of content) — topic-aware -->
   <template id="mid-article-cta">
     <div class="not-prose my-10 rounded-xl border border-primary/20 bg-primary/5 p-6 sm:p-8 text-center">
-      <p class="font-heading text-lg sm:text-xl font-semibold text-text-primary mb-2">Need a block explorer for your chain?</p>
-      <p class="text-text-secondary text-sm mb-4">Connect your RPC and get a fully working explorer in under 5 minutes.</p>
-      <a href={`${import.meta.env.PUBLIC_APP_URL || 'https://app.tryethernal.com'}/auth?flow=public`} class="mid-cta-link inline-flex items-center gap-2 px-6 py-2.5 rounded-full font-semibold text-sm tracking-wide transition-all duration-200 hover:opacity-90 hover:shadow-lg hover:shadow-primary/30" style="background: linear-gradient(90deg, #2670A5, #3D95CE); color: #ffffff;">
-        Get Started Free
+      <p class="font-heading text-lg sm:text-xl font-semibold text-text-primary mb-2">{ctaVariant.headline}</p>
+      <p class="text-text-secondary text-sm mb-4">{ctaVariant.body}</p>
+      <a href={ctaVariant.primary.href.replace('utm_medium=cta', 'utm_medium=mid_article_cta')} class="mid-cta-link inline-flex items-center gap-2 px-6 py-2.5 rounded-full font-semibold text-sm tracking-wide transition-all duration-200 hover:opacity-90 hover:shadow-lg hover:shadow-primary/30" style="background: linear-gradient(90deg, #2670A5, #3D95CE); color: #ffffff;">
+        {ctaVariant.primary.label}
         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
       </a>
     </div>
@@ -211,13 +284,13 @@ const relatedPosts = allPosts
       var articlePath = window.location.pathname;
       var articleTitle = document.querySelector('h1')?.textContent || '';
 
-      // Inject mid-article CTA after ~40% of content
+      // Inject mid-article CTA after ~40% of content (lowered threshold so short posts get one too)
       var articleBody = document.getElementById('article-body');
       var ctaTemplate = document.getElementById('mid-article-cta');
       if (articleBody && ctaTemplate) {
         var headings = articleBody.querySelectorAll('h2, h3');
-        if (headings.length >= 3) {
-          var targetIndex = Math.floor(headings.length * 0.4);
+        if (headings.length >= 2) {
+          var targetIndex = Math.max(1, Math.floor(headings.length * 0.4));
           headings[targetIndex].parentNode.insertBefore(ctaTemplate.content.cloneNode(true), headings[targetIndex]);
         }
       }
@@ -228,6 +301,24 @@ const relatedPosts = allPosts
         midCta.addEventListener('click', function() {
           if (window.posthog) window.posthog.capture('blog:cta_click', {
             cta_type: 'get_started', cta_position: 'mid_article', article_path: articlePath, article_title: articleTitle
+          });
+        });
+      }
+
+      // End-of-article CTA tracking
+      var endPrimary = document.querySelector('.end-cta-primary');
+      if (endPrimary) {
+        endPrimary.addEventListener('click', function() {
+          if (window.posthog) window.posthog.capture('blog:cta_click', {
+            cta_type: 'primary', cta_position: 'end_article', article_path: articlePath, article_title: articleTitle
+          });
+        });
+      }
+      var endSecondary = document.querySelector('.end-cta-secondary');
+      if (endSecondary) {
+        endSecondary.addEventListener('click', function() {
+          if (window.posthog) window.posthog.capture('blog:cta_click', {
+            cta_type: 'secondary', cta_position: 'end_article', article_path: articlePath, article_title: articleTitle
           });
         });
       }

--- a/landing/public/llms.txt
+++ b/landing/public/llms.txt
@@ -1,6 +1,15 @@
 # Ethernal
 
-> Ethernal is an open-source block explorer for EVM-based chains. It supports public and private explorers, transaction tracing, contract verification, token and NFT tracking, and L2 rollup features for OP Stack and Arbitrum Orbit chains.
+> Ethernal is an open-source, MIT-licensed block explorer for EVM-based chains. Connect any EVM RPC and get a fully working hosted explorer in under 5 minutes — with transaction decoding and tracing, contract verification, token and NFT tracking, and L2-native features for OP Stack and Arbitrum Orbit. Used by L2s, appchains, and private networks in production.
+
+## Quick facts
+
+- Open source, MIT licensed: https://github.com/tryethernal/ethernal
+- Public pricing: Starter (free, ad-supported), Team ($150/mo, custom domain), App Chain ($500/mo, full whitelabel), Enterprise (custom)
+- Setup time: under 5 minutes — paste an RPC URL, get an explorer
+- Works with any EVM chain: Ethereum, all major L2s, OP Stack, Arbitrum Orbit, Polygon CDK, custom appchains, private networks, local devchains (Hardhat, Anvil, Ganache)
+- Self-hostable or hosted by Ethernal
+- Common alternatives: Etherscan (closed source, per-chain), Blockscout (open source, self-host only), Routescan (closed source, vendor-locked)
 
 ## Product
 
@@ -50,10 +59,10 @@
 
 ## Comparisons
 
-- [Blockscout Alternative](https://tryethernal.com/blockscout-alternative): Side-by-side comparison of Ethernal vs Blockscout — setup, runtime, L2 support, pricing
-- [Routescan Alternative](https://tryethernal.com/routescan-alternative): Side-by-side comparison of Ethernal vs Routescan — open source vs closed source, self-hosting, vendor lock-in, pricing
-- [Etherscan Alternative](https://tryethernal.com/etherscan-alternative): Ethernal as an open-source Etherscan alternative for custom EVM chains — self-hostable, MIT licensed, published pricing vs Etherscan's closed-source EaaS
-- [Build vs Buy Block Explorer](https://tryethernal.com/build-vs-buy-block-explorer): Should you build a custom block explorer or use Ethernal? Compare cost ($150K+ vs $0), timeline (3-6 months vs 5 minutes), and capabilities. MIT licensed, fully customizable.
+- [Etherscan Alternative](https://tryethernal.com/etherscan-alternative): Ethernal as an open-source Etherscan / Arbiscan / BscScan / Basescan / Optimistic Etherscan alternative for custom EVM chains. Self-hostable, MIT licensed, published pricing vs Etherscan's closed-source Explorer-as-a-Service.
+- [Blockscout Alternative](https://tryethernal.com/blockscout-alternative): Ethernal vs Blockscout for L2s, appchains, and rollups. Hosted (no Postgres/Redis ops) vs self-host, faster setup, modern UI, transparent pricing.
+- [Routescan Alternative](https://tryethernal.com/routescan-alternative): Ethernal vs Routescan. Open source vs closed source, no vendor lock-in, custom domain on every paid plan.
+- [Build vs Buy Block Explorer](https://tryethernal.com/build-vs-buy-block-explorer): Should you build a custom block explorer or use Ethernal? Cost ($150K+ vs $0-$500/mo), timeline (3-6 months vs 5 minutes), maintenance, and feature parity.
 
 ## Free Tools
 

--- a/landing/src/components/LandingFooter.vue
+++ b/landing/src/components/LandingFooter.vue
@@ -19,7 +19,7 @@
                         <router-link to="/pricing" class="footer-link">Pricing</router-link>
                         <router-link to="/transaction-tracing" class="footer-link">Transaction Tracing</router-link>
                         <a href="https://doc.tryethernal.com" target="_blank" rel="noopener noreferrer" class="footer-link">Docs</a>
-                        <a :href="`${appUrl}/auth`" class="footer-link">Sign In</a>
+                        <a :href="`${appUrl}/auth?utm_source=landing&utm_medium=footer&utm_campaign=signin`" class="footer-link">Sign In</a>
                     </div>
                 </v-col>
 

--- a/landing/src/components/LandingNavbar.vue
+++ b/landing/src/components/LandingNavbar.vue
@@ -173,8 +173,8 @@
                         <path d="M208.31,75.68A59.78,59.78,0,0,0,202.93,28,8,8,0,0,0,196,24a59.75,59.75,0,0,0-48,24H124A59.75,59.75,0,0,0,76,24a8,8,0,0,0-6.93,4,59.78,59.78,0,0,0-5.38,47.68A58.14,58.14,0,0,0,56,104v8a56.06,56.06,0,0,0,48.44,55.47A39.8,39.8,0,0,0,96,192v8H72a24,24,0,0,1-24-24A40,40,0,0,0,8,136a8,8,0,0,0,0,16,24,24,0,0,1,24,24,40,40,0,0,0,40,40H96v16a8,8,0,0,0,16,0V192a24,24,0,0,1,48,0v40a8,8,0,0,0,16,0V192a39.8,39.8,0,0,0-8.44-24.53A56.06,56.06,0,0,0,216,112v-8A58.14,58.14,0,0,0,208.31,75.68ZM200,112a40,40,0,0,1-40,40H112a40,40,0,0,1-40-40v-8a41.74,41.74,0,0,1,6.9-22.48A8,8,0,0,0,80,73.83a43.81,43.81,0,0,1,.79-33.58,43.88,43.88,0,0,1,32.32,20.06A8,8,0,0,0,119.82,64h32.35a8,8,0,0,0,6.74-3.69,43.87,43.87,0,0,1,32.32-20.06A43.81,43.81,0,0,1,192,73.83a8.09,8.09,0,0,0,1,7.65A41.72,41.72,0,0,1,200,104Z"/>
                     </svg>
                 </a>
-                <a :href="`${appUrl}/auth`" class="navbar-signin">Sign In</a>
-                <a :href="`${appUrl}/auth?flow=public`" class="navbar-cta" @click="trackCta">Get Started</a>
+                <a :href="`${appUrl}/auth?utm_source=landing&utm_medium=navbar&utm_campaign=signin`" class="navbar-signin">Sign In</a>
+                <a :href="`${appUrl}/auth?flow=public&utm_source=landing&utm_medium=navbar&utm_campaign=get_started`" class="navbar-cta" @click="trackCta">Get Started</a>
             </div>
 
             <!-- Mobile hamburger -->
@@ -226,8 +226,8 @@
             <v-divider class="my-3" :style="{ borderColor: 'var(--drawer-divider)' }" />
 
             <div class="pa-2 d-flex flex-column ga-2">
-                <v-btn block variant="outlined" color="white" :href="`${appUrl}/auth`" rounded="lg" class="btn-signin">Sign In</v-btn>
-                <v-btn block class="btn-primary" :href="`${appUrl}/auth?flow=public`" rounded="lg">Get Started</v-btn>
+                <v-btn block variant="outlined" color="white" :href="`${appUrl}/auth?utm_source=landing&utm_medium=mobile_nav&utm_campaign=signin`" rounded="lg" class="btn-signin">Sign In</v-btn>
+                <v-btn block class="btn-primary" :href="`${appUrl}/auth?flow=public&utm_source=landing&utm_medium=mobile_nav&utm_campaign=get_started`" rounded="lg">Get Started</v-btn>
             </div>
         </v-list>
     </v-navigation-drawer>

--- a/landing/src/main.js
+++ b/landing/src/main.js
@@ -54,9 +54,12 @@ export const createApp = ViteSSG(
                     ui_host: 'https://us.posthog.com',
                     person_profiles: 'identified_only',
                     capture_pageview: false,
-                    capture_pageleave: true
+                    capture_pageleave: true,
+                    autocapture: true,
+                    ip: true
                 });
 
+                window.posthog = posthog;
                 app.config.globalProperties.$posthog = posthog;
 
                 router.afterEach((to) => {

--- a/landing/src/pages/chains/ArbitrumNovaPage.vue
+++ b/landing/src/pages/chains/ArbitrumNovaPage.vue
@@ -298,6 +298,13 @@
                             <span class="related-desc">Full rollup explorer with retryable ticket tracking and BOLD fraud proofs</span>
                         </div>
                     </router-link>
+                    <router-link to="/blockscout-alternative" class="related-link">
+                        <v-icon size="18" style="color: #5DAAE0;">mdi-compare-horizontal</v-icon>
+                        <div>
+                            <span class="related-title">Blockscout Alternative</span>
+                            <span class="related-desc">How Ethernal compares to Blockscout for L2 explorers</span>
+                        </div>
+                    </router-link>
                     <router-link to="/pricing" class="related-link">
                         <v-icon size="18" style="color: #5DAAE0;">mdi-tag-outline</v-icon>
                         <div>

--- a/landing/src/pages/chains/ArbitrumOnePage.vue
+++ b/landing/src/pages/chains/ArbitrumOnePage.vue
@@ -305,6 +305,13 @@
                             <span class="related-desc">Bridge monitoring and Nitro-native features for all Orbit chains</span>
                         </div>
                     </router-link>
+                    <router-link to="/blockscout-alternative" class="related-link">
+                        <v-icon size="18" style="color: #5DAAE0;">mdi-compare-horizontal</v-icon>
+                        <div>
+                            <span class="related-title">Blockscout Alternative</span>
+                            <span class="related-desc">How Ethernal compares to Blockscout for L2 explorers</span>
+                        </div>
+                    </router-link>
                     <router-link to="/pricing" class="related-link">
                         <v-icon size="18" style="color: #5DAAE0;">mdi-tag-outline</v-icon>
                         <div>

--- a/landing/src/pages/chains/ArbitrumSepoliaPage.vue
+++ b/landing/src/pages/chains/ArbitrumSepoliaPage.vue
@@ -237,6 +237,13 @@
                             <span class="related-desc">Explorer support for all Orbit and Nitro-based networks</span>
                         </div>
                     </router-link>
+                    <router-link to="/blockscout-alternative" class="related-link">
+                        <v-icon size="18" style="color: #5DAAE0;">mdi-compare-horizontal</v-icon>
+                        <div>
+                            <span class="related-title">Blockscout Alternative</span>
+                            <span class="related-desc">How Ethernal compares to Blockscout for testnet explorers</span>
+                        </div>
+                    </router-link>
                     <router-link to="/pricing" class="related-link">
                         <v-icon size="18" style="color: #5DAAE0;">mdi-tag-outline</v-icon>
                         <div>

--- a/landing/src/pages/chains/BasePage.vue
+++ b/landing/src/pages/chains/BasePage.vue
@@ -302,6 +302,13 @@
                             <span class="related-desc">Bridge monitoring, withdrawals, and fault proofs for all OP Stack chains</span>
                         </div>
                     </router-link>
+                    <router-link to="/blockscout-alternative" class="related-link">
+                        <v-icon size="18" style="color: #5DAAE0;">mdi-compare-horizontal</v-icon>
+                        <div>
+                            <span class="related-title">Blockscout Alternative</span>
+                            <span class="related-desc">How Ethernal compares to Blockscout for L2 explorers</span>
+                        </div>
+                    </router-link>
                     <router-link to="/pricing" class="related-link">
                         <v-icon size="18" style="color: #5DAAE0;">mdi-tag-outline</v-icon>
                         <div>

--- a/landing/src/pages/chains/BaseSepoliaPage.vue
+++ b/landing/src/pages/chains/BaseSepoliaPage.vue
@@ -238,6 +238,13 @@
                             <span class="related-desc">Explorer support for all OP Stack and Superchain networks</span>
                         </div>
                     </router-link>
+                    <router-link to="/blockscout-alternative" class="related-link">
+                        <v-icon size="18" style="color: #5DAAE0;">mdi-compare-horizontal</v-icon>
+                        <div>
+                            <span class="related-title">Blockscout Alternative</span>
+                            <span class="related-desc">How Ethernal compares to Blockscout for testnet explorers</span>
+                        </div>
+                    </router-link>
                     <router-link to="/pricing" class="related-link">
                         <v-icon size="18" style="color: #5DAAE0;">mdi-tag-outline</v-icon>
                         <div>

--- a/landing/src/pages/chains/BlastPage.vue
+++ b/landing/src/pages/chains/BlastPage.vue
@@ -294,6 +294,13 @@
                             <span class="related-desc">Block explorer for the original OP Stack chain by OP Labs</span>
                         </div>
                     </router-link>
+                    <router-link to="/blockscout-alternative" class="related-link">
+                        <v-icon size="18" style="color: #5DAAE0;">mdi-compare-horizontal</v-icon>
+                        <div>
+                            <span class="related-title">Blockscout Alternative</span>
+                            <span class="related-desc">How Ethernal compares to Blockscout for L2 explorers</span>
+                        </div>
+                    </router-link>
                     <router-link to="/pricing" class="related-link">
                         <v-icon size="18" style="color: #5DAAE0;">mdi-tag-outline</v-icon>
                         <div>

--- a/landing/src/pages/chains/BnbChainPage.vue
+++ b/landing/src/pages/chains/BnbChainPage.vue
@@ -310,6 +310,13 @@
                             <span class="related-desc">Block explorer for Ethereum mainnet with call traces and contract verification</span>
                         </div>
                     </router-link>
+                    <router-link to="/etherscan-alternative" class="related-link">
+                        <v-icon size="18" style="color: #5DAAE0;">mdi-compare-horizontal</v-icon>
+                        <div>
+                            <span class="related-title">BscScan Alternative</span>
+                            <span class="related-desc">How Ethernal compares to BscScan for custom BNB Chain forks</span>
+                        </div>
+                    </router-link>
                     <router-link to="/pricing" class="related-link">
                         <v-icon size="18" style="color: #5DAAE0;">mdi-tag-outline</v-icon>
                         <div>

--- a/landing/src/pages/chains/CyberPage.vue
+++ b/landing/src/pages/chains/CyberPage.vue
@@ -125,6 +125,13 @@
                 <div class="related-links">
                     <router-link to="/op-stack" class="related-link"><v-icon size="18" style="color: #5DAAE0;">mdi-layers-outline</v-icon><div><span class="related-title">OP Stack Explorer</span><span class="related-desc">Bridge monitoring, withdrawals, and fault proofs for all OP Stack chains</span></div></router-link>
                     <router-link to="/features" class="related-link"><v-icon size="18" style="color: #5DAAE0;">mdi-view-grid-outline</v-icon><div><span class="related-title">All Features</span><span class="related-desc">Transaction decoding, contract verification, token tracking, and more</span></div></router-link>
+                    <router-link to="/blockscout-alternative" class="related-link">
+                        <v-icon size="18" style="color: #5DAAE0;">mdi-compare-horizontal</v-icon>
+                        <div>
+                            <span class="related-title">Blockscout Alternative</span>
+                            <span class="related-desc">How Ethernal compares to Blockscout for L2 explorers</span>
+                        </div>
+                    </router-link>
                     <router-link to="/pricing" class="related-link"><v-icon size="18" style="color: #5DAAE0;">mdi-tag-outline</v-icon><div><span class="related-title">Pricing</span><span class="related-desc">Starter (free), Team ($150/mo), App Chain ($500/mo), Enterprise</span></div></router-link>
                 </div>
             </section>

--- a/landing/src/pages/chains/DegenChainPage.vue
+++ b/landing/src/pages/chains/DegenChainPage.vue
@@ -302,6 +302,13 @@
                             <span class="related-desc">Degen Chain's parent L2, built on the OP Stack by Coinbase</span>
                         </div>
                     </router-link>
+                    <router-link to="/blockscout-alternative" class="related-link">
+                        <v-icon size="18" style="color: #5DAAE0;">mdi-compare-horizontal</v-icon>
+                        <div>
+                            <span class="related-title">Blockscout Alternative</span>
+                            <span class="related-desc">How Ethernal compares to Blockscout for L3/appchain explorers</span>
+                        </div>
+                    </router-link>
                     <router-link to="/pricing" class="related-link">
                         <v-icon size="18" style="color: #5DAAE0;">mdi-tag-outline</v-icon>
                         <div>

--- a/landing/src/pages/chains/EthereumPage.vue
+++ b/landing/src/pages/chains/EthereumPage.vue
@@ -311,6 +311,13 @@
                             <span class="related-desc">Block explorer for Ethereum's primary testnet</span>
                         </div>
                     </router-link>
+                    <router-link to="/etherscan-alternative" class="related-link">
+                        <v-icon size="18" style="color: #5DAAE0;">mdi-compare-horizontal</v-icon>
+                        <div>
+                            <span class="related-title">Etherscan Alternative</span>
+                            <span class="related-desc">How Ethernal compares to Etherscan for custom EVM chains</span>
+                        </div>
+                    </router-link>
                     <router-link to="/pricing" class="related-link">
                         <v-icon size="18" style="color: #5DAAE0;">mdi-tag-outline</v-icon>
                         <div>

--- a/landing/src/pages/chains/HoleskyPage.vue
+++ b/landing/src/pages/chains/HoleskyPage.vue
@@ -262,6 +262,13 @@
                             <span class="related-desc">Auto-sync contracts and transactions from your local Hardhat node</span>
                         </div>
                     </router-link>
+                    <router-link to="/blockscout-alternative" class="related-link">
+                        <v-icon size="18" style="color: #5DAAE0;">mdi-compare-horizontal</v-icon>
+                        <div>
+                            <span class="related-title">Blockscout Alternative</span>
+                            <span class="related-desc">How Ethernal compares to Blockscout for testnet explorers</span>
+                        </div>
+                    </router-link>
                     <router-link to="/pricing" class="related-link">
                         <v-icon size="18" style="color: #5DAAE0;">mdi-tag-outline</v-icon>
                         <div>

--- a/landing/src/pages/chains/LiskPage.vue
+++ b/landing/src/pages/chains/LiskPage.vue
@@ -125,6 +125,13 @@
                 <div class="related-links">
                     <router-link to="/op-stack" class="related-link"><v-icon size="18" style="color: #5DAAE0;">mdi-layers-outline</v-icon><div><span class="related-title">OP Stack Explorer</span><span class="related-desc">Bridge monitoring, withdrawals, and fault proofs for all OP Stack chains</span></div></router-link>
                     <router-link to="/chains/base" class="related-link"><v-icon size="18" style="color: #5DAAE0;">mdi-link-variant</v-icon><div><span class="related-title">Base Explorer</span><span class="related-desc">Another OP Stack L2 in the Superchain, built by Coinbase</span></div></router-link>
+                    <router-link to="/blockscout-alternative" class="related-link">
+                        <v-icon size="18" style="color: #5DAAE0;">mdi-compare-horizontal</v-icon>
+                        <div>
+                            <span class="related-title">Blockscout Alternative</span>
+                            <span class="related-desc">How Ethernal compares to Blockscout for L2 explorers</span>
+                        </div>
+                    </router-link>
                     <router-link to="/pricing" class="related-link"><v-icon size="18" style="color: #5DAAE0;">mdi-tag-outline</v-icon><div><span class="related-title">Pricing</span><span class="related-desc">Starter (free), Team ($150/mo), App Chain ($500/mo), Enterprise</span></div></router-link>
                 </div>
             </section>

--- a/landing/src/pages/chains/MintPage.vue
+++ b/landing/src/pages/chains/MintPage.vue
@@ -125,6 +125,13 @@
                 <div class="related-links">
                     <router-link to="/op-stack" class="related-link"><v-icon size="18" style="color: #5DAAE0;">mdi-layers-outline</v-icon><div><span class="related-title">OP Stack Explorer</span><span class="related-desc">Bridge monitoring, withdrawals, and fault proofs for all OP Stack chains</span></div></router-link>
                     <router-link to="/features" class="related-link"><v-icon size="18" style="color: #5DAAE0;">mdi-view-grid-outline</v-icon><div><span class="related-title">All Features</span><span class="related-desc">Transaction decoding, contract verification, token tracking, and more</span></div></router-link>
+                    <router-link to="/blockscout-alternative" class="related-link">
+                        <v-icon size="18" style="color: #5DAAE0;">mdi-compare-horizontal</v-icon>
+                        <div>
+                            <span class="related-title">Blockscout Alternative</span>
+                            <span class="related-desc">How Ethernal compares to Blockscout for L2 explorers</span>
+                        </div>
+                    </router-link>
                     <router-link to="/pricing" class="related-link"><v-icon size="18" style="color: #5DAAE0;">mdi-tag-outline</v-icon><div><span class="related-title">Pricing</span><span class="related-desc">Starter (free), Team ($150/mo), App Chain ($500/mo), Enterprise</span></div></router-link>
                 </div>
             </section>

--- a/landing/src/pages/chains/ModePage.vue
+++ b/landing/src/pages/chains/ModePage.vue
@@ -319,6 +319,13 @@
                             <span class="related-desc">Block explorer for the original OP Stack chain by OP Labs</span>
                         </div>
                     </router-link>
+                    <router-link to="/blockscout-alternative" class="related-link">
+                        <v-icon size="18" style="color: #5DAAE0;">mdi-compare-horizontal</v-icon>
+                        <div>
+                            <span class="related-title">Blockscout Alternative</span>
+                            <span class="related-desc">How Ethernal compares to Blockscout for L2 explorers</span>
+                        </div>
+                    </router-link>
                     <router-link to="/pricing" class="related-link">
                         <v-icon size="18" style="color: #5DAAE0;">mdi-tag-outline</v-icon>
                         <div>

--- a/landing/src/pages/chains/OptimismPage.vue
+++ b/landing/src/pages/chains/OptimismPage.vue
@@ -309,6 +309,13 @@
                             <span class="related-desc">Block explorer for Coinbase's L2, built on the OP Stack</span>
                         </div>
                     </router-link>
+                    <router-link to="/blockscout-alternative" class="related-link">
+                        <v-icon size="18" style="color: #5DAAE0;">mdi-compare-horizontal</v-icon>
+                        <div>
+                            <span class="related-title">Blockscout Alternative</span>
+                            <span class="related-desc">How Ethernal compares to Blockscout for L2 explorers</span>
+                        </div>
+                    </router-link>
                     <router-link to="/pricing" class="related-link">
                         <v-icon size="18" style="color: #5DAAE0;">mdi-tag-outline</v-icon>
                         <div>

--- a/landing/src/pages/chains/PolygonPosPage.vue
+++ b/landing/src/pages/chains/PolygonPosPage.vue
@@ -319,6 +319,13 @@
                             <span class="related-desc">Block explorer for Ethereum mainnet with call traces and contract verification</span>
                         </div>
                     </router-link>
+                    <router-link to="/blockscout-alternative" class="related-link">
+                        <v-icon size="18" style="color: #5DAAE0;">mdi-compare-horizontal</v-icon>
+                        <div>
+                            <span class="related-title">Blockscout Alternative</span>
+                            <span class="related-desc">How Ethernal compares to Blockscout for Polygon and CDK chains</span>
+                        </div>
+                    </router-link>
                     <router-link to="/pricing" class="related-link">
                         <v-icon size="18" style="color: #5DAAE0;">mdi-tag-outline</v-icon>
                         <div>

--- a/landing/src/pages/chains/ProofOfPlayApexPage.vue
+++ b/landing/src/pages/chains/ProofOfPlayApexPage.vue
@@ -308,6 +308,13 @@
                             <span class="related-desc">Another gaming L3 on Arbitrum Orbit with gas-free gameplay</span>
                         </div>
                     </router-link>
+                    <router-link to="/blockscout-alternative" class="related-link">
+                        <v-icon size="18" style="color: #5DAAE0;">mdi-compare-horizontal</v-icon>
+                        <div>
+                            <span class="related-title">Blockscout Alternative</span>
+                            <span class="related-desc">How Ethernal compares to Blockscout for L3/gaming chains</span>
+                        </div>
+                    </router-link>
                     <router-link to="/pricing" class="related-link">
                         <v-icon size="18" style="color: #5DAAE0;">mdi-tag-outline</v-icon>
                         <div>

--- a/landing/src/pages/chains/RedstonePage.vue
+++ b/landing/src/pages/chains/RedstonePage.vue
@@ -279,6 +279,13 @@
                             <span class="related-desc">Another OP Stack L2, built by Coinbase</span>
                         </div>
                     </router-link>
+                    <router-link to="/blockscout-alternative" class="related-link">
+                        <v-icon size="18" style="color: #5DAAE0;">mdi-compare-horizontal</v-icon>
+                        <div>
+                            <span class="related-title">Blockscout Alternative</span>
+                            <span class="related-desc">How Ethernal compares to Blockscout for L2 explorers</span>
+                        </div>
+                    </router-link>
                     <router-link to="/pricing" class="related-link">
                         <v-icon size="18" style="color: #5DAAE0;">mdi-tag-outline</v-icon>
                         <div>

--- a/landing/src/pages/chains/SepoliaPage.vue
+++ b/landing/src/pages/chains/SepoliaPage.vue
@@ -253,6 +253,13 @@
                             <span class="related-desc">Foundry-native explorer for local Anvil development</span>
                         </div>
                     </router-link>
+                    <router-link to="/etherscan-alternative" class="related-link">
+                        <v-icon size="18" style="color: #5DAAE0;">mdi-compare-horizontal</v-icon>
+                        <div>
+                            <span class="related-title">Etherscan Alternative</span>
+                            <span class="related-desc">How Ethernal compares to Etherscan for custom EVM chains and testnets</span>
+                        </div>
+                    </router-link>
                     <router-link to="/pricing" class="related-link">
                         <v-icon size="18" style="color: #5DAAE0;">mdi-tag-outline</v-icon>
                         <div>

--- a/landing/src/pages/chains/XaiPage.vue
+++ b/landing/src/pages/chains/XaiPage.vue
@@ -308,6 +308,13 @@
                             <span class="related-desc">Xai's parent L2, the main Arbitrum optimistic rollup</span>
                         </div>
                     </router-link>
+                    <router-link to="/blockscout-alternative" class="related-link">
+                        <v-icon size="18" style="color: #5DAAE0;">mdi-compare-horizontal</v-icon>
+                        <div>
+                            <span class="related-title">Blockscout Alternative</span>
+                            <span class="related-desc">How Ethernal compares to Blockscout for L3/gaming chains</span>
+                        </div>
+                    </router-link>
                     <router-link to="/pricing" class="related-link">
                         <v-icon size="18" style="color: #5DAAE0;">mdi-tag-outline</v-icon>
                         <div>

--- a/landing/src/pages/chains/ZoraPage.vue
+++ b/landing/src/pages/chains/ZoraPage.vue
@@ -301,6 +301,13 @@
                             <span class="related-desc">Block explorer for Coinbase's L2, built on the OP Stack</span>
                         </div>
                     </router-link>
+                    <router-link to="/blockscout-alternative" class="related-link">
+                        <v-icon size="18" style="color: #5DAAE0;">mdi-compare-horizontal</v-icon>
+                        <div>
+                            <span class="related-title">Blockscout Alternative</span>
+                            <span class="related-desc">How Ethernal compares to Blockscout for L2 explorers</span>
+                        </div>
+                    </router-link>
                     <router-link to="/pricing" class="related-link">
                         <v-icon size="18" style="color: #5DAAE0;">mdi-tag-outline</v-icon>
                         <div>

--- a/landing/src/pages/tools/BlockDateConverterPage.vue
+++ b/landing/src/pages/tools/BlockDateConverterPage.vue
@@ -160,7 +160,7 @@
                     <!-- Inline CTA -->
                     <div v-if="blockToDateResult || dateToBlockResult" class="inline-cta mt-8">
                         <p>Browse blocks, transactions, and logs in your block explorer. Try Ethernal free.</p>
-                        <a :href="`${appUrl}/auth?flow=public`" class="btn-primary btn-sm">Get Started</a>
+                        <a :href="`${appUrl}/auth?flow=public&utm_source=tool&utm_medium=inline_cta&utm_campaign=block_date_converter`" class="btn-primary btn-sm" @click="trackCta">Get Started</a>
                     </div>
                 </v-col>
             </v-row>
@@ -194,6 +194,10 @@ import LandingCTA from '@/components/LandingCTA.vue';
 import ToolsSidebar from '@/components/ToolsSidebar.vue';
 
 const appUrl = __APP_URL__;
+
+function trackCta() {
+    window.posthog?.capture('landing:tool_cta_click', { tool: 'block_date_converter' });
+}
 
 const chains = [
     { slug: 'ethereum', name: 'Ethereum', logo: 'ethereum.svg', rpc: 'https://ethereum-rpc.publicnode.com', explorer: 'https://etherscan.io/block/' },

--- a/landing/src/pages/tools/CallDataDecoderPage.vue
+++ b/landing/src/pages/tools/CallDataDecoderPage.vue
@@ -179,7 +179,7 @@
                     <!-- Inline CTA -->
                     <div v-if="decodeResult || encodeResult" class="inline-cta mt-8">
                         <p>Decode transactions automatically in your block explorer. Try Ethernal free.</p>
-                        <a :href="`${appUrl}/auth?flow=public`" class="btn-primary btn-sm">Get Started</a>
+                        <a :href="`${appUrl}/auth?flow=public&utm_source=tool&utm_medium=inline_cta&utm_campaign=calldata_decoder`" class="btn-primary btn-sm" @click="trackCta">Get Started</a>
                     </div>
                 </v-col>
             </v-row>
@@ -217,6 +217,10 @@ import {
 } from '@/composables/useEvmTools.js';
 
 const appUrl = __APP_URL__;
+
+function trackCta() {
+    window.posthog?.capture('landing:tool_cta_click', { tool: 'calldata_decoder' });
+}
 
 // --- Decode state ---
 const activeTab = ref('decode');

--- a/landing/src/pages/tools/FourByteLookupPage.vue
+++ b/landing/src/pages/tools/FourByteLookupPage.vue
@@ -114,7 +114,7 @@
                     <!-- Inline CTA -->
                     <div v-if="lookupResults.length || searchResults.length || computedSelector" class="inline-cta mt-8">
                         <p>See decoded function calls in real-time. Try Ethernal's block explorer.</p>
-                        <a :href="`${appUrl}/auth?flow=public`" class="btn-primary btn-sm">Get Started</a>
+                        <a :href="`${appUrl}/auth?flow=public&utm_source=tool&utm_medium=inline_cta&utm_campaign=4byte_lookup`" class="btn-primary btn-sm" @click="trackCta">Get Started</a>
                     </div>
                 </v-col>
             </v-row>
@@ -149,6 +149,10 @@ import ToolsSidebar from '@/components/ToolsSidebar.vue';
 import { computeSelector, parseSignature, lookup4byte, search4byte } from '@/composables/useEvmTools.js';
 
 const appUrl = __APP_URL__;
+
+function trackCta() {
+    window.posthog?.capture('landing:tool_cta_click', { tool: '4byte_lookup' });
+}
 
 // --- Lookup tab state ---
 const activeTab = ref('lookup');

--- a/landing/src/pages/tools/UnitConverterPage.vue
+++ b/landing/src/pages/tools/UnitConverterPage.vue
@@ -53,7 +53,7 @@
                     <!-- Inline CTA -->
                     <div v-if="hasValue" class="inline-cta mt-8">
                         <p>View gas costs and token values in your block explorer. Try Ethernal free.</p>
-                        <a :href="`${appUrl}/auth?flow=public`" class="btn-primary btn-sm">Get Started</a>
+                        <a :href="`${appUrl}/auth?flow=public&utm_source=tool&utm_medium=inline_cta&utm_campaign=unit_converter`" class="btn-primary btn-sm" @click="trackCta">Get Started</a>
                     </div>
                 </v-col>
             </v-row>
@@ -88,6 +88,10 @@ import ToolsSidebar from '@/components/ToolsSidebar.vue';
 import { ETH_UNITS, convertEthUnits } from '@/composables/useEvmTools.js';
 
 const appUrl = __APP_URL__;
+
+function trackCta() {
+    window.posthog?.capture('landing:tool_cta_click', { tool: 'unit_converter' });
+}
 
 const units = reactive(ETH_UNITS.map(u => ({ ...u, displayValue: '' })));
 const conversionError = ref('');

--- a/run/emails/drip-base.html
+++ b/run/emails/drip-base.html
@@ -42,7 +42,7 @@
 <div class="wrapper">
   <div class="container">
     <div class="header">
-      <a href="https://{{appDomain}}" class="brand-row" style="text-decoration:none;">
+      <a href="https://{{appDomain}}?utm_source=drip&utm_medium=email&utm_campaign=brand_header" class="brand-row" style="text-decoration:none;">
         <span class="logo-mark">E</span><span class="brand">Ethernal</span>
       </a>
     </div>
@@ -50,7 +50,7 @@
       {{content}}
     </div>
     <div class="footer">
-      <a href="{{unsubscribeUrl}}">Unsubscribe</a> &middot; <a href="https://{{appDomain}}">Ethernal</a>
+      <a href="{{unsubscribeUrl}}">Unsubscribe</a> &middot; <a href="https://{{appDomain}}?utm_source=drip&utm_medium=email&utm_campaign=brand_footer">Ethernal</a>
     </div>
   </div>
 </div>

--- a/run/jobs/sendDemoExplorerLink.js
+++ b/run/jobs/sendDemoExplorerLink.js
@@ -17,7 +17,7 @@ module.exports = async (job) => {
 
     const mailjet = Mailjet.apiConnect(getMailjetPublicKey(), getMailjetPrivateKey());
 
-    const explorerLink = `https://${explorerSlug}.${getAppDomain()}`;
+    const explorerLink = `https://${explorerSlug}.${getAppDomain()}?utm_source=transactional&utm_medium=email&utm_campaign=demo_ready`;
 
     await mailjet.post('send', { version: 'v3.1' })
         .request({

--- a/run/jobs/sendDripEmail.js
+++ b/run/jobs/sendDripEmail.js
@@ -70,15 +70,16 @@ module.exports = async (job) => {
 
     const mailjet = Mailjet.apiConnect(getMailjetPublicKey(), getMailjetPrivateKey());
     const appDomain = getAppDomain();
-    const explorerLink = `https://${explorerSlug}.${appDomain}`;
+    const utm = `utm_source=drip&utm_medium=email&utm_campaign=demo_drip_step_${step}`;
+    const explorerLink = `https://${explorerSlug}.${appDomain}?${utm}`;
     const unsubscribeToken = generateUnsubscribeToken(email);
     const unsubscribeUrl = `https://${appDomain}/api/demo/unsubscribe?token=${unsubscribeToken}`;
 
     // Steps 3-6 link to migration flow; steps 1-2 link to the explorer
-    let migrateUrl = `https://app.${appDomain}`;
+    let migrateUrl = `https://app.${appDomain}?${utm}`;
     if (step >= 3 && schedule && schedule.explorerId) {
         const explorerToken = encode({ explorerId: schedule.explorerId });
-        migrateUrl = `https://app.${appDomain}/?explorerToken=${explorerToken}`;
+        migrateUrl = `https://app.${appDomain}/?explorerToken=${explorerToken}&${utm}`;
     }
 
     // Load enrichment for steps 3+ (personalized copy)

--- a/run/jobs/sendProspectEmail.js
+++ b/run/jobs/sendProspectEmail.js
@@ -49,8 +49,15 @@ module.exports = async (job) => {
     const appUrl = getAppUrl() || 'https://app.tryethernal.com';
     const unsubscribeUrl = `${appUrl}/api/prospects/unsubscribe?token=${unsubscribeToken}`;
 
-    const body = prospect.emailBody.replace('{{unsubscribeUrl}}', unsubscribeUrl);
     const isFollowUp = prospect.followUpCount > 0;
+    const utm = `utm_source=prospect&utm_medium=email&utm_campaign=${isFollowUp ? `followup_${prospect.followUpCount}` : 'cold'}`;
+
+    const body = prospect.emailBody
+        .replace('{{unsubscribeUrl}}', unsubscribeUrl)
+        .replace(/https?:\/\/(?:[a-z0-9-]+\.)*tryethernal\.com[^\s)\]>"']*/gi, (url) => {
+            if (url.includes('/api/prospects/unsubscribe')) return url;
+            return url + (url.includes('?') ? '&' : '?') + utm;
+        });
 
     await mailjet.post('send', { version: 'v3.1' }).request({
         Messages: [{

--- a/run/jobs/sendProspectEmail.js
+++ b/run/jobs/sendProspectEmail.js
@@ -56,6 +56,7 @@ module.exports = async (job) => {
         .replace('{{unsubscribeUrl}}', unsubscribeUrl)
         .replace(/https?:\/\/(?:[a-z0-9-]+\.)*tryethernal\.com[^\s)\]>"']*/gi, (url) => {
             if (url.includes('/api/prospects/unsubscribe')) return url;
+            if (url.includes('utm_source=')) return url;
             return url + (url.includes('?') ? '&' : '?') + utm;
         });
 

--- a/src/plugins/posthog.js
+++ b/src/plugins/posthog.js
@@ -13,9 +13,20 @@ export default {
         const envStore = useEnvStore();
         const $posthog = envStore.hasAnalyticsEnabled ?
             posthog.init(
-                envStore.postHogApiKey, { api_host: envStore.postHogApiHost }
+                envStore.postHogApiKey,
+                {
+                    api_host: envStore.postHogApiHost,
+                    person_profiles: 'identified_only',
+                    autocapture: true,
+                    capture_pageview: true,
+                    capture_pageleave: true,
+                    ip: true
+                }
             ) :
             { capture: () => {}, reset: () => {}, identify: () => {} }
+
+        if (envStore.hasAnalyticsEnabled && typeof window !== 'undefined')
+            window.posthog = $posthog;
 
         app.config.globalProperties.$posthog = $posthog;
         app.provide('$posthog', $posthog);

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -42,6 +42,13 @@ export const useUserStore = defineStore('user', {
                     window.smartsupp('name', user.email);
                     window.smartsupp('email', user.email);
                 }
+
+                if (envStore.hasAnalyticsEnabled && user.id && window.posthog && typeof window.posthog.identify === 'function') {
+                    const props = {};
+                    if (user.email) props.email = user.email;
+                    if (user.plan) props.plan = user.plan;
+                    window.posthog.identify(String(user.id), props);
+                }
             }
             else {
                 this.$reset();
@@ -56,8 +63,8 @@ export const useUserStore = defineStore('user', {
                     window.smartsupp('email', null);
                 }
 
-                if (envStore.hasAnalyticsEnabled)
-                    this.globalProperties.$posthog.reset();
+                if (envStore.hasAnalyticsEnabled && window.posthog && typeof window.posthog.reset === 'function')
+                    window.posthog.reset();
             }
         }
     },

--- a/tweet-pipeline/promote-blog.sh
+++ b/tweet-pipeline/promote-blog.sh
@@ -100,7 +100,7 @@ full article →"
   fi
 
   # Build full tweet text (hook already ends with transition phrase)
-  BLOG_URL="https://tryethernal.com/blog/${SLUG}"
+  BLOG_URL="https://tryethernal.com/blog/${SLUG}?utm_source=twitter&utm_medium=social&utm_campaign=blog_promo"
   TWEET_TEXT="${HOOK}
 ${BLOG_URL}"
 


### PR DESCRIPTION
## Summary

PostHog data audit revealed three structural blockers preventing meaningful marketing analysis:

1. **0 attribution** between landing visitors and signups — anonymous landing distinct_id never bridged to backend user id
2. **No UTMs on any outbound surface** — channel performance was guesswork
3. **100% bounce on every blog article** — single generic CTA, no topic tailoring, nothing at the end of the article

This PR fixes all three across landing, blog, app frontend, email, and tweet pipeline.

## What changed

### Tracking fixes (the main analytics blockers)
- `posthog.identify(user.id, {email, plan})` on signin/signup completion in `src/stores/user.js` — bridges the anonymous landing cookie to the backend user id so `auth:user_signup`, `workspace:workspace_create`, `explorer:subscription_create` events finally roll up to the originating marketing visit
- Expose PostHog client on `window` so the existing `window.posthog.capture(...)` calls in onboarding components actually fire
- Explicit `autocapture: true` and `ip: true` on both PostHog inits (app + landing)

### UTM tagging on every outbound link we control
- Tweet pipeline blog promos (`utm_source=twitter&utm_medium=social&utm_campaign=blog_promo`)
- Drip email sequence — per-step campaign + brand header/footer
- Demo-ready transactional email
- Prospect cold emails (regex post-processor adds UTMs to any `*.tryethernal.com` URL in AI-generated body, preserves the unsubscribe URL)
- Landing navbar / mobile nav / footer (Sign In, Get Started)
- Blog footer Sign In, blog article mid/end CTAs
- Free tools inline CTAs (`utm_source=tool&utm_medium=inline_cta&utm_campaign=<tool_name>`)

### Blog conversion (`blog/src/layouts/PostLayout.astro`)
- Topic-aware CTA picker with 6 variants based on frontmatter tags:
  - **Comparison** → "See how Ethernal compares" → /pricing + /etherscan-alternative
  - **Security/Auditing/MEV/DeFi** → "Trace any transaction" → signup + tracing demo article
  - **L2/Infrastructure/Blobs** → "Run a block explorer for your L2" → signup + /pricing
  - **Ethernal/Developer Tools** → "Try Ethernal on your chain" → signup + /features
  - **EVM/Smart Contracts/Ethereum/AA/ZK/etc.** → "Need an explorer that understands modern EVM?" → signup + live explorer demo
  - **Default fallback** → original generic copy
- Always-rendered end-of-article CTA card between body and related posts (previously nothing — readers hit the related rail and bounced)
- Mid-article CTA now uses the same topic-aware copy and triggers on 2+ headings (was 3+) so short EIP posts also get one
- All CTAs tracked with `cta_position: mid_article|end_article` for downstream funnel analysis

### Chain page comparison cross-links
- Every `/chains/*` page now links to the relevant comparison page in its Related section:
  - L1s + Sepolia → `/etherscan-alternative`
  - BNB Chain → `/etherscan-alternative` (titled "BscScan Alternative")
  - All L2s/L3s/testnets → `/blockscout-alternative`

### llms.txt polish
- Tightened lede with concrete value props ("in under 5 minutes", "Used by L2s, appchains, and private networks in production")
- Added "Quick facts" block so LLMs grab pricing, setup time, supported chains, and alternative names in the first chunk
- Sharpened Comparisons section descriptions

### PostHog project setting (applied via API, not in this diff)
- Added `$referring_domain not_regex tryethernal\.com$` to project `test_account_filters` to drop bot-subdomain referrer pollution from dashboards

## Test plan

- [ ] After deploy, in 24h confirm `$identify` events fire (currently 0)
- [ ] Re-run "landing visitors → signup overlap" query — should now be non-zero
- [ ] `SELECT properties.utm_source, count() FROM events WHERE event='$pageview' AND properties.utm_source IS NOT NULL` — should show twitter / landing / blog / drip / tool / prospect rows
- [ ] Spot-check `$el_text` is populated on a normal CTA click event
- [ ] `$geoip_country_code` should populate on new pageviews
- [ ] Visit a blog article from each topic group (e.g. `/blog/best-block-explorers-evm-chains-2026`, `/blog/the-bug-auditors-tools-miss`, `/blog/evm-opcodes-101`, `/blog/transaction-tracing-with-ethernal`, `/blog/what-is-l2-why-rollup-needs-block-explorer`) and verify the right CTA variant renders both mid and end of article
- [ ] Visit `/chains/ethereum` and `/chains/arbitrum-one` — comparison link should appear in Related section above Pricing
- [ ] Visit each `/tools/*` page, perform an action that triggers the inline CTA, click it — confirm the URL contains the right `utm_campaign`
- [ ] After deploy + 24-48h, build the saved Insight: pageview → auth:user_signup → workspace:workspace_create → explorer:subscription_create, broken down by utm_source

🧙 Built with [WOZCODE](https://wozcode.com)