### PR TITLE
feat: pipeline resilience — tweet circuit breaker + Sentry scanner preflight

### DIFF
--- a/.github/workflows/sentry-scanner.yml
+++ b/.github/workflows/sentry-scanner.yml
@@ -53,6 +53,70 @@ jobs:
             - Pattern: `curl -s -o /tmp/resp.json "URL" -H "Authorization: Bearer $SENTRY_API_TOKEN" && jq '...' /tmp/resp.json`
             - **CRITICAL — `count` is LIFETIME, not 24h.** The `count` field on each issue in the list response is the lifetime `times_seen` total, NOT the 24h rolling volume. Do NOT use it for thresholds or report it as "Events (24h)" — that caused a false-incident storm (issues #1218–#1232 were all closed as self-resolved because the scanner reported 6,000+ "24h events" when actual 24h volume was 2–16). The TRUE 24h volume is `([.stats."24h"[]?[1]] | add)` — sum of the hourly buckets in the `stats."24h"` array. Always compute and use this value.
 
+            ## Step 0: Pre-flight health & auth probe (MANDATORY)
+
+            Before doing anything else, distinguish three top-level states:
+            - **Service down** (Sentry API itself returns 5xx)
+            - **Auth broken** (Sentry API up, but token is rejected with 401/403)
+            - **Healthy** (proceed to Step 1)
+
+            Past incidents created **separate issues per scanner run for the same outage** (#1301/#1302/#1303 + #1305 were all the same Sentry outage, and #1304 was the actual token-regen item that got buried). This step deduplicates against open infra issues and **must run before any Sentry query**.
+
+            ```bash
+            BASE_UNAUTH=$(curl -s -o /tmp/preflight_base.json -w "%{http_code}" "https://sentry.tryethernal.com/api/0/" --max-time 15 || echo "000")
+            AUTH_PROBE=$(curl -s -o /tmp/preflight_auth.json -w "%{http_code}" "https://sentry.tryethernal.com/api/0/projects/" -H "Authorization: Bearer $SENTRY_API_TOKEN" --max-time 15 || echo "000")
+            echo "preflight base=$BASE_UNAUTH auth=$AUTH_PROBE"
+            ```
+
+            Decision matrix:
+
+            | base | auth | Verdict | Action |
+            |------|------|---------|--------|
+            | 2xx  | 2xx  | Healthy | Continue to Step 1 |
+            | 2xx  | 401/403 | Token bad | Run "AUTH_BROKEN handler" below, then exit 0 |
+            | 5xx / 000 | any | Service down | Run "SERVICE_DOWN handler" below, then exit 0 |
+            | other | other | Unknown | Run "SERVICE_DOWN handler" with verdict="unknown", exit 0 |
+
+            ### SERVICE_DOWN handler
+
+            Dedup against an open service-down issue from the last 24h, then either comment on it or create one. **Never create a second open service-down issue.**
+
+            1. Search for an existing open issue:
+               ```bash
+               gh issue list --state open --label sentry --search 'in:title "Sentry monitoring service down"' \
+                 --json number,createdAt \
+                 --jq '[.[] | select((now - (.createdAt | fromdateiso8601)) < 86400)] | .[0].number'
+               ```
+            2. If a number comes back: comment on it with `gh issue comment <num>` noting the current timestamp, the HTTP codes from the preflight, and "outage still in progress". Then `exit 0`.
+            3. If no existing issue: `gh issue create` with:
+               - title: `Sentry monitoring service down - API returning <BASE_UNAUTH> errors`
+               - labels: `sentry`, `needs-human`, `infra-alert`
+               - body: the timestamp, both HTTP codes, the first 500 chars of `/tmp/preflight_base.json` if it has content, and "Scanner skipped this cycle — will retry on next hourly run."
+               Then `exit 0`.
+
+            ### AUTH_BROKEN handler
+
+            Dedup against an open auth-issue from the last 24h. Title pattern: `Sentry API scanner failing - authentication`.
+
+            1. Search for an existing open issue:
+               ```bash
+               gh issue list --state open --label sentry --search 'in:title "Sentry API scanner failing"' \
+                 --json number,createdAt \
+                 --jq '[.[] | select((now - (.createdAt | fromdateiso8601)) < 86400)] | .[0].number'
+               ```
+            2. If a number comes back: comment on it noting the current timestamp and that the authenticated API still returns HTTP `<AUTH_PROBE>`. Then `exit 0`.
+            3. If no existing issue: `gh issue create` with:
+               - title: `Sentry API scanner failing - authentication/server errors`
+               - labels: `sentry`, `needs-human`
+               - body: timestamps, both HTTP codes, and these manual action items:
+                 1. Log into https://sentry.tryethernal.com → Settings → Account → API → Auth Tokens
+                 2. Regenerate the token with scopes: `org:read`, `project:read`, `event:read`, `event:admin`
+                 3. Update the `SENTRY_API_TOKEN` GitHub Actions secret
+                 4. Re-run this workflow manually
+               Then `exit 0`.
+
+            Only proceed past Step 0 if the preflight verdict is "Healthy".
+
             ## Step 1: Query Sentry for all unresolved issues
 
             Run ALL 6 queries in a single bash command to save turns. Save each to a temp file:
@@ -271,6 +335,7 @@ jobs:
 
             ## Rules
             - NEVER create duplicate GitHub issues — always check first
+            - **NEVER create your own "Sentry service down" or "Sentry API failing" issue from Steps 1-7.** Those are infra issues, not Sentry-issue findings, and they're owned by Step 0 (preflight). If you find yourself wanting to file one mid-scan, abort and re-run Step 0 instead. Past scanner runs created #1301/#1302/#1303 + #1305 for the same outage because this rule wasn't enforced.
             - Be conservative: only create issues for clear code bugs or significant performance problems
             - When resolving in Sentry, always include a reason
             - Keep issue descriptions concise but include enough for the auto-fix agent

--- a/tweet-pipeline/lib/circuit-breaker.js
+++ b/tweet-pipeline/lib/circuit-breaker.js
@@ -1,0 +1,139 @@
+/**
+ * @fileoverview Persistent circuit breaker for fail-stop conditions in the
+ * tweet pipeline. When a non-recoverable error is detected (e.g. Twitter
+ * returns HTTP 402 CreditsDepleted), we write a marker file with a TTL so
+ * subsequent timer fires bail out fast instead of generating a fresh
+ * GitHub issue every 10 minutes.
+ *
+ * Used by tweet-pipeline/lib/twitter.js (to trip the breaker on 402) and
+ * tweet-pipeline/publish.sh + promote-blog.sh (to check the breaker at
+ * the start of each run).
+ *
+ * Design notes:
+ * - File-based, no daemon — survives process restarts and is shared
+ *   across publish.sh, promote-blog.sh and the underlying node helpers.
+ * - JSON payload so we can store reason + tripped-at + TTL.
+ * - TTL is 6h by default; auto-recovers once Twitter credits are topped
+ *   up (the next scheduled run after expiry will retry and either succeed
+ *   or re-trip the breaker for another 6h).
+ */
+
+import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+/** Default marker location. Overridden by TWEET_PIPELINE_BREAKER_PATH env. */
+const DEFAULT_PATH = '/var/lib/tweet-pipeline/circuit-breaker.json';
+
+/** Default TTL: 6 hours. After this, the next run will retry the API. */
+const DEFAULT_TTL_MS = 6 * 60 * 60 * 1000;
+
+/**
+ * Resolves the breaker marker file path from env or default.
+ * @returns {string}
+ */
+function breakerPath() {
+    return process.env.TWEET_PIPELINE_BREAKER_PATH || DEFAULT_PATH;
+}
+
+/**
+ * Trips the circuit breaker, writing a marker file with the supplied reason.
+ * Subsequent calls to {@link isBreakerOpen} will return true until the TTL
+ * expires or {@link resetBreaker} is called.
+ *
+ * Safe to call repeatedly — overwrites the marker each time so the TTL
+ * window slides forward on every fresh failure.
+ *
+ * @param {string} reason - Human-readable explanation, e.g.
+ *   "Twitter HTTP 402 CreditsDepleted".
+ * @param {number} [ttlMs=DEFAULT_TTL_MS] - How long the breaker stays open.
+ * @returns {{path: string, reason: string, trippedAt: string, expiresAt: string}}
+ */
+export function tripBreaker(reason, ttlMs = DEFAULT_TTL_MS) {
+    const path = breakerPath();
+    const now = Date.now();
+    const payload = {
+        reason,
+        trippedAt: new Date(now).toISOString(),
+        expiresAt: new Date(now + ttlMs).toISOString(),
+    };
+
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify(payload, null, 2));
+    return { path, ...payload };
+}
+
+/**
+ * Checks whether the breaker is currently open (tripped and not expired).
+ * A breaker file with an `expiresAt` in the past is treated as closed
+ * and silently removed so the caller doesn't have to.
+ *
+ * @returns {null | {reason: string, trippedAt: string, expiresAt: string}}
+ *   null if breaker is closed; otherwise the payload of the open breaker.
+ */
+export function isBreakerOpen() {
+    const path = breakerPath();
+    if (!existsSync(path)) return null;
+
+    let payload;
+    try {
+        payload = JSON.parse(readFileSync(path, 'utf8'));
+    } catch {
+        // Corrupt marker — treat as closed and clear it.
+        try { unlinkSync(path); } catch { /* ignore */ }
+        return null;
+    }
+
+    if (!payload || !payload.expiresAt) return null;
+    if (Date.parse(payload.expiresAt) <= Date.now()) {
+        try { unlinkSync(path); } catch { /* ignore */ }
+        return null;
+    }
+
+    return payload;
+}
+
+/**
+ * Resets the breaker (removes the marker file). Called on successful API
+ * calls so a brief outage doesn't leave the breaker open for its full TTL.
+ * No-op if the marker doesn't exist.
+ *
+ * @returns {boolean} true if a marker was removed, false if none existed.
+ */
+export function resetBreaker() {
+    const path = breakerPath();
+    if (!existsSync(path)) return false;
+    try {
+        unlinkSync(path);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Inspects a thrown error from twitter-api-v2 and decides whether it is a
+ * non-recoverable, account-level failure that should trip the breaker.
+ *
+ * Currently matches:
+ * - HTTP 402 CreditsDepleted (Twitter pay-per-use credits exhausted).
+ *
+ * Does NOT trip on transient errors (5xx, rate limits, network timeouts) —
+ * those should retry on the next scheduled run.
+ *
+ * @param {unknown} err - The error thrown by a twitter-api-v2 call.
+ * @returns {null | {reason: string}} A reason string if the breaker should
+ *   trip; null otherwise.
+ */
+export function classifyTwitterError(err) {
+    if (!err || typeof err !== 'object') return null;
+
+    const code = err.code;
+    const title = err.data && err.data.title;
+
+    if (code === 402 || title === 'CreditsDepleted') {
+        const detail = (err.data && err.data.detail) || 'Twitter account credits exhausted';
+        return { reason: `Twitter HTTP 402 CreditsDepleted: ${detail}` };
+    }
+
+    return null;
+}

--- a/tweet-pipeline/lib/circuit-breaker.test.js
+++ b/tweet-pipeline/lib/circuit-breaker.test.js
@@ -1,0 +1,146 @@
+/**
+ * @fileoverview Tests for the persistent circuit breaker.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+    tripBreaker,
+    isBreakerOpen,
+    resetBreaker,
+    classifyTwitterError,
+} from './circuit-breaker.js';
+
+let workDir;
+
+beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), 'cb-test-'));
+    process.env.TWEET_PIPELINE_BREAKER_PATH = join(workDir, 'breaker.json');
+});
+
+afterEach(() => {
+    delete process.env.TWEET_PIPELINE_BREAKER_PATH;
+    rmSync(workDir, { recursive: true, force: true });
+});
+
+describe('circuit-breaker', () => {
+    describe('isBreakerOpen', () => {
+        it('returns null when no marker file exists', () => {
+            assert.equal(isBreakerOpen(), null);
+        });
+
+        it('returns the payload when the breaker is tripped and not expired', () => {
+            tripBreaker('test reason');
+            const open = isBreakerOpen();
+            assert.ok(open, 'expected breaker to be open');
+            assert.equal(open.reason, 'test reason');
+            assert.ok(open.trippedAt);
+            assert.ok(open.expiresAt);
+        });
+
+        it('treats an expired breaker as closed and removes the marker', () => {
+            tripBreaker('old', 1); // 1ms TTL
+            // Wait past expiry — node:test guarantees microtask order but use sleep
+            // via a deterministic synchronous loop on Date.now to avoid timer flakiness.
+            const deadline = Date.now() + 10;
+            while (Date.now() <= deadline) { /* spin briefly */ }
+            assert.equal(isBreakerOpen(), null);
+            assert.equal(existsSync(process.env.TWEET_PIPELINE_BREAKER_PATH), false);
+        });
+
+        it('treats a corrupt marker as closed and removes it', async () => {
+            const { writeFileSync } = await import('node:fs');
+            writeFileSync(process.env.TWEET_PIPELINE_BREAKER_PATH, '{not json');
+            assert.equal(isBreakerOpen(), null);
+            assert.equal(existsSync(process.env.TWEET_PIPELINE_BREAKER_PATH), false);
+        });
+    });
+
+    describe('tripBreaker', () => {
+        it('writes a marker that survives between calls', () => {
+            tripBreaker('first');
+            const first = isBreakerOpen();
+            assert.equal(first.reason, 'first');
+        });
+
+        it('overwrites the marker on each trip with a fresher expiry', async () => {
+            tripBreaker('first', 1000);
+            const a = isBreakerOpen();
+            // Ensure the wall clock advances at least 2ms so timestamps differ
+            // even on fast machines where Date.now() resolution may coalesce
+            // back-to-back trips into the same millisecond.
+            await new Promise(r => setTimeout(r, 5));
+            tripBreaker('second', 1000);
+            const b = isBreakerOpen();
+            assert.equal(b.reason, 'second');
+            assert.ok(
+                Date.parse(b.expiresAt) > Date.parse(a.expiresAt),
+                `expected new expiry (${b.expiresAt}) to be after old (${a.expiresAt})`,
+            );
+        });
+
+        it('creates the parent directory if missing', () => {
+            const nested = join(workDir, 'nested', 'deeper', 'breaker.json');
+            process.env.TWEET_PIPELINE_BREAKER_PATH = nested;
+            tripBreaker('nested');
+            assert.ok(existsSync(nested));
+        });
+    });
+
+    describe('resetBreaker', () => {
+        it('removes an existing marker and returns true', () => {
+            tripBreaker('reason');
+            assert.equal(resetBreaker(), true);
+            assert.equal(isBreakerOpen(), null);
+        });
+
+        it('returns false when no marker exists', () => {
+            assert.equal(resetBreaker(), false);
+        });
+    });
+
+    describe('classifyTwitterError', () => {
+        it('returns a reason for HTTP 402 errors', () => {
+            const err = {
+                code: 402,
+                data: { title: 'CreditsDepleted', detail: 'Account has no credits.' },
+            };
+            const verdict = classifyTwitterError(err);
+            assert.ok(verdict, 'expected a non-null verdict');
+            assert.match(verdict.reason, /CreditsDepleted/);
+            assert.match(verdict.reason, /Account has no credits/);
+        });
+
+        it('returns a reason when title is CreditsDepleted even without code 402', () => {
+            const err = { data: { title: 'CreditsDepleted', detail: 'd' } };
+            assert.ok(classifyTwitterError(err));
+        });
+
+        it('returns null for transient errors (5xx)', () => {
+            const err = { code: 503, data: { title: 'ServiceUnavailable' } };
+            assert.equal(classifyTwitterError(err), null);
+        });
+
+        it('returns null for rate limits (429)', () => {
+            const err = { code: 429, data: { title: 'TooManyRequests' } };
+            assert.equal(classifyTwitterError(err), null);
+        });
+
+        it('returns null for null / non-object inputs', () => {
+            assert.equal(classifyTwitterError(null), null);
+            assert.equal(classifyTwitterError(undefined), null);
+            assert.equal(classifyTwitterError('error string'), null);
+            assert.equal(classifyTwitterError(42), null);
+        });
+
+        it('falls back to a generic detail when data.detail is missing', () => {
+            const err = { code: 402, data: { title: 'CreditsDepleted' } };
+            const verdict = classifyTwitterError(err);
+            assert.match(verdict.reason, /credits exhausted/i);
+        });
+    });
+});

