### PR TITLE
chore: ignore local-only files; track AGENTS.md

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,7 +13,11 @@ seeders/private
 
 **/functions/report*
 
-# local env files
+# local env files. The **/.env.* glob misses a bare `.env`, which
+# Dockerfile.caddyfile and Dockerfile.frontend would otherwise embed via
+# their `COPY .env* ./` step — leaking VITE_SENTRY_AUTH_TOKEN and other
+# secrets into the image layer. Mirror the .gitignore fix.
+**/.env
 **/.env.*
 **/functions/.runtimeconfig.json
 ganache-db

--- a/.gitignore
+++ b/.gitignore
@@ -81,4 +81,18 @@ skills-lock.json
 # Session artifacts
 .claude/handoff-*.md
 .claude/plans/
+.claude/scheduled_tasks.lock
+.claude/settings.local.json
 generated_imgs/
+
+# Local env (secrets — repo is PUBLIC). The existing `.env.*` rule above
+# does NOT match a bare `.env`; add it explicitly to prevent leaking
+# tokens like VITE_SENTRY_AUTH_TOKEN.
+.env
+
+# Coding-agent workspace caches
+.factory/
+
+# Vite build caches (regenerated on each build)
+landing/.vite/
+sentry-dashboard/.vite/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,104 @@
+# Ethernal
+
+Open-source block explorer for EVM-based chains. Monorepo with Vue 3 frontend, Node.js/Express backend, PostgreSQL (TimescaleDB), and Redis/BullMQ.
+
+## Project Layout
+
+```
+src/              → Vue 3 + Vuetify frontend (Vite, yarn)
+run/              → Express backend + Sequelize ORM (npm)
+run/api/          → API route handlers
+run/lib/          → Core libraries (firebase.js = data access layer)
+run/models/       → Sequelize models
+run/migrations/   → Database migrations
+run/jobs/         → BullMQ background jobs
+run/workers/      → BullMQ worker processes
+run/middlewares/   → Auth & workspace middleware
+run/tests/        → Backend tests (Jest)
+tests/unit/       → Frontend tests (Vitest)
+landing/          → Marketing site (Vue 3, Vite SSG, npm)
+blog/             → Blog (Astro + Tailwind, npm)
+pm2-server/       → PM2 process manager for L2 listeners (npm)
+tweet-pipeline/   → Twitter automation (shell scripts)
+scripts/          → Operational scripts
+```
+
+## Build, Lint & Test
+
+All local dev runs through Docker Compose. Never run npm/yarn directly on the host.
+
+```bash
+# Start all services
+docker compose -f docker-compose.dev.yml up postgres redis backend frontend soketi high_priority_worker pgbouncer landing blog caddy -d
+
+# Frontend tests (Vitest, jsdom, @vue/test-utils)
+docker compose -f docker-compose.dev.yml exec frontend yarn test
+
+# Backend tests (Jest, supertest)
+docker compose -f docker-compose.dev.yml exec backend npm test tests/
+
+# Frontend lint (ESLint + eslint-plugin-vue + eslint-plugin-vuetify)
+docker compose -f docker-compose.dev.yml exec frontend yarn lint
+
+# Backend lint
+docker compose -f docker-compose.dev.yml exec backend npx eslint --fix .
+
+# Run single backend test
+docker compose -f docker-compose.dev.yml exec backend npx jest tests/api/myTest.test.js
+
+# Database migration
+docker compose -f docker-compose.dev.yml exec backend npx sequelize db:migrate
+```
+
+If Docker is unavailable, CI runs tests locally:
+- Frontend: `yarn && FORCE_COLOR=true vitest run`
+- Backend: `cd run && npm install && npm test tests/`
+
+## Architecture
+
+- **Request flow:** Vue → `$server` plugin (src/plugins/server.js) → HTTP → API route (run/api/) → Middleware → firebase.js (data access) → Sequelize models
+- **Auth:** JWT via `authMiddleware` and `workspaceAuthMiddleware` (run/middlewares/)
+- **Multi-tenancy:** All queries filter by `workspaceId` (Workspace is the boundary)
+- **Entity hierarchy:** User → Workspace (many) → Explorer (1) + Blocks/Transactions/Contracts
+- **Background jobs:** BullMQ queues (run/jobs/, run/queues.js). Always `throw new Error()` on failure, never return strings.
+- **WebSocket:** Soketi (Pusher-compatible). Frontend Pusher client must NOT set `wsPath`.
+
+## Package Managers & Node
+
+- **Root (frontend):** yarn, `type: "module"` (ESM)
+- **run/ (backend):** npm, CommonJS
+- **landing/:** npm, ESM
+- **blog/:** npm, ESM
+- **pm2-server/:** npm, CommonJS
+- **Node version:** 18+ (CI), 20 (Docker)
+
+## Conventions
+
+- `@/` alias for imports from `src/` in frontend
+- ESLint only (no Prettier): `no-multi-spaces`, `no-trailing-spaces`, `eol-last`, single quotes in backend
+- JSDoc on all new files and functions. Vue: `@fileoverview`, `@component`, `@prop`, `@emits`
+- Sequelize migrations for all schema changes (never raw SQL). Use `CREATE INDEX CONCURRENTLY` for large tables.
+- Error handling: `managedError()` for expected (400), `unmanagedError()` for unexpected (500, Sentry)
+- Never hardcode credentials in any file. Repo is PUBLIC.
+- `withTimeout(promise, ms)` from `run/lib/utils` instead of inline Promise.race
+
+## Git Workflow
+
+- Branch from `develop` (default branch), never `master`
+- PRs target `develop`
+- Release: tag on develop → CI runs tests → create_release → run_migrations → deploy to Fly.io
+- Blog/landing changes auto-deploy on push to `develop`
+
+## CI/CD
+
+- GitHub Actions: `.github/workflows/test_and_deploy.yml`
+- Tests run on every push (frontend + backend in parallel)
+- Deploy on version tags (`v*`): Fly.io (backend, Caddy, PM2, Soketi)
+- Docker images: multi-arch (amd64 + arm64), pushed to Fly.io registry + Docker Hub
+
+## Key Environment
+
+- Local Caddy proxy: `ethernal.local:8180` (landing), `app.ethernal.local:8180` (app)
+- Raw ports: landing=8174, blog=8176, app=8080, backend=8888
+- Postgres: TimescaleDB on port 8432 (local), PgBouncer on 8433
+- Redis: port 8379 (local)


### PR DESCRIPTION
Repo hygiene fix.

## Problem

`git status` on a fresh checkout listed 7 untracked items. All but one were either secrets, build caches, or per-developer files that would corrupt commits if anyone ran `git add .`. Most consequentially:

- **Bare `.env` was NOT gitignored.** The existing `.env.*` rule matches dotted suffixes only. The local `.env` in my working tree contains `VITE_SENTRY_AUTH_TOKEN=6bcc18…` — a real Sentry secret. **This repo is public.** One `git add .env && git commit -m 'wip'` away from a public token leak.

## Changes

### .gitignore additions
| Pattern | Reason |
|---|---|
| `.env` (bare) | Plug the secret-leak hole |
| `.factory/` | Coding-agent workspace cache |
| `landing/.vite/` | Vite build cache (regenerated on each build) |
| `sentry-dashboard/.vite/` | Same |
| `.claude/scheduled_tasks.lock` | Runtime lockfile |
| `.claude/settings.local.json` | Per-developer overrides |

### Tracking AGENTS.md

`AGENTS.md` is the OpenCode-standard agent spec doc — analogous to the already-tracked `CLAUDE.md`, but for AGENT.md-aware tools (Codex, OpenCode, Cursor, etc.). It contained generic project context (no secrets) and was clearly intended to be shared. Adding it to git.

## Verification

```bash
$ git status --short
# (empty)

$ git check-ignore -v .env .factory/ landing/.vite/ sentry-dashboard/.vite/ .claude/scheduled_tasks.lock .claude/settings.local.json
.gitignore:91:.env      .env
.gitignore:94:.factory/ .factory/
.gitignore:97:landing/.vite/    landing/.vite/
.gitignore:98:sentry-dashboard/.vite/   sentry-dashboard/.vite/
.gitignore:84:.claude/scheduled_tasks.lock      .claude/scheduled_tasks.lock
.gitignore:85:.claude/settings.local.json       .claude/settings.local.json
```

## Note for the user

The `VITE_SENTRY_AUTH_TOKEN` in your local `.env` is **already exposed locally** but not committed. After this merges, you should still consider rotating that token if it was ever in any pushed branch or shared elsewhere — and double-check it's set as a GitHub Actions secret, not a hardcoded file.