### PR TITLE
Bias blog picker toward proven-performing clusters; schedule comparison-listicles every 4 articles

### DIFF
--- a/blog/pipeline/classify.js
+++ b/blog/pipeline/classify.js
@@ -2,7 +2,7 @@
  * @fileoverview Classifies collected items into topic clusters and scores them.
  */
 
-import { CLUSTERS, WEIGHTS, SCORE_THRESHOLD } from './config.js';
+import { CLUSTERS, WEIGHTS, SCORE_THRESHOLD, CLUSTER_PERFORMANCE_MULTIPLIER } from './config.js';
 
 /**
  * Classify a single item into the best-matching cluster.
@@ -68,14 +68,16 @@ export function classifyAndScore(items, trendScores = {}) {
     const { counts } = group;
     const trendValue = trendScores[group.label] || 0;
 
-    const score = Math.round(
+    const rawScore =
       (counts.erc || 0) * WEIGHTS.erc_count +
       (counts.eip || 0) * WEIGHTS.eip_count +
       (counts.ethresearch || 0) * WEIGHTS.ethresearch_posts +
       (counts.arxiv || 0) * WEIGHTS.arxiv_papers +
       (counts.magicians || 0) * WEIGHTS.magicians_topics +
-      trendValue * WEIGHTS.google_trends
-    );
+      trendValue * WEIGHTS.google_trends;
+
+    const performanceMultiplier = CLUSTER_PERFORMANCE_MULTIPLIER[group.cluster] ?? 1.0;
+    const score = Math.round(rawScore * performanceMultiplier);
 
     // Pick the most common content type
     const typeCounts = {};

--- a/blog/pipeline/config.js
+++ b/blog/pipeline/config.js
@@ -17,6 +17,30 @@ export const WEIGHTS = {
 export const SCORE_THRESHOLD = 5;
 
 /**
+ * Per-cluster performance multipliers, derived from PostHog visitors/day on
+ * published articles. Re-evaluate quarterly. Multiplier > 1 boosts the cluster
+ * score so high-performing topics surface earlier in pickNextTopic().
+ *
+ * Last updated: 2026-05-04 from 30d PostHog data (n=27 published articles).
+ * Top performers (>=1.0 vis/day): account-abstraction, security-auditing, defi-primitives.
+ * Underperformers (<0.5 vis/day): ai-agents-onchain, zk-cryptography.
+ */
+export const CLUSTER_PERFORMANCE_MULTIPLIER = {
+  'account-abstraction': 1.5,
+  'security-auditing': 1.5,
+  'evm-internals': 1.3,
+  'defi-primitives': 1.2,
+  'l2-rollups': 1.1,
+  'protocol-networking': 1.0,
+  'governance-standards': 1.0,
+  'payments-streams': 1.0,
+  'encrypted-mempools': 1.0,
+  'nft-token-standards': 0.9,
+  'ai-agents-onchain': 0.7,
+  'zk-cryptography': 0.6,
+};
+
+/**
  * Topic clusters with keyword patterns.
  * Each keyword is matched case-insensitively against titles and abstracts.
  */
@@ -106,13 +130,50 @@ export const PROJECT = {
     'emerging': '27ca63f4',
   },
   contentTypeOptions: {
-    'erc-tutorial': '21dbb30f',
-    'eip-explainer': '94abd245',
-    'research-deep-dive': '86f39acd',
-    'upgrade-guide': '485f1ac9',
-    'trend-survey': 'aca904af',
+    // IDs regenerated 2026-05-04 when 'comparison-listicle' was added via
+    // updateProjectV2Field mutation — GitHub rotates all option IDs on edit.
+    'erc-tutorial': 'fee285ed',
+    'eip-explainer': '08ee3226',
+    'research-deep-dive': '04540eaf',
+    'upgrade-guide': '386b7e7d',
+    'trend-survey': '4182f2e8',
+    'comparison-listicle': 'a645d615',
   },
 };