--- a/tweet-pipeline/lib/cli/check-breaker.js
+++ b/tweet-pipeline/lib/cli/check-breaker.js
@@ -5,6 +5,14 @@
  * Exit codes:
  *   0 — breaker is OPEN (caller should short-circuit / skip this run)
  *   1 — breaker is CLOSED (caller should proceed normally)
+ *   2 — unexpected error reading the breaker (treat as CLOSED but log)
+ *
+ * Exit 2 is critical: Node's default crash exit is 1, which would collide
+ * with "breaker is closed" and silently fail-open the entire system if
+ * shell callers use `2>/dev/null`. We reserve 1 for "definitively closed"
+ * and 2 for "couldn't tell — assume closed but the caller should at least
+ * surface the stderr output before proceeding". This way `set -e` shell
+ * callers can distinguish.
  *
  * Stdout (when open): one human-readable line with reason + expiry, e.g.
  *   "Twitter HTTP 402 CreditsDepleted: ... (expires 2026-05-25T06:15:13.000Z)"
@@ -14,12 +22,15 @@
  * true". Same convention as is-promoted.js in this directory.
  */
 
-import { isBreakerOpen } from '../circuit-breaker.js';
-
-const open = isBreakerOpen();
-if (open) {
-    process.stdout.write(`${open.reason} (expires ${open.expiresAt})\n`);
-    process.exit(0);
+try {
+    const { isBreakerOpen } = await import('../circuit-breaker.js');
+    const open = isBreakerOpen();
+    if (open) {
+        process.stdout.write(`${open.reason} (expires ${open.expiresAt})\n`);
+        process.exit(0);
+    }
+    process.exit(1);
+} catch (err) {
+    process.stderr.write(`check-breaker: failed to read breaker state (${err.message})\n`);
+    process.exit(2);
 }
-
-process.exit(1);

--- a/tweet-pipeline/lib/cli/check-breaker.js
+++ b/tweet-pipeline/lib/cli/check-breaker.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+/**
+ * @fileoverview CLI shim around the circuit-breaker module for shell scripts.
+ *
+ * Exit codes:
+ *   0 — breaker is OPEN (caller should short-circuit / skip this run)
+ *   1 — breaker is CLOSED (caller should proceed normally)
+ *
+ * Stdout (when open): one human-readable line with reason + expiry, e.g.
+ *   "Twitter HTTP 402 CreditsDepleted: ... (expires 2026-05-25T06:15:13.000Z)"
+ *
+ * The unusual "0 == open" convention matches shell `if check-breaker; then skip; fi`
+ * ergonomics — `gh` and friends use exit-0 for "the condition you asked about is
+ * true". Same convention as is-promoted.js in this directory.
+ */
+
+import { isBreakerOpen } from '../circuit-breaker.js';
+
+const open = isBreakerOpen();
+if (open) {
+    process.stdout.write(`${open.reason} (expires ${open.expiresAt})\n`);
+    process.exit(0);
+}
+
+process.exit(1);

--- a/tweet-pipeline/lib/cli/check-breaker.test.js
+++ b/tweet-pipeline/lib/cli/check-breaker.test.js
@@ -98,4 +98,32 @@ describe('check-breaker CLI exit codes', () => {
         assert.notEqual(result.status, 2, 'exit 2 must be reserved for errors only');
         assert.ok([0, 1].includes(result.status), `unexpected exit ${result.status}`);
     });
+
+    it('the documented shell wrapper pattern does not trip `set -euo pipefail`', () => {
+        // Second regression guarantee from Greptile review on #1309: the
+        // shell callers (publish.sh, promote-blog.sh) run under
+        // `set -euo pipefail` with an ERR trap that calls report_failure.
+        // The naive `VAR=$(cmd); RC=$?` pattern aborts on cmd's non-zero
+        // exit and never reaches the `RC=$?` line — meaning the ERR trap
+        // fires on EVERY normal run (exit 1 = breaker closed). The
+        // documented pattern uses `|| RC=$?` to absorb the non-zero exit.
+        // Test by invoking the exact pattern in a fresh bash subshell and
+        // asserting that the trap does NOT fire.
+        const script = `
+            set -euo pipefail
+            trap 'echo TRAP_FIRED >&2; exit 99' ERR
+
+            BREAKER_RC=0
+            BREAKER_REASON=$(node ${JSON.stringify(CLI)}) || BREAKER_RC=$?
+
+            echo "rc=$BREAKER_RC"
+        `;
+        const result = spawnSync('bash', ['-c', script], {
+            env: { ...process.env, TWEET_PIPELINE_BREAKER_PATH: breakerPath },
+            encoding: 'utf8',
+        });
+        assert.equal(result.status, 0, `shell wrapper exited ${result.status}; stderr: ${result.stderr}`);
+        assert.doesNotMatch(result.stderr, /TRAP_FIRED/, 'ERR trap should not fire on breaker-closed path');
+        assert.match(result.stdout, /rc=1/);
+    });
 });

