### PR TITLE
docs: ArgoCD deploy mechanism + Sentry server config

### DIFF
--- a/.claude/references/SENTRY.md
+++ b/.claude/references/SENTRY.md
@@ -42,3 +42,31 @@ Standalone Vue 3 app at `sentry-dashboard/` served at `/sentry-dashboard` path. 
 ## CLI Access
 
 SSH into the Sentry server (see `.credentials.local` for host/IP), then `cd /opt/sentry && docker compose --env-file .env --env-file .env.custom exec -T web sentry shell` for Django shell access. API token with full scopes stored as `SENTRY_API_TOKEN` GitHub secret.
+
+## Server Configuration
+
+Self-hosted Sentry runs on a single Hetzner box (see `.credentials.local` for host). Config lives in `/opt/sentry/` (forked from `getsentry/self-hosted` v26.2.1). Two files matter for ops:
+
+- `/opt/sentry/.env` — environment overrides
+- `/opt/sentry/sentry/config.yml` — Sentry runtime config
+
+### Retention & Storage Policy
+
+This installation is **issues-only** (errors + stacktraces). Performance traces, replays, profiling, feedback, and attachments are all disabled or rejected at ingest.
+
+| Knob | Value | File | Why |
+|---|---|---|---|
+| `SENTRY_EVENT_RETENTION_DAYS` | `30` | `.env` | Reduced from default 90 to cap Postgres/Clickhouse/Kafka growth |
+| `system.options.max-attachment-size` | `0` | `sentry/config.yml` | Drops attachments at ingest. Stops seaweedfs blob store growing (it has no built-in retention) |
+
+**Disabled service containers** (`profiles: [disabled]` in `docker-compose.yml`): replays (`ingest-replay-recordings`, `snuba-replays-consumer`), profiling (`ingest-profiles`, `vroom`, `vroom-cleanup`, `snuba-profiling-*`), cron monitors (`ingest-monitors`, `monitors-clock-tasks`, `monitors-clock-tick`), feedback (`ingest-feedback-events`). Uptime monitoring kept enabled (watches `app.tryethernal.com/api/status/health`).
+
+**Re-apply after Sentry version upgrades**: the upstream `docker-compose.yml` does not preserve our disabled profiles, the `--auto-offset-reset=latest --no-strict-offset-reset` flags on `run consumer` commands (required to survive Kafka retention purges), or the `SENTRY_SYSTEM_SECRET_KEY` line in `.env`. Without these the stack will crash-loop on the next major upgrade.
+
+### Operational Notes
+
+- **Backup PG before retention reductions**: dropping `SENTRY_EVENT_RETENTION_DAYS` triggers the cleanup cron to purge old events on next run.
+- **Kafka volume cannot be partially deleted**: removing individual topic dirs while leaving `__cluster_metadata` causes KRaft to fail with NPE on restart. Either wipe `/var/lib/docker/volumes/sentry-kafka/_data/*` entirely or use `kafka-topics --delete`.
+- **Compose status lags reality**: after a stack restart, check for containers in `Created` state (not just `Up`) — they failed dependency checks and need `docker rm -f` + `docker compose up -d` to recreate properly.
+
+See incident history in memory file `incident-2026-05-01-hetzner-disk-full.md` for the two disk-full outages that led to this config.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -360,6 +360,15 @@ Ethernal is registered on [Karma](https://gap.karmahq.xyz/project/ethernal) (Opt
 
 ## Infrastructure & Secrets
 
+### K8s Cluster Deployment (ArgoCD GitOps)
+
+The k3s cluster lives on Hetzner (managed by Terraform in the [k8s-iac repo](https://github.com/tryethernal/k8s-iac), backend: azurerm). **All cluster changes flow through ArgoCD GitOps** — there is no `kubectl apply` workflow.
+
+- **App workloads, Helm charts, ConfigMaps, ExternalSecrets**: push to `master` in `k8s-iac` → ArgoCD auto-syncs within 20s. ArgoCD itself runs on the cluster's single worker node alongside everything else.
+- **Cluster provisioning (nodes, LB, firewall)**: `cd k3s && terraform apply` from a workstation with Azure auth — manual, no CI. Touches `k3s/*.tf`.
+- **Direct `kubectl patch/edit` will be reverted** by ArgoCD on the next sync. To make a change stick, edit the manifest in `k8s-iac` and merge.
+- **ArgoCD UI**: `https://argo.tryethernal.com`. Use it to inspect sync status, force-sync, or roll back to a previous git revision.
+
 ### K8s Secrets (ExternalSecrets + Azure Key Vault)
 
 K8s secrets in `ethernal-prod` are managed by **ExternalSecrets** syncing from **Azure Key Vault** (`ethernalkeyvault.vault.azure.net`), reconciled by **ArgoCD**. Direct `kubectl patch secret` will be reverted on the next sync cycle. To rotate a secret:


### PR DESCRIPTION
## Summary
- Add **K8s Cluster Deployment (ArgoCD GitOps)** subsection to CLAUDE.md explaining that push-to-master in `k8s-iac` is how cluster changes deploy. ArgoCD was previously mentioned only in passing.
- Add **Server Configuration** section to SENTRY.md covering retention knobs, disabled service containers, and operational gotchas. SENTRY.md previously documented the alert/auto-fix pipeline but said nothing about the self-hosted server itself.

Both gaps surfaced during tonight's Sentry disk-full outage triage — the durable fix (attachments disabled + 30d retention) is now in the project's reference docs, not just buried in an incident memory file.

## Test plan
- [ ] Render CLAUDE.md and SENTRY.md, verify formatting and link to k8s-iac repo works
- [ ] Future readers can answer "how do k8s changes deploy?" and "what's the Sentry retention policy?" from these docs alone

🧙 Built with [WOZCODE](https://wozcode.com)