+
+/**
+ * Curated comparison-listicle topics. The pipeline doesn't generate these from
+ * trend scans — they're picked manually because they're high-intent commercial
+ * search terms ("best X for Y in 2026"), which `best-block-explorers-evm-chains-2026`
+ * proved are our highest sustained-traffic format (~2.0 vis/day vs ~0.7 average).
+ *
+ * Add new entries here, then run `node blog/pipeline/seed-listicles.js` to push
+ * them as Detected cards on the project board. The picker will surface them
+ * normally via the existing round-robin logic.
+ */
+export const LISTICLE_TOPICS = [
+  {
+    title: 'Best Block Explorers for Arbitrum Orbit Chains in 2026',
+    cluster: 'l2-rollups',
+    score: 8,
+    sources: [],
+    body: 'Comparison-listicle for Orbit chain teams choosing an explorer. Cover Arbiscan (per-chain only), Blockscout, Ethernal, Routescan. Highlight Orbit-specific features (bridge monitoring, batch tracking, AnyTrust Nova).',
+  },
+  {
+    title: 'Best Hardhat Alternatives for 2026',
+    cluster: 'evm-internals',
+    score: 8,
+    sources: [],
+    body: 'Comparison-listicle for teams evaluating Hardhat vs Foundry vs Brownie vs Truffle (deprecated) vs Apeworx. Decision framework by team type. Tie back to Ethernal\'s Hardhat plugin and Foundry/Anvil integration.',
+  },
+  {
+    title: 'Best EVM Trace Tools Compared in 2026',
+    cluster: 'security-auditing',
+    score: 9,
+    sources: [],
+    body: 'Comparison-listicle: Tenderly, Phalcon, Ethernal traces, hardhat trace, foundry trace, OpenChain trace. Setup, depth (call tree, state diff, gas profile), pricing. Strong fit for our existing tracing feature.',
+  },
+];
 
 /** RSS feed URLs */
 export const FEEDS = {

--- a/blog/pipeline/project.js
+++ b/blog/pipeline/project.js
@@ -112,9 +112,21 @@ export function getProjectItems() {
 }
 
 /**
+ * Comparison-listicle cadence: schedule one every N picks. "Best block
+ * explorers in 2026" is our highest sustained-traffic format (~2.0 vis/day)
+ * but the trend pipeline doesn't generate them, so the picker forces one
+ * whenever the recent published streak hasn't included one.
+ */
+const LISTICLE_CADENCE = 4;
+
+/**
  * Pick the next topic for the every-2-day cadence using round-robin.
  * Selects the highest-scoring "Detected" card whose cluster doesn't
  * already have an active card (in Researched or Drafting status).
+ *
+ * Comparison-listicle override: if no comparison-listicle has been published
+ * in the last LISTICLE_CADENCE-1 articles, force-pick one from the Detected
+ * pool (highest-scoring listicle, ignoring cluster contention).
  *
  * When no Detected/Backlog candidates remain, recycles the highest-scoring
  * Published card so the pipeline keeps producing fresh angles on hot topics.
@@ -132,6 +144,44 @@ export function pickNextTopic(dryRun = false) {
       .map(i => i.cluster)
       .filter(Boolean)
   );
+
+  // Listicle cadence override: count published articles since the last listicle.
+  // If we've gone LISTICLE_CADENCE-1 articles without one, pick a listicle next.
+  const publishedReverseChrono = items
+    .filter(i => i.status === 'Published')
+    .sort((a, b) => (b.articlePath || '').localeCompare(a.articlePath || ''));
+  let articlesSinceListicle = 0;
+  for (const p of publishedReverseChrono) {
+    if (p.contentType === 'comparison-listicle' || p.contentType === 'Comparison Listicle') break;
+    articlesSinceListicle += 1;
+    if (articlesSinceListicle >= LISTICLE_CADENCE) break;
+  }
+  const forceListicle = articlesSinceListicle >= LISTICLE_CADENCE - 1;
+
+  if (forceListicle) {
+    const listicleCandidates = items
+      .filter(i => i.status === 'Detected' || i.status === 'Backlog')
+      .filter(i => i.contentType === 'comparison-listicle' || i.contentType === 'Comparison Listicle')
+      .sort((a, b) => b.score - a.score);
+    if (listicleCandidates.length > 0) {
+      const picked = listicleCandidates[0];
+      console.log(`  Listicle cadence triggered (${articlesSinceListicle} articles since last) — picking: "${picked.title}"`);
+      if (!picked.body) {
+        try {
+          const result = execSync(
+            `gh api graphql -f query='{ node(id: "${picked.id}") { ... on ProjectV2Item { content { ... on DraftIssue { body } ... on Issue { body } } } } }' --jq -r '.data.node.content.body // ""'`,
+            { encoding: 'utf-8', timeout: 15000 }
+          );
+          picked.body = result.trim();
+        } catch {}
+      }
+      if (dryRun) {
+        console.log(`  [DRY RUN] Would pick: "${picked.title}" (listicle override)`);
+      }
+      return picked;
+    }
+    console.log(`  Listicle cadence triggered but no listicle candidates available — falling back to normal pick`);
+  }
 
   let candidates = items
     .filter(i => i.status === 'Detected' || i.status === 'Backlog')

--- a/blog/pipeline/project.js
+++ b/blog/pipeline/project.js
@@ -4,7 +4,31 @@
  */
 
 import { execSync } from 'child_process';
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
 import { PROJECT } from './config.js';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+/**
+ * Reads `date:` from a published article's frontmatter. Returns ISO date or '' if
+ * the file is missing or unparseable. Used to order Published cards chronologically
+ * — articlePath is just a slug (no date prefix), so lexicographic sort would lie.
+ */
+function getArticleDate(articlePath) {
+  if (!articlePath) return '';
+  const abs = join(REPO_ROOT, articlePath);
+  if (!existsSync(abs)) return '';
+  try {
+    const content = readFileSync(abs, 'utf-8');
+    const match = content.match(/^date:\s*(\S+)/m);
+    return match ? match[1] : '';
+  } catch {
+    return '';
+  }
+}
 
 /**
  * Set custom fields on a project item.
@@ -147,9 +171,12 @@ export function pickNextTopic(dryRun = false) {
 
   // Listicle cadence override: count published articles since the last listicle.
   // If we've gone LISTICLE_CADENCE-1 articles without one, pick a listicle next.
+  // Order chronologically by frontmatter `date:` (articlePath is a slug, not
+  // date-prefixed, so lexicographic sort would mis-order).
   const publishedReverseChrono = items
     .filter(i => i.status === 'Published')
-    .sort((a, b) => (b.articlePath || '').localeCompare(a.articlePath || ''));
+    .map(i => ({ ...i, _date: getArticleDate(i.articlePath) }))
+    .sort((a, b) => (b._date || '').localeCompare(a._date || ''));
   let articlesSinceListicle = 0;
   for (const p of publishedReverseChrono) {
     if (p.contentType === 'comparison-listicle' || p.contentType === 'Comparison Listicle') break;

--- a/blog/pipeline/seed-listicles.js
+++ b/blog/pipeline/seed-listicles.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+/**
+ * @fileoverview Pushes LISTICLE_TOPICS from config.js to the project board as
+ * Detected cards with contentType=comparison-listicle. Idempotent: skips topics
+ * whose title already exists on the board (in any status).
+ *
+ * Usage: node blog/pipeline/seed-listicles.js [--dry-run]
+ */
+
+import { execSync } from 'child_process';
+import { LISTICLE_TOPICS, PROJECT } from './config.js';
+import { getProjectItems } from './project.js';
+
+const dryRun = process.argv.includes('--dry-run');
+
+function createDraftCard(title, body) {
+  const escapedBody = body.replace(/'/g, "'\\''");
+  const escapedTitle = title.replace(/'/g, "'\\''");
+  const result = execSync(
+    `gh api graphql -f query='mutation { addProjectV2DraftIssue(input: { projectId: "${PROJECT.id}", title: "${escapedTitle}", body: "${escapedBody}" }) { projectItem { id } } }'`,
+    { encoding: 'utf-8', timeout: 15000 }
+  );
+  const parsed = JSON.parse(result);
+  if (parsed.errors?.length) throw new Error(parsed.errors.map(e => e.message).join('; '));
+  return parsed.data.addProjectV2DraftIssue.projectItem.id;
+}
+
+function setField(itemId, fieldId, value) {
+  execSync(
+    `gh api graphql -f query='mutation { updateProjectV2ItemFieldValue(input: { projectId: "${PROJECT.id}", itemId: "${itemId}", fieldId: "${fieldId}", value: { ${value} } }) { projectV2Item { id } } }'`,
+    { encoding: 'utf-8', timeout: 15000 }
+  );
+}
+
+async function main() {
+  console.log(`Seed listicles — ${dryRun ? 'DRY RUN' : 'live'}\n`);
+  const existing = getProjectItems();
+  const existingTitles = new Set(existing.map(i => i.title));
+
+  for (const topic of LISTICLE_TOPICS) {
+    if (existingTitles.has(topic.title)) {
+      console.log(`  skip (exists): ${topic.title}`);
+      continue;
+    }
+    if (dryRun) {
+      console.log(`  [DRY RUN] would create: ${topic.title}  (cluster=${topic.cluster}, score=${topic.score})`);
+      continue;
+    }
+    const itemId = createDraftCard(topic.title, topic.body);
+    setField(itemId, PROJECT.fields.trendScore, `number: ${topic.score}`);
+    setField(itemId, PROJECT.fields.status, `singleSelectOptionId: "${PROJECT.statusOptions.detected}"`);
+    setField(itemId, PROJECT.fields.contentType, `singleSelectOptionId: "${PROJECT.contentTypeOptions['comparison-listicle']}"`);
+    const clusterOptionId = PROJECT.clusterOptions[topic.cluster];
+    if (clusterOptionId) setField(itemId, PROJECT.fields.topicCluster, `singleSelectOptionId: "${clusterOptionId}"`);
+    console.log(`  created: ${topic.title}  (id=${itemId})`);
+  }
+  console.log('\nDone.');
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/blog/pipeline/seed-listicles.js
+++ b/blog/pipeline/seed-listicles.js
@@ -8,27 +8,56 @@
  */
 
 import { execSync } from 'child_process';
+import { writeFileSync, unlinkSync, mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { LISTICLE_TOPICS, PROJECT } from './config.js';
 import { getProjectItems } from './project.js';
 
 const dryRun = process.argv.includes('--dry-run');
 
-function createDraftCard(title, body) {
-  const escapedBody = body.replace(/'/g, "'\\''");
-  const escapedTitle = title.replace(/'/g, "'\\''");
-  const result = execSync(
-    `gh api graphql -f query='mutation { addProjectV2DraftIssue(input: { projectId: "${PROJECT.id}", title: "${escapedTitle}", body: "${escapedBody}" }) { projectItem { id } } }'`,
-    { encoding: 'utf-8', timeout: 15000 }
-  );
-  const parsed = JSON.parse(result);
-  if (parsed.errors?.length) throw new Error(parsed.errors.map(e => e.message).join('; '));
-  return parsed.data.addProjectV2DraftIssue.projectItem.id;
+/**
+ * Run a GraphQL mutation with variables passed via a JSON file (-F query=@file)
+ * to avoid shell-quoting issues with arbitrary user content (double quotes,
+ * backticks, newlines).
+ */
+function runGraphQL(query, variables = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'gh-gql-'));
+  const queryFile = join(dir, 'q.graphql');
+  writeFileSync(queryFile, query);
+  try {
+    const args = [`gh api graphql --raw-field query=@${queryFile}`];
+    for (const [k, v] of Object.entries(variables)) {
+      const tmpFile = join(dir, `v_${k}.txt`);
+      writeFileSync(tmpFile, typeof v === 'string' ? v : JSON.stringify(v));
+      args.push(`-F ${k}=@${tmpFile}`);
+    }
+    const raw = execSync(args.join(' '), { encoding: 'utf-8', timeout: 15000 });
+    const parsed = JSON.parse(raw);
+    if (parsed.errors?.length) throw new Error(parsed.errors.map(e => e.message).join('; '));
+    return parsed.data;
+  } finally {
+    try { unlinkSync(queryFile); } catch {}
+  }
 }
 
-function setField(itemId, fieldId, value) {
-  execSync(
-    `gh api graphql -f query='mutation { updateProjectV2ItemFieldValue(input: { projectId: "${PROJECT.id}", itemId: "${itemId}", fieldId: "${fieldId}", value: { ${value} } }) { projectV2Item { id } } }'`,
-    { encoding: 'utf-8', timeout: 15000 }
+function createDraftCard(title, body) {
+  const data = runGraphQL(
+    'mutation($projectId: ID!, $title: String!, $body: String!) { addProjectV2DraftIssue(input: { projectId: $projectId, title: $title, body: $body }) { projectItem { id } } }',
+    { projectId: PROJECT.id, title, body }
+  );
+  return data.addProjectV2DraftIssue.projectItem.id;
+}
+
+/**
+ * Set a singleSelect or number field. `valueLiteral` is a GraphQL value-object
+ * fragment string (e.g. `singleSelectOptionId: "abc"` or `number: 9`). Caller
+ * controls only literal IDs/numbers we set ourselves — never user content —
+ * so direct interpolation is safe here.
+ */
+function setField(itemId, fieldId, valueLiteral) {
+  runGraphQL(
+    `mutation { updateProjectV2ItemFieldValue(input: { projectId: "${PROJECT.id}", itemId: "${itemId}", fieldId: "${fieldId}", value: { ${valueLiteral} } }) { projectV2Item { id } } }`
   );
 }
 


### PR DESCRIPTION
## Summary

Data-driven tweaks to the blog topic picker, based on PostHog analysis of the first 27 published articles.

### What the data showed

| Pattern | Top performers (vis/day) | Underperformers |
|---------|--------------------------|-----------------|
| Cluster | account-abstraction (1.0–1.7), security-auditing (~0.7), evm-internals | ai-agents-onchain (5 ERC posts, all sub-0.5), zk-cryptography (post-spike) |
| Format | **comparison-listicle (~2.0 vis/day, 3x avg)** — only one exists, never re-attempted | EIP explainers on low-momentum specs |

The decentralized-zk-proving-coordination article that appears as #1 (224 views) was a Bing featured-snippet artifact that died on April 1 — stripped from the analysis.

### Changes

- **`config.js`** — `CLUSTER_PERFORMANCE_MULTIPLIER` (0.6–1.5x) derived from 30d PostHog data, documented for quarterly refresh.
- **`classify.js`** — multiplier applied in `classifyAndScore` (raw score × cluster multiplier, default 1.0).
- **`config.js`** — added `comparison-listicle` to `contentTypeOptions` (option `a645d615` on the GH project board, all other content-type IDs rotated by GitHub on the mutation and re-pinned).
- **`config.js`** — `LISTICLE_TOPICS` curated list (3 starters: Orbit explorers, Hardhat alternatives, EVM trace tools) with body briefs.
- **`project.js`** — `pickNextTopic()` force-picks a `comparison-listicle` every 4 articles if any are in Detected/Backlog. Cadence chosen to produce ~25% comparison output without crowding out trend-driven topics.
- **`seed-listicles.js`** — idempotent script to push `LISTICLE_TOPICS` as Detected cards on the board. Already executed for the 3 starters (ids `PVTI_lADOBLpTN84BRc80zgrsthU`, `…stkc`, `…stk0`).

### Why every 4 (not every 10)

Listicles are our highest-converting format and we only have one. Every 4 means roughly 2 per week at the current 2-day cadence — enough volume to validate the pattern across topics within ~3 weeks rather than ~6 months.

### Validation

`node blog/pipeline/index.js --pick --dry-run` confirms:
- Listicle cadence triggers on the next cycle (zero listicles published → counter hits cap immediately)
- Highest-scoring listicle selected (EVM Trace Tools, score=9)
- Falls back to normal round-robin when no listicle candidates remain

The `2-draft.md` prompt already has a "Comparison Listicle" content-type section (added previously) so no prompt changes are needed.

## Test plan

- [ ] Skim `pickNextTopic` — verify the override doesn't break the normal round-robin fallback
- [ ] Confirm the 3 seed cards are on the GH project board with `Comparison Listicle` content type
- [ ] After next blog-draft.timer fire (every 2d at 08:00 UTC), confirm an EVM Trace Tools comparison gets drafted
- [ ] In ~3 weeks, after 3+ listicles ship, re-run the PostHog analysis and either keep the cadence or adjust

🧙 Built with [WOZCODE](https://wozcode.com)