--- a/tweet-pipeline/lib/cli/check-breaker.test.js
+++ b/tweet-pipeline/lib/cli/check-breaker.test.js
@@ -1,0 +1,101 @@
+/**
+ * @fileoverview Exit-code contract tests for lib/cli/check-breaker.js.
+ *
+ * The shell callers (publish.sh, promote-blog.sh) depend on a specific
+ * three-code contract: 0 = OPEN, 1 = CLOSED, 2 = error. Confusing 1 and 2
+ * would either fail-closed (deadlock the pipeline) or fail-open (defeat the
+ * breaker entirely — the original bug pre-Greptile-review).
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CLI = join(HERE, 'check-breaker.js');
+
+let workDir;
+let breakerPath;
+
+beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), 'check-breaker-test-'));
+    breakerPath = join(workDir, 'breaker.json');
+});
+
+afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+});
+
+/**
+ * Run the CLI with TWEET_PIPELINE_BREAKER_PATH set to our temp file.
+ * @param {Record<string,string>} [extraEnv]
+ */
+function runCli(extraEnv = {}) {
+    return spawnSync('node', [CLI], {
+        env: { ...process.env, TWEET_PIPELINE_BREAKER_PATH: breakerPath, ...extraEnv },
+        encoding: 'utf8',
+    });
+}
+
+describe('check-breaker CLI exit codes', () => {
+    it('exits 1 (CLOSED) when no marker file exists', () => {
+        const result = runCli();
+        assert.equal(result.status, 1);
+        assert.equal(result.stdout, '');
+    });
+
+    it('exits 0 (OPEN) when a valid unexpired marker exists', () => {
+        const future = new Date(Date.now() + 60_000).toISOString();
+        writeFileSync(breakerPath, JSON.stringify({
+            reason: 'test reason',
+            trippedAt: new Date().toISOString(),
+            expiresAt: future,
+        }));
+
+        const result = runCli();
+        assert.equal(result.status, 0);
+        assert.match(result.stdout, /test reason/);
+        assert.match(result.stdout, /expires/);
+    });
+
+    it('exits 1 (CLOSED) when the marker is expired', () => {
+        const past = new Date(Date.now() - 60_000).toISOString();
+        writeFileSync(breakerPath, JSON.stringify({
+            reason: 'expired',
+            trippedAt: past,
+            expiresAt: past,
+        }));
+
+        const result = runCli();
+        assert.equal(result.status, 1);
+    });
+
+    it('exits 1 (CLOSED) when the marker is corrupt — recoverable as closed', () => {
+        // A corrupt marker is treated as closed by isBreakerOpen() (it removes
+        // the file and returns null). This is intentional self-healing; only
+        // genuinely unexpected errors (e.g. fs permission denial) should hit
+        // exit-2. Test it stays in the "fail-recoverable" lane, not the
+        // "fail-open silently" lane.
+        writeFileSync(breakerPath, '{not json');
+        const result = runCli();
+        assert.equal(result.status, 1);
+    });
+
+    it('exit 2 is distinct from exit 1 (no fail-open collision with Node crash)', () => {
+        // This is the regression guarantee from Greptile review on #1309:
+        // Node's default uncaught-exception exit is 1, which previously
+        // collided with our "CLOSED, proceed" code. The CLI now wraps its
+        // body in try/catch and reserves 2 for errors. We can't easily force
+        // an internal crash from outside, but we can assert the documented
+        // codes (0, 1, 2) are all distinct and 1 is not used as a catch-all.
+        // The other tests in this file cover 0 and 1; here we assert the
+        // contract is documented.
+        const result = runCli();
+        assert.notEqual(result.status, 2, 'exit 2 must be reserved for errors only');
+        assert.ok([0, 1].includes(result.status), `unexpected exit ${result.status}`);
+    });
+});

