### PR TITLE
fix(rpc): swallow Substrate-EVM DispatchError (-32603) in tracer

### DIFF
--- a/run/lib/rpc.js
+++ b/run/lib/rpc.js
@@ -535,11 +535,13 @@ class Tracer {
             };
 
         // Handle -32603 (Internal error) selectively - only ignore block size/complexity limits
+        // and Substrate-EVM DispatchError (chain-side runtime error for a specific tx, not our bug)
         if (error.error && error.error.code === -32603) {
             const message = error.error.message || '';
             if (message.includes('too many transactions') ||
                 message.includes('block too large') ||
-                message.includes('block size limit')) {
+                message.includes('block size limit') ||
+                message.includes('DispatchError')) {
                 return this.error = {
                     code: `Error code "${error.error.code}".`,
                     message: error.error.message,

--- a/run/tests/lib/rpc.test.js
+++ b/run/tests/lib/rpc.test.js
@@ -226,5 +226,20 @@ describe('Tracer', () => {
 
             expect(rpcCapabilityCache.recordTraceSuccess).toHaveBeenCalledWith('http://localhost:8545');
         });
+
+        it('Should swallow Substrate DispatchError (-32603) as a benign per-tx error and not throw (regression: gh#1298)', async () => {
+            const tracer = new Tracer('http://localhost:8545', {});
+            const error = { error: { code: -32603, message: 'DispatchError: Other("")' } };
+            jest.spyOn(tracer.traceProvider, 'send').mockRejectedValueOnce(error);
+
+            await tracer.process({ hash: '0x123' });
+
+            expect(tracer.error).toEqual({
+                code: 'Error code "-32603".',
+                message: 'DispatchError: Other("")',
+                error: error
+            });
+            expect(rpcCapabilityCache.markTraceUnsupported).not.toHaveBeenCalled();
+        });
     });
 });

--- a/run/tests/lib/rpc.test.js
+++ b/run/tests/lib/rpc.test.js
@@ -240,6 +240,7 @@ describe('Tracer', () => {
                 error: error
             });
             expect(rpcCapabilityCache.markTraceUnsupported).not.toHaveBeenCalled();
+            expect(rpcCapabilityCache.recordTraceSuccess).not.toHaveBeenCalled();
         });
     });
 });


### PR DESCRIPTION
Closes #1298

## Problem

Substrate-EVM chains (e.g. Frontier/Moonbeam-family) return JSON-RPC `-32603` with body `DispatchError: Other("")` when a single transaction's runtime call fails on the chain side. This is **not** an RPC misconfiguration or a bug on our side — it's a per-tx chain-side error meaning the trace simply can't be produced for that specific transaction.

The `Tracer` was rethrowing this error, causing ~170 Sentry events/day (Sentry issue [60/26], lifetime 4,114 events) and previously closed dupes #1230, #1219, #1210 that kept regressing.

## Fix

Add `DispatchError` to the existing `-32603` benign-message allowlist in `Tracer.#handleError` (`run/lib/rpc.js:537-548`). Mirrors the existing handling for `too many transactions` / `block too large` / `block size limit` — store on `this.error` and return cleanly so the trace is skipped for that tx without a Sentry alert.

## Test

Added regression test:
```
✓ Should swallow Substrate DispatchError (-32603) as a benign per-tx error and not throw (regression: gh#1298)
```

All 20 `tests/lib/rpc.test.js` tests pass locally.

## Risk

Minimal — the allowlist already exists and is scoped to `-32603`. Worst case is one more class of trace failure becomes silent (intended). Other `-32603` codes still propagate as before.