### PR TITLE
fix(block): lazy-require enqueue inside afterCreate (#1318)

### DIFF
--- a/run/models/block.js
+++ b/run/models/block.js
@@ -25,7 +25,11 @@ const {
 const moment = require('moment');
 
 const { trigger } = require('../lib/pusher');
-const { enqueue, bulkEnqueue } = require('../lib/queue');
+// NOTE: `enqueue`/`bulkEnqueue` are intentionally NOT destructured at module load.
+// `lib/queue` is part of a circular load chain (models/block → lib/queue → lib/queueCaps
+// → models/*), and a top-level destructure here can capture `undefined` if this file
+// loads while lib/queue is still mid-init. Resolve at hook-call time instead — by then
+// require cache is populated. See issue #1318 for the failure mode + stack trace.
 const { getNodeEnv } = require('../lib/env');
 
 const STALLED_BLOCK_REMOVAL_DELAY = getNodeEnv() == 'production' ? 5 * 60 * 1000 : 15 * 60 * 1000;
@@ -148,6 +152,8 @@ module.exports = (sequelize, DataTypes) => {
      */
     async afterCreate(options) {
         const afterCreateFn = async () => {
+            const { enqueue, bulkEnqueue } = require('../lib/queue');
+
             if (Date.now() / 1000 - this.timestamp < 60 * 10)
                 trigger(`private-blocks;workspace=${this.workspaceId}`, 'new', { number: this.number, withTransactions: this.transactionsCount > 0 });
 


### PR DESCRIPTION
## Summary
- Move `const { enqueue, bulkEnqueue } = require('../lib/queue')` from the top of `models/block.js` into the `afterCreate` hook body
- Add a comment pointing to the failure mode + issue

## Why
On 2026-04-25, ws 15537 (`hyperliquid_testnet`) produced 8 failed `blockSync` jobs, all with the same stack:

```
TypeError: enqueue is not a function
    at Transaction.afterCreateFn (/app/models/block.js:157:23)
    at Transaction.commit (...)
    at module.exports [as blockSync] (/app/jobs/blockSync.js:484:29)
```

A top-level destructure of `lib/queue` is fragile because `lib/queue` is part of a circular load chain (`models/block → lib/queue → lib/queueCaps → models/*`). If a model file lands mid-load while `lib/queue`'s `module.exports = {...}` reassignment hasn't run yet, the destructure captures `undefined` and the hook closure holds it forever — throwing whenever the hook fires.

`lib/queueCaps.js:52-55` already lazy-requires models for the exact same reason. Applying the same fix here.

Has not recurred in 30 days, so this is preventive / defensive — not a hot incident. Only `block.js` is touched in this PR (proven failure site). Other model files with the same pattern (contract.js, explorer.js, workspace.js, etc.) are documented in issue #1318 for a follow-up cleanup PR.

## Test plan
- [x] `jest tests/jobs/blockSync.test.js tests/lib/queue.test.js` — 35 passing
- [ ] Post-deploy: confirm no new `enqueue is not a function` failures on `bull:blockSync:failed`

Closes #1318

🤖 Generated with [Claude Code](https://claude.com/claude-code)