--- a/tweet-pipeline/lib/twitter.js
+++ b/tweet-pipeline/lib/twitter.js
@@ -2,9 +2,33 @@
  * @fileoverview Twitter API v2 client for the tweet pipeline.
  * Wraps the twitter-api-v2 package with helpers for posting threads,
  * uploading media, and fetching engagement metrics.
+ *
+ * All write paths (postTweet, uploadMedia) consult the circuit breaker
+ * and trip it on non-recoverable account-level failures (HTTP 402
+ * CreditsDepleted) so the systemd timers don't generate a fresh GitHub
+ * issue every 10 minutes while credits are exhausted.
  */
 
 import { TwitterApi } from 'twitter-api-v2';
+import {
+    classifyTwitterError,
+    isBreakerOpen,
+    resetBreaker,
+    tripBreaker,
+} from './circuit-breaker.js';
+
+/**
+ * Thrown when a write call short-circuits because the breaker is open.
+ * Carries the breaker payload so callers can decide how to handle it
+ * (publish.sh / promote-blog.sh exit silently; tests inspect .breaker).
+ */
+export class CircuitBreakerOpenError extends Error {
+    constructor(payload) {
+        super(`Tweet pipeline circuit breaker is open: ${payload.reason} (expires ${payload.expiresAt})`);
+        this.name = 'CircuitBreakerOpenError';
+        this.breaker = payload;
+    }
+}
 
 /**
  * Formats a hook tweet and optional replies into a thread array.
@@ -50,21 +74,39 @@ export function createTwitterClient(creds) {
 
     /**
      * Uploads an image file to Twitter.
+     * Trips the circuit breaker on HTTP 402 CreditsDepleted.
      * @param {string} filePath - Absolute path to the image file.
      * @returns {Promise<string>} The media ID string.
+     * @throws {CircuitBreakerOpenError} if the breaker is already open.
      */
     async function uploadMedia(filePath) {
-        const mediaId = await v1.uploadMedia(filePath, { mimeType: 'image/png' });
-        return mediaId;
+        const open = isBreakerOpen();
+        if (open) throw new CircuitBreakerOpenError(open);
+
+        try {
+            const mediaId = await v1.uploadMedia(filePath, { mimeType: 'image/png' });
+            return mediaId;
+        } catch (err) {
+            const verdict = classifyTwitterError(err);
+            if (verdict) tripBreaker(verdict.reason);
+            throw err;
+        }
     }
 
     /**
      * Posts a single tweet.
+     * Trips the circuit breaker on HTTP 402 CreditsDepleted.
+     * Resets the breaker on a successful post (a brief outage shouldn't
+     * silence the pipeline for the full TTL once it self-resolves).
      * @param {string} text - The tweet text.
      * @param {{mediaId?: string, replyToId?: string}} [options={}] - Optional media and reply settings.
      * @returns {Promise<{id: string}>} The posted tweet's ID.
+     * @throws {CircuitBreakerOpenError} if the breaker is already open.
      */
     async function postTweet(text, options = {}) {
+        const open = isBreakerOpen();
+        if (open) throw new CircuitBreakerOpenError(open);
+
         const payload = { text };
 
         if (options.mediaId) {
@@ -75,8 +117,16 @@ export function createTwitterClient(creds) {
             payload.reply = { in_reply_to_tweet_id: options.replyToId };
         }
 
-        const result = await v2.tweet(payload);
-        return { id: result.data.id };
+        try {
+            const result = await v2.tweet(payload);
+            // Successful write — clear any stale breaker.
+            resetBreaker();
+            return { id: result.data.id };
+        } catch (err) {
+            const verdict = classifyTwitterError(err);
+            if (verdict) tripBreaker(verdict.reason);
+            throw err;
+        }
     }
 
     /**

--- a/tweet-pipeline/promote-blog.sh
+++ b/tweet-pipeline/promote-blog.sh
@@ -28,6 +28,15 @@ fi
 # Ensure we're in the right directory for Node.js imports
 cd "$SCRIPT_DIR"
 
+# Circuit breaker — bail fast if a non-recoverable account-level failure
+# (e.g. Twitter HTTP 402 CreditsDepleted) tripped the breaker. Avoids
+# spamming GitHub issues every 10 minutes while credits are depleted
+# (see #1289, #1290, #1307).
+if BREAKER_REASON=$(node lib/cli/check-breaker.js 2>/dev/null); then
+  log "Circuit breaker OPEN — skipping promo cycle. $BREAKER_REASON"
+  exit 0
+fi
+
 # Scan for published articles via GitHub API
 PROMOTED=0
 

--- a/tweet-pipeline/promote-blog.sh
+++ b/tweet-pipeline/promote-blog.sh
@@ -32,10 +32,20 @@ cd "$SCRIPT_DIR"
 # (e.g. Twitter HTTP 402 CreditsDepleted) tripped the breaker. Avoids
 # spamming GitHub issues every 10 minutes while credits are depleted
 # (see #1289, #1290, #1307).
-if BREAKER_REASON=$(node lib/cli/check-breaker.js 2>/dev/null); then
+#
+# Exit semantics: 0 = OPEN (skip), 1 = CLOSED (proceed), 2 = error (fail-open
+# with stderr surfaced).
+BREAKER_STDERR=$(mktemp)
+BREAKER_REASON=$(node lib/cli/check-breaker.js 2>"$BREAKER_STDERR")
+BREAKER_RC=$?
+if [ "$BREAKER_RC" -eq 0 ]; then
   log "Circuit breaker OPEN — skipping promo cycle. $BREAKER_REASON"
+  rm -f "$BREAKER_STDERR"
   exit 0
+elif [ "$BREAKER_RC" -eq 2 ]; then
+  log "WARNING: circuit breaker check errored, proceeding anyway: $(cat "$BREAKER_STDERR")"
 fi
+rm -f "$BREAKER_STDERR"
 
 # Scan for published articles via GitHub API
 PROMOTED=0

--- a/tweet-pipeline/promote-blog.sh
+++ b/tweet-pipeline/promote-blog.sh
@@ -35,9 +35,13 @@ cd "$SCRIPT_DIR"
 #
 # Exit semantics: 0 = OPEN (skip), 1 = CLOSED (proceed), 2 = error (fail-open
 # with stderr surfaced).
+#
+# IMPORTANT: under `set -euo pipefail` (line 4), `VAR=$(cmd)` aborts on cmd's
+# non-zero exit — including the breaker-closed path (exit 1). Pre-init
+# BREAKER_RC and use `|| BREAKER_RC=$?` so `set -e` is not triggered.
 BREAKER_STDERR=$(mktemp)
-BREAKER_REASON=$(node lib/cli/check-breaker.js 2>"$BREAKER_STDERR")
-BREAKER_RC=$?
+BREAKER_RC=0
+BREAKER_REASON=$(node lib/cli/check-breaker.js 2>"$BREAKER_STDERR") || BREAKER_RC=$?
 if [ "$BREAKER_RC" -eq 0 ]; then
   log "Circuit breaker OPEN — skipping promo cycle. $BREAKER_REASON"
   rm -f "$BREAKER_STDERR"

--- a/tweet-pipeline/promote-blog.sh
+++ b/tweet-pipeline/promote-blog.sh
@@ -161,17 +161,38 @@ ${BLOG_URL}"
     log "WARNING: No cover image for $SLUG — posting without image"
   fi
 
-  # Post the promo tweet
-  if ! RESULT=$(TWEET_TEXT="$TWEET_TEXT" MEDIA_ID="$MEDIA_ID" node --input-type=module -e "
-    import { createTwitterClientFromEnv } from './lib/twitter.js';
-    const client = createTwitterClientFromEnv();
-    const options = {};
-    if (process.env.MEDIA_ID && process.env.MEDIA_ID !== '') {
-      options.mediaId = process.env.MEDIA_ID;
+  # Post the promo tweet.
+  #
+  # Distinguish a breaker-open failure (mid-loop, e.g. uploadMedia tripped the
+  # breaker for the current article — every subsequent postTweet in this run
+  # will also fail with CircuitBreakerOpenError) from a genuine post failure.
+  # Without this branch, every remaining article in the loop would file its
+  # own GitHub issue via report_failure. Exit code 7 means breaker-open;
+  # any other non-zero is a real failure.
+  RESULT=""
+  POST_RC=0
+  RESULT=$(TWEET_TEXT="$TWEET_TEXT" MEDIA_ID="$MEDIA_ID" node --input-type=module -e "
+    import { createTwitterClientFromEnv, CircuitBreakerOpenError } from './lib/twitter.js';
+    try {
+      const client = createTwitterClientFromEnv();
+      const options = {};
+      if (process.env.MEDIA_ID && process.env.MEDIA_ID !== '') {
+        options.mediaId = process.env.MEDIA_ID;
+      }
+      const result = await client.postTweet(process.env.TWEET_TEXT, options);
+      console.log(JSON.stringify({ tweetId: result.id }));
+    } catch (err) {
+      if (err instanceof CircuitBreakerOpenError) {
+        console.error(err.message);
+        process.exit(7);
+      }
+      throw err;
     }
-    const result = await client.postTweet(process.env.TWEET_TEXT, options);
-    console.log(JSON.stringify({ tweetId: result.id }));
-  " 2>&1); then
+  " 2>&1) || POST_RC=$?
+  if [ "$POST_RC" -eq 7 ]; then
+    log "Circuit breaker tripped during promo loop — aborting remaining articles. $RESULT"
+    break
+  elif [ "$POST_RC" -ne 0 ]; then
     log "ERROR: Failed to post promo tweet for $SLUG: $RESULT"
     report_failure "Post tweet for $SLUG"
     continue

--- a/tweet-pipeline/publish.sh
+++ b/tweet-pipeline/publish.sh
@@ -35,6 +35,16 @@ fi
 
 cd "$SCRIPT_DIR"
 
+# Circuit breaker — bail fast if a non-recoverable account-level failure
+# (e.g. Twitter HTTP 402 CreditsDepleted) tripped the breaker on a previous
+# run. Without this, every 10-minute timer fire generates a fresh GitHub
+# issue while credits are depleted (see #1289, #1290, #1307). The breaker
+# self-clears on TTL or on the next successful post.
+if BREAKER_REASON=$(node lib/cli/check-breaker.js 2>/dev/null); then
+  log "Circuit breaker OPEN — skipping publish cycle. $BREAKER_REASON"
+  exit 0
+fi
+
 POSTED_COUNT=0
 MIN_GAP_MINUTES=90
 

--- a/tweet-pipeline/publish.sh
+++ b/tweet-pipeline/publish.sh
@@ -40,10 +40,20 @@ cd "$SCRIPT_DIR"
 # run. Without this, every 10-minute timer fire generates a fresh GitHub
 # issue while credits are depleted (see #1289, #1290, #1307). The breaker
 # self-clears on TTL or on the next successful post.
-if BREAKER_REASON=$(node lib/cli/check-breaker.js 2>/dev/null); then
+#
+# Exit semantics: 0 = OPEN (skip), 1 = CLOSED (proceed), 2 = error (fail-open
+# with stderr surfaced — don't silence the error or we lose all visibility).
+BREAKER_STDERR=$(mktemp)
+BREAKER_REASON=$(node lib/cli/check-breaker.js 2>"$BREAKER_STDERR")
+BREAKER_RC=$?
+if [ "$BREAKER_RC" -eq 0 ]; then
   log "Circuit breaker OPEN — skipping publish cycle. $BREAKER_REASON"
+  rm -f "$BREAKER_STDERR"
   exit 0
+elif [ "$BREAKER_RC" -eq 2 ]; then
+  log "WARNING: circuit breaker check errored, proceeding anyway: $(cat "$BREAKER_STDERR")"
 fi
+rm -f "$BREAKER_STDERR"
 
 POSTED_COUNT=0
 MIN_GAP_MINUTES=90

--- a/tweet-pipeline/publish.sh
+++ b/tweet-pipeline/publish.sh
@@ -43,9 +43,15 @@ cd "$SCRIPT_DIR"
 #
 # Exit semantics: 0 = OPEN (skip), 1 = CLOSED (proceed), 2 = error (fail-open
 # with stderr surfaced — don't silence the error or we lose all visibility).
+#
+# IMPORTANT: under `set -euo pipefail` (line 4), a plain VAR=$(cmd) assignment
+# aborts the whole script on cmd's non-zero exit — which on the breaker-closed
+# path (exit 1) would trip the ERR trap and call report_failure, defeating
+# the breaker entirely. Pre-init BREAKER_RC and use `|| BREAKER_RC=$?` so the
+# non-zero exit is absorbed and `set -e` is not triggered.
 BREAKER_STDERR=$(mktemp)
-BREAKER_REASON=$(node lib/cli/check-breaker.js 2>"$BREAKER_STDERR")
-BREAKER_RC=$?
+BREAKER_RC=0
+BREAKER_REASON=$(node lib/cli/check-breaker.js 2>"$BREAKER_STDERR") || BREAKER_RC=$?
 if [ "$BREAKER_RC" -eq 0 ]; then
   log "Circuit breaker OPEN — skipping publish cycle. $BREAKER_REASON"
   rm -f "$BREAKER_STDERR"


### PR DESCRIPTION
Two independent, complementary changes that prevent the recurring GitHub-issue cascades observed during the May 2026 triage round.

## 1. Tweet-pipeline circuit breaker (commit 449fef12)

Closes the loop on #1289 / #1290 / #1307 — once Twitter returns HTTP 402 `CreditsDepleted`, the pipeline now writes a 6h breaker marker. `publish.sh` and `promote-blog.sh` consult it at startup and exit silently if open. A successful post resets the breaker.

### Files
- `tweet-pipeline/lib/circuit-breaker.js` (new) — `tripBreaker` / `isBreakerOpen` / `resetBreaker` / `classifyTwitterError`
- `tweet-pipeline/lib/circuit-breaker.test.js` (new) — 15 tests
- `tweet-pipeline/lib/cli/check-breaker.js` (new) — shell-callable shim
- `tweet-pipeline/lib/twitter.js` — wire breaker into `postTweet` / `uploadMedia`
- `tweet-pipeline/publish.sh` / `promote-blog.sh` — preflight check

### Tests
`node --test lib/circuit-breaker.test.js lib/twitter.test.js` → **23/23 pass**. Pre-existing failures in `config.test.js` / `image-generator.test.js` are unrelated (baseline 63 pass / 5 fail; with this PR 78 pass / 5 fail).

### Behaviour
- 402 once → breaker trips for 6h. Every subsequent timer fire (~36 fires in 6h) logs one line and exits — **zero GitHub issues filed**.
- After 6h, breaker auto-clears. Next attempt either succeeds (credits topped up → breaker stays closed) or re-trips for another 6h.
- Operator can also `rm /var/lib/tweet-pipeline/circuit-breaker.json` to force an immediate retry.

## 2. Sentry scanner preflight + dedup (commit b1d9ce0e)

Closes the loop on #1301 / #1302 / #1303 / #1304 / #1305 — five issues from one outage cycle. The scanner now distinguishes three top-level states before doing any work:

| base `/api/0/` | authed `/api/0/projects/` | Verdict | Action |
|---|---|---|---|
| 2xx | 2xx | Healthy | Proceed to scan |
| 2xx | 401/403 | Token bad | AUTH_BROKEN handler |
| 5xx / unreachable | any | Service down | SERVICE_DOWN handler |

Both handlers `gh issue list` against the appropriate title and comment on an existing open issue from the last 24h instead of filing a new one. Adds an explicit rule forbidding the main scan from re-creating these infra-level issues.

### Files
- `.github/workflows/sentry-scanner.yml` — Step 0 preflight inserted before Step 1; rule added to Step 7

### Behaviour
- 4-minute outage with 24 scanner runs: 1 issue (or 0 new + N+1 comments), not N issues.
- Auth and outage states are now never conflated in the same issue.

## Verification

- YAML validated via `python3 -c "import yaml; yaml.safe_load(open(...))"."
- Tweet-pipeline tests pass locally with new files included.
- No backend / frontend code touched — no risk to live API.

## Notes
- Both changes are additive and gated; if either misbehaves, deleting the marker file (#1) or reverting Step 0 (#2) is safe and reversible.