### PR TITLE
feat(seo): search-feedback sprint — GSC-driven CTR rewrites, converter/explorer targeting, launch page

### DIFF
--- a/.claude/references/SERP-INTEGRATION-PLAN.md
+++ b/.claude/references/SERP-INTEGRATION-PLAN.md
@@ -1,0 +1,313 @@
+# SERP/GSC/DataForSEO Integration Plan (porting ronda's feedback loop)
+
+Plan to port ronda's search-feedback blog pipeline (GSC signals, DataForSEO keyword
+enrichment, SERP coverage hints, refresh-mode) into ethernal-marketing's pipeline.
+
+**Status:** Proposal. Not yet implemented.
+**Source of truth studied:** `~/projects/ronda/blog/pipeline/` + ronda design docs
+(`docs/superpowers/specs/2026-05-25-blog-keyword-enrichment-design.md`,
+`docs/superpowers/handoffs/2026-05-27-blog-pipeline-sensai-integration.md`) +
+ronda `.claude/rules/seo-geo.md` + Ronda Multica workspace RON-107…RON-211.
+
+---
+
+## 1. The two pipelines side by side
+
+| Dimension | ronda | ethernal-marketing |
+|---|---|---|
+| Lang/runtime | Node ESM `.mjs`, self-contained | Node ESM `.js`, self-contained |
+| Discovery | RSS/arXiv/HN/Reddit/PH/GH + **GSC content-gap** | EIPs/ERCs/ethresear.ch/Magicians/arXiv + Google Trends |
+| Backlog store | **Multica issues** (`blog:` prefix, JSON-meta block) | **GitHub Projects V2** draft cards |
+| Topic pick | `pick-next.mjs` (GSC refresh vs backlog, funnel bias) | `project.js` `pickNextTopic` (round-robin by cluster) |
+| Draft engine | 3-phase Claude (research/draft/humanize) + 3b verify + GEO score | 3-phase Claude (research/draft/humanize) |
+| Keyword data | **DataForSEO enrichment** (`enrich-keywords.mjs`) | none |
+| SERP grounding | **`serp-terms.mjs`** (term/entity coverage at draft time) | none |
+| Search feedback | **`gsc.mjs`** 5 signals → new/refresh decision | none |
+| Refresh mode | **`refresh.mjs`** (quick-win/decay/ctr strategies) | none (recycles Published cards instead) |
+| Sitemap ping | `submit-sitemap.mjs` post-merge GH Action | none |
+| Schedule | Multica autopilots (cron) | systemd timers on Hetzner |
+
+The **engine architecture is identical** (3-phase Claude, cluster scoring, content
+types, em-dash-free humanize, References footer, GEO/answer-first posture). The gap is
+entirely the **search feedback layer**: ronda closes the loop with real Google data;
+ethernal does not.
+
+### The biggest single discovery
+
+The ronda GSC service account — `ethernal@ethernal-493613.iam.gserviceaccount.com`
+— **already owns BOTH `sc-domain:useronda.com` AND `sc-domain:tryethernal.com`**
+(verified in the handoff doc, `sites.list` returns both, both `siteOwner`). So:
+
+- The credential that powers ronda's GSC integration **already has read access to
+  `tryethernal.com` Search Console data**. No new GCP project, no new SA, no GSC UI
+  user-add dance (which is the exact thing that blocked ronda for a day — see RON-112).
+- `gsc.mjs` is already parameterized by `--site`. Pointing it at
+  `sc-domain:tryethernal.com` is a one-flag change.
+
+This collapses the single hardest part of ronda's rollout (the auth gotcha that ate a
+day and leaked two credentials in chat) into "reuse the existing key."
+
+---
+
+## 2. Prompt differences (what ronda's prompts have that ethernal's don't)
+
+ethernal's `prompts/2-draft.md` is 102 lines and already covers: voice, citations,
+GEO/answer-first leading sentences, comparison-listicle structure, tables as extraction
+targets, FAQ + FAQPage JSON-LD, research-depth (named customers/stats). It is a *good*
+GEO prompt already.
+
+ronda's `prompts/2-draft.md` (252 lines) adds layers ethernal lacks:
+
+1. **Search-grounding block** (lines 20-52). Hard contract: `primaryKeyword` MUST appear
+   in title + slug + first 150 words; `keywordsEnriched[]` phrases woven naturally;
+   explicit "if the keyword doesn't fit the angle, comment on the issue and use the
+   secondary, do not contort the post" escape hatch. **ethernal has no keyword input at
+   all** — this is the enrichment consumer.
+
+2. **SERP coverage targets block** (lines 5-16). Reads `/tmp/serp-terms.json` (`terms[]`,
+   `entities[]`, `relatedSearches[]`, `peopleAlsoAsk[]`) as *soft* hints. Anti-stuffing
+   rule is non-negotiable; the humanize phase enforces. **ethernal has no SERP grounding.**
+
+3. **Princeton GEO study citations** (arXiv:2311.09735) made load-bearing: direct quotes
+   (+27% citation visibility), statistics over adjectives (+25-37%), source citations
+   (+25%). ronda's `1-research.md` *requires gathering* ≥1 verbatim attributed quote and
+   concrete stats during research so the draft can use them. ethernal's research prompt
+   is lighter on this.
+
+4. **The hook frames the DECISION, not item #1** (lines 138-140, 162). A subtle but high-
+   value anti-redundancy rule for listicles/comparisons: orient-then-answer, never
+   cold-open, never pre-write the winner's pitch in the hook. ethernal's prompt doesn't
+   have this nuance.
+
+5. **References table as a hard schema** (lines 191-214): `| Source | Author/Org | Year |
+   Supports |`, one row per cited source, fails the build if missing. ethernal uses a
+   looser numbered-footnote `<sup>[N](#fn-N)</sup>` + `## References` style. Both work;
+   ronda's is more machine-auditable (feeds the 3b source-verification subagent).
+
+6. **`draft: true` hidden-draft gate** — ronda ships every new post as a hidden draft for
+   human review. ethernal **publishes directly to develop with no review** (per
+   MARKETING.md). This is a deliberate philosophy difference, **keep ethernal's** unless
+   we want to add review friction.
+
+7. **Scored GEO rubric** (`5-geo-score.md`, 6 weighted dims, 7.5/10 pass gate) +
+   **parallel verify subagents** (`3b-verify-sources.md`). ethernal's humanize is a single
+   pass. This is the quality-gate upgrade, separable from the search-feedback work.
+
+**Recommendation on prompts:** port items 1-5 (search/SERP grounding + GEO depth). Defer
+6 (keep ethernal's no-review publish) and 7 (scored rubric — nice-to-have, ship after the
+feedback loop proves out).
+
+---
+
+## 3. The process / data flow ronda runs (what we're porting)
+
+```
+WEEKLY (trend scan):
+  collect.mjs ──→ classify.mjs ──→ enrich-keywords.mjs ──→ (issues)
+   + gsc-gap                          (DataForSEO volume,
+   demand                              +30% cap on score)
+
+EVERY 2 DAYS (draft):
+  pick-next.mjs                          (GSC: quickWin/decay/ctr → refresh
+    │                                     OR backlog → new, funnel-biased)
+    ├── mode: refresh ──→ refresh.mjs ──→ targeted edits + chore(blog): refresh
+    └── mode: new ──→ enrich (re-fresh stale kw) ──→ serp-terms.mjs ──→
+                      research ──→ draft ──→ humanize ──→ feat(blog): publish
+
+POST-MERGE:
+  submit-sitemap.mjs (GH Action) ──→ GSC sitemap re-ping
+```
+
+Five GSC signals (`gsc.mjs`), all best-effort/exit-0:
+
+| Signal | Window | Filter | Drives |
+|---|---|---|---|
+| siteSnapshot | 28d | aggregate | health line |
+| quickWins | 28d | impressions≥50, pos 4–15 | **refresh** (almost-ranking) |
+| contentGaps | 90d | impressions≥20, pos>20 | **new post** (unserved demand) |
+| contentDecay | 28d vs prior | clicks −30% (≥5 baseline) | **refresh** (defensive) |
+| ctrOpportunities | 28d | impr≥100, CTR ≤50% expected | **refresh title/meta only** |
+
+Two bright lines from ronda's design (carry them verbatim):
+
+- **Keyword volume enriches editorial candidates; it never sources them.** Boost capped at
+  30% of editorial score. A candidate below the classify threshold is never enriched. This
+  prevents "best CRM 2026"-shaped SEO slop.
+- **`serp-terms.mjs` is draft-time grounding only.** It MUST NOT feed classify scoring or
+  candidate creation. Soft hints, never density quotas.
+
+---
+
+## 4. The adaptation problem: Multica issues vs GitHub Projects
+
+ronda's `pick-next.mjs` reads Multica issues; ethernal's `pickNextTopic` reads GitHub
+Projects V2 cards. This is the **only structural rewrite** required. Two options:
+
+**Option A (recommended): keep GitHub Projects, port the logic into `project.js`.**
+- `gsc.mjs`, `enrich-keywords.mjs`, `serp-terms.mjs`, `keyword-providers/dataforseo.mjs`,
+  `refresh.mjs`, `submit-sitemap.mjs` port almost verbatim (they're store-agnostic except
+  pick-next/refresh path resolution).
+- Rewrite `pick-next.mjs`'s backlog read to call `getProjectItems()` instead of
+  `multica issue list`. The GSC-refresh half is store-agnostic and ports directly.
+- Enrichment writes the `keywordsEnriched`/`primaryKeyword`/`finalScore` fields into the
+  **card body** (already free-form markdown in `buildCardBody`) + optionally a new
+  `Primary Keyword` / `Final Score` custom field on the board.
+- `contentGaps` become new draft cards via `createProjectCard` with a synthetic
+  `source: 'gsc-gap'` item.
+
+**Option B: migrate ethernal's blog backlog to a Multica workspace** (there is no Ethernal
+workspace today — only Capo/Better-UI/Ronda/Tenanture). Heavier; gains the autopilot
+tooling but throws away the working GitHub Projects integration and the systemd-timer
+deploy. **Not recommended** unless there's an independent reason to adopt Multica here.
+
+Go with **Option A**.
+
+---
+
+## 5. Concrete work plan (phased, each independently shippable)
+
+Mirror ronda's phased rollout — every phase is dead-safe on its own (broken search layer
+degrades to exactly today's behavior).
+
+### Phase 0 — Schema + cred plumbing (0.5 day)
+- Add `keywords: z.array(z.string()).default([])` to `blog/src/content.config.ts`
+  (additive, existing posts still build — they default to `[]`).
+- Add to `/opt/blog-pipeline.env` on Hetzner: `DATAFORSEO_LOGIN`, `DATAFORSEO_PASSWORD`,
+  and `GSC_SERVICE_ACCOUNT_JSON_B64` (base64 of the existing ronda/ethernal SA key —
+  it already owns `tryethernal.com`). Store actual values ONLY in `.credentials.local`
+  / env file, never in the repo (this repo is PUBLIC).
+- Add `blog/pipeline/.cache/` to `.gitignore`.
+- `cd blog/pipeline && npm i googleapis` (for `gsc.mjs`).
+
+### Phase 1 — GSC client + signals (1 day) [port `gsc.mjs`]
+- Copy `gsc.mjs` verbatim. Change `DEFAULT_SITE` to `sc-domain:tryethernal.com`.
+- Keep the cred-resolution order, the graceful-skip contract, the temp-file cleanup.
+- Smoke: `node gsc.mjs --site sc-domain:tryethernal.com` → real data (this property has
+  far more history than useronda.com did, so expect richer signals immediately).
+
+### Phase 2 — DataForSEO keyword enrichment (1-1.5 days) [port `dataforseo.mjs` + `enrich-keywords.mjs`]
+- Copy `keyword-providers/dataforseo.mjs` verbatim (both `fetchKeywordIdeas` and
+  `fetchSerpOrganic`).
+- Port `enrich-keywords.mjs`, adapting seed extraction to ethernal's cluster shape
+  (`config.js` `CLUSTERS` keywords). **Critical:** ethernal's clusters are technical
+  (e.g. "ERC-4337", "rollup", "zero knowledge") — these are already multi-word/distinctive,
+  which is exactly the seed strategy ronda landed on (multi-word only, never single-word
+  ambiguous nouns). The "feature flag only ever means software" logic applies even more
+  cleanly to "account abstraction" / "encrypted mempool".
+- Re-validate the volume ceiling. ronda capped at 10k for a 0-DR consumer domain;
+  `tryethernal.com` is a higher-authority dev-tooling domain with niche B2B queries — the
+  50–500/mo band still dominates, but revisit the ceiling after first run.
+- Port `keyword-blacklist.json` (competitor names: Etherscan, Blockscout, Routescan, Alchemy,
+  Infura, etc. — ethernal already has compare pages for these).
+- Wire into the weekly run (`index.js`): after `classifyAndScore`, before card creation,
+  run enrichment and write `finalScore` + keyword block into the card body.
+
+### Phase 3 — SERP coverage hints (0.5 day) [port `serp-terms.mjs`]
+- Copy `serp-terms.mjs` verbatim. It's pure (term/entity extraction + cache); no ethernal-
+  specific changes beyond the UA string and cache path.
+- In `draft.sh`, before Phase 1 research, run `serp-terms.mjs --keyword "$PRIMARY_KW"` →
+  `.serp-terms.json` when a primary keyword exists.
+- Add the SERP-coverage + search-grounding blocks to `prompts/2-draft.md` and the SERP-
+  context paragraph to `prompts/1-research.md` (port items 1-2 from §2).
+
+### Phase 4 — GSC-driven pick + refresh (1.5-2 days) [adapt `pick-next.mjs`, port `refresh.mjs`]
+- Add a `--gsc` mode to `index.js`/`project.js`: before the round-robin backlog pick,
+  call `fetchGscSignals({ site: 'sc-domain:tryethernal.com' })`; map `quickWins`/
+  `contentDecay`/`ctrOpportunities` pages → blog slugs (`slugFromPageUrl`, adapt the
+  `/blog/<slug>` URL pattern to ethernal's blog URL structure) → existing post files in
+  `blog/src/content/blog/`.
+- If a signal maps to a real post → emit `{mode:'refresh', signal, slug, metrics}`;
+  else fall through to `pickNextTopic`.
+- Port `refresh.mjs` (the three strategies: `expand_for_query`, `verify_and_update`,
+  `rewrite_title_meta_only`). Adapt `BLOG_POSTS_DIR` and the frontmatter parser to
+  ethernal's schema (no `updatedDate` field yet — add `updatedDate` to the Zod schema and
+  render it in the post layout, mirroring ronda PR 2.1).
+- `draft.sh` branches on mode: refresh → targeted edits + `chore(blog): refresh` style
+  commit; new → existing flow. Note ethernal publishes directly to develop, so "refresh"
+  is a direct commit, not a draft PR.
+- `contentGaps` → new cards in the weekly scan (synthetic `gsc-gap` source items).
+
+### Phase 5 — Sitemap re-ping (0.25 day) [port `submit-sitemap.mjs`]
+- Copy `submit-sitemap.mjs`, point at `tryethernal.com` sitemaps.
+- The existing SA must be **Owner** (not just full-user) of the GSC property to submit
+  sitemaps (ronda gotcha, `seo-geo.md` line 25). Verify the ethernal SA's role on
+  `sc-domain:tryethernal.com`; promote to Owner if needed.
+- Wire a GH Action on push-to-develop touching `blog/src/content/blog/**` (ethernal already
+  auto-deploys blog changes on develop — add the ping step there).
+
+### Phase 6 (optional, defer) — quality gates
+- Scored GEO rubric (`5-geo-score.md`) + parallel verify subagents (`3b-verify-sources.md`).
+- Funnel-position tagging + 80/20 TOFU/MOFU bias (`stats.mjs`). Lower priority for a
+  technical dev-tooling blog than for ronda's PM/designer funnel.
+
+---
+
+## 6. Cost, risk, and the bright lines
+
+**Cost.** DataForSEO: enrichment ~$0.075/1000 keywords (cents per weekly run);
+`serp/google/organic/live/advanced` ~$0.002-0.006/call, one per new-post draft. GSC API:
+free. Total: well under $5/mo. 30-day keyword cache + 7-day SERP cache keep it near-zero.
+
+**Risk register (all mitigated by the best-effort contract):**
+- DataForSEO down/quota (cf. ronda RON-136 "DataForSEO 402 enrichment down") → enrichment
+  no-ops, `finalScore === score`, pipeline produces identical candidate set. **Verified
+  contract in `enrich-keywords.mjs`: exit 0 always.**
+- GSC SA rotated/revoked → `gsc.mjs` returns `{status:'skipped'}`, pick falls through to
+  backlog. No crash.
+- Cross-project SA coupling: the GSC key belongs to GCP project `ethernal-493613`. For
+  ethernal-marketing this is actually the *natural* owner (it's the ethernal project),
+  removing ronda's RON-112 tech-debt entirely on this side.
+
+**The two invariants to enforce in code review (copy from ronda):**
+1. Keyword volume enriches, never sources, candidates. Boost ≤30% of editorial score.
+   Candidates below threshold are never enriched.
+2. `serp-terms.mjs` is draft-time grounding only. It never touches `classify.js` scoring
+   or card creation. classify output must be byte-identical before/after the module exists.
+
+**Secrets discipline (repo is PUBLIC):** never commit `DATAFORSEO_*`, the GSC SA JSON, or
+the base64. Reference by name only; values live in `.credentials.local` and
+`/opt/blog-pipeline.env`.
+
+---
+
+## 7. Files to create/modify in ethernal-marketing
+
+New (ported from ronda, near-verbatim):
+- `blog/pipeline/gsc.mjs`
+- `blog/pipeline/enrich-keywords.mjs`
+- `blog/pipeline/serp-terms.mjs`
+- `blog/pipeline/keyword-providers/dataforseo.mjs`
+- `blog/pipeline/keyword-blacklist.json`
+- `blog/pipeline/refresh.mjs`
+- `blog/pipeline/submit-sitemap.mjs`
+- `.github/workflows/blog-submit-sitemap.yml`
+
+Modify:
+- `blog/pipeline/index.js` (wire enrichment into weekly run; add `--gsc` pick path)
+- `blog/pipeline/project.js` (write keyword/finalScore to card body; GSC-refresh branch;
+  `gsc-gap` cards)
+- `blog/pipeline/classify.js` (optional: keep store-agnostic; no scoring change needed)
+- `blog/pipeline/config.js` (keyword weight `scoreBonus.keywordVolume`, volume floors/
+  ceilings, optional per-cluster `enrichmentEnabled`)
+- `blog/pipeline/prompts/1-research.md` (SERP context + GEO gathering)
+- `blog/pipeline/prompts/2-draft.md` (search-grounding + SERP-coverage blocks)
+- `blog/pipeline/draft.sh` (serp-terms pre-flight; refresh-mode branch)
+- `blog/pipeline/package.json` (add `googleapis`)
+- `blog/pipeline/.gitignore` (add `.cache/`)
+- `blog/src/content.config.ts` (add `keywords` + `updatedDate`)
+- `blog/src/.../PostLayout` (render "Updated: <date>" + JSON-LD `dateModified`)
+- `.claude/references/MARKETING.md` (document the new search-feedback layer)
+
+---
+
+## 8. Open questions to resolve before building
+
+1. **GSC SA Owner role on `tryethernal.com`?** Sitemap submit needs Owner. Confirm /
+   promote. (Read access for signals is already confirmed via `sites.list`.)
+2. **Blog URL → slug mapping.** ronda assumes `/blog/<slug>`. Confirm ethernal's blog URL
+   structure (`tryethernal.com/blog/<slug>`?) so `slugFromPageUrl` maps correctly.
+3. **Keep direct-publish or add hidden-draft review?** ronda gates new posts behind
+   `draft: true` for human review; ethernal auto-publishes. Recommend keeping auto-publish
+   for now; the GEO/scored-rubric gate (Phase 6) is the quality safety net if drift appears.
+4. **Volume ceiling for a higher-authority domain.** Re-tune after the first enriched run
+   against `tryethernal.com`'s actual GSC ranking data.

--- a/.claude/references/SERP-RESEARCH-FINDINGS.md
+++ b/.claude/references/SERP-RESEARCH-FINDINGS.md
@@ -1,0 +1,157 @@
+# SERP Research Findings — tryethernal.com (live run)
+
+Live run of the ported ronda SERP stack (GSC signals + DataForSEO keyword volume +
+`serp-terms.mjs` coverage) against `sc-domain:tryethernal.com`, using the existing
+`~/.credentials/gsc-ronda.json` (reads tryethernal.com) and `~/.credentials/dataforseo-ronda`.
+
+**Run date:** see git. **28-day baseline:** 8,441 impressions, 77 clicks, avg pos 11.0,
+CTR 0.91%. Signals: 18 content gaps, 6 quick wins, 9 CTR opportunities, 3 decaying pages.
+
+> **Read this caveat first.** DataForSEO's Google-Ads volume is **bucketed/zero for niche
+> dev queries** (the exact failure ronda's spec flagged). For our queries, **GSC impression
+> counts are the more reliable demand signal** — they're *our actual observed demand*, not a
+> third-party estimate. Where DataForSEO returned real volume (head terms), it's noted.
+
+---
+
+## The four opportunities, by priority
+
+### 1. Converter utility pages — fix ranking, not write a blog post  ⭐ highest leverage
+
+GSC content gaps are dominated by **unit-converter queries** we rank for on page 3-4:
+
+| Query | GSC impr (90d) | GSC pos | DataForSEO vol |
+|---|---|---|---|
+| wei to eth | 119 | 26.9 | (bucketed ~0) |
+| gwei to eth | 83 | 38.5 | (bucketed ~0) |
+| wei to ether | 31 | 39.3 | **260/mo, LOW** |
+| eth to wei | 25 | 30.4 | (bucketed ~0) |
+| gwei to wei | — | — | 30/mo, LOW |
+| wei converter | — | — | 50/mo, LOW |
+
+We already own `landing/src/pages/tools/UnitConverterPage.vue` — and it surfaces in CTR
+opportunities at **position 24, 380 impressions, 0.26% CTR**. The page exists and ranks
+badly. SERP for "wei to eth" shows pure converter intent (entities: Unit Converter, Ether,
+Gwei, Wei, Finney, Szabo; PAA: "How much is 1 ETH in Wei?", "How much is 1 wei?", "What is
+a wei Ethereum?", "How much is 1 Wei in dollars?").
+
+**Action: on-page SEO for the converter tool, not a blog post.**
+- Add per-pair landing routes/anchors (`/tools/unit-converter#wei-to-eth`, gwei-to-eth, etc.)
+  or dedicated thin pages with the query as H1.
+- Answer the 4 PAA questions inline (answer-first, ≤60 words each) — these are extractable.
+- Add HowTo/FAQ-legible content + a worked example with real numbers.
+- This is the clearest-intent, we-already-have-the-asset, lowest-effort win in the dataset.
+
+### 2. "EVM explorer / block explorer hosting" — quick wins at pos 5-15, 0% CTR  ⭐ blog/landing
+
+Money keywords where we're *almost* on page 1 but getting **zero clicks**:
+
+| Query | GSC impr (28d) | GSC pos | CTR | DataForSEO vol |
+|---|---|---|---|---|
+| block explorer hosting | 121 | 5.8 | 0.82% | (bucketed) |
+| evm explorer | 87 | 6.9 | 0% | 10/mo, LOW |
+| evm scan | 93 | 8.0 | 0% | 20/mo, LOW (cpc $10) |
+| launch custom block explorer | 135 | 14.8 | 0% | (bucketed) |
+
+SERP vocabulary for "evm explorer": blockchain explorer, **Blockscout**, Etherscan,
+"EVM Block Explorer" entity. "launch custom block explorer" SERP is thin (Autoscout the
+only real competitor) — **a genuine content gap**. "block explorer hosting" SERP is
+half Bitcoin-noise — also winnable.
+
+**Action: a focused landing page or blog post** on "self-hosted / custom EVM block explorer"
+targeting all four. This is Ethernal's core product positioning, so a `/launch-block-explorer`
+or `/evm-block-explorer` landing (or a how-to blog post) maps directly to intent. The 0% CTR
+at pos 6-8 says the homepage is matching but not satisfying these queries — they want a
+*dedicated* answer page.
+
+### 3. Explorer-discovery head terms — high volume, we're on page 3-6  ⭐ refresh existing post
+
+The surprise: real head-term volume, LOW competition, and we already rank (badly):
+
+| Query | GSC impr (90d) | GSC pos | DataForSEO vol |
+|---|---|---|---|
+| ether explorer | 77 | 34.4 | **49,500/mo, LOW** |
+| blockchain explorer | — | — | **22,200/mo, LOW** |
+| ethereum explorer | 73 | 52.3 | (bucketed) |
+| eth explorer | 67 | 61.7 | (bucketed) |
+| chain explorer | 62 | 59.0 | 70/mo |
+| multi chain explorer | 55 | 52.3 | 20/mo |
+| best block explorer | 34 | 56.7 | 140/mo, LOW |
+| arbitrum explorer | 27 | 26.3 | 210/mo, LOW |
+| optimism explorer | 48 | 36.1 | 170/mo, LOW |
+
+"ether explorer" at 49.5k/mo is the biggest raw-volume term in the set and we're at
+position 34. SERP is Etherscan/Ethplorer-dominated (hard head term), BUT **"multi chain
+explorer"** SERP is Blockscan/Multichain — *exactly* Ethernal's multi-chain positioning,
+and far more winnable. **"arbitrum explorer"/"optimism explorer"** (pos 26-36, 170-210/mo)
+map straight onto our existing **chain landing pages** (`ArbitrumOnePage.vue`,
+`OptimismPage.vue`) — those pages should target "<chain> explorer" intent directly.
+
+We already have `best-block-explorers-evm-chains-2026.md` (ranks, 12 min read, full
+comparison + FAQ). It targets "best block explorer" but isn't capturing the "ether/eth/
+chain/multi-chain explorer" variant demand.
+
+**Action (refresh, not new):**
+- Expand the existing best-block-explorers post to cover the "ether explorer / multi-chain
+  explorer / chain explorer" query variants (ronda's `expand_for_query` strategy).
+- Ensure chain landing pages (`/chains/arbitrum-one`, `/chains/optimism`) target
+  "<chain> explorer" in title/H1/meta — they're already ranking pos 11-36 for these.
+- Don't chase "ether explorer" (49.5k) head-on against Etherscan; chase the multi-chain +
+  per-L2 long tail where we have a real product wedge.
+
+### 4. Existing page CTR rewrites — page-1 rankings leaking all clicks  ⭐ cheapest win
+
+Pages ranking on page 1 with **~0% CTR** = title/meta problem, not content problem
+(ronda's `rewrite_title_meta_only` strategy — two frontmatter fields, no body edits):
+
+| Page | GSC pos | GSC impr | CTR |
+|---|---|---|---|
+| `/blog/the-commerce-layer-erc-8183` | 9.0 | **815** | 0% |
+| `/etherscan-alternative` | 8.5 | 356 | 0.27% |
+| `/blockscout-alternative` | 8.4 | 385 | 0% |
+| `/routescan-alternative` | 8.6 | 250 | 0% |
+| `/chains/arbitrum-one` | 11.8 | 189 | 0% |
+| `/blog/what-does-it-mean-to-sell-an-ai-agent` | 7.6 | 102 | 0% |
+| `/tools/unit-converter` | 24.3 | 380 | 0.26% |
+
+`the-commerce-layer-erc-8183` at 815 impressions / 0% CTR is the single biggest pure-CTR
+leak. The three `*-alternative` pages rank page-1 and convert nothing — their titles/metas
+need a curiosity-gap or concrete-benefit rewrite.
+
+**Action: rewrite title + meta-description** on these 6-7 pages. Highest ROI per minute of
+work in the entire dataset. No new content required.
+
+---
+
+## Recommended execution order (by ROI)
+
+1. **Title/meta rewrites** (Opp 4) — hours of work, page-1 rankings already there. Start with
+   `the-commerce-layer-erc-8183`, the three `*-alternative` pages.
+2. **Converter tool SEO** (Opp 1) — we own the asset, demand is clear, intent is unambiguous.
+3. **Chain-page "<chain> explorer" targeting** (Opp 3, subset) — existing pages, just retarget
+   title/H1/meta for arbitrum/optimism explorer.
+4. **"Launch a custom EVM block explorer" landing or post** (Opp 2) — net-new, but core product
+   intent and a genuine SERP gap.
+5. **Expand best-block-explorers post** for explorer-discovery variants (Opp 3, main).
+
+## What this validates about the integration plan
+
+- The **GSC signal layer is the high-value piece** for ethernal — it surfaced 4 concrete,
+  prioritized opportunities from real demand, most of which are *page fixes*, not blog posts.
+- **DataForSEO volume is secondary here** (bucketed for our niche), but the SERP term/entity
+  extraction (`serp-terms.mjs`) is useful for competitive vocabulary + PAA mining.
+- The ronda **refresh-mode strategies map 1:1** onto what we found: `rewrite_title_meta_only`
+  (Opp 4), `expand_for_query` (Opp 3). Porting `refresh.mjs` is well-justified.
+- Biggest practical insight: **for a product-led dev-tooling site, "what should we write
+  about" is often "what page should we fix/build" — the loop points at landing/tool pages
+  more than blog posts.** The pipeline should be able to emit non-blog actions too.
+
+## Reproduce this run
+
+```bash
+cd ~/projects/ronda/blog/pipeline
+GSC_KEY_FILE=~/.credentials/gsc-ronda.json node gsc.mjs --site sc-domain:tryethernal.com
+LOGIN=$(sed -n 1p ~/.credentials/dataforseo-ronda); PASS=$(sed -n 2p ~/.credentials/dataforseo-ronda)
+DATAFORSEO_LOGIN=$LOGIN DATAFORSEO_PASSWORD=$PASS node serp-terms.mjs --keyword "multi chain explorer"
+# volumes: POST keywords_data/google_ads/search_volume/live with location_code 2840
+```

--- a/blog/src/content/blog/best-block-explorers-evm-chains-2026.md
+++ b/blog/src/content/blog/best-block-explorers-evm-chains-2026.md
@@ -294,6 +294,18 @@ Etherscan EaaS offers limited white-label customization within fixed templates. 
 
 Yes. Ethernal (MIT license) and Blockscout (open source) both support self-hosting. Ethernal can be deployed via Docker with `git clone` and `make start`. Blockscout requires more infrastructure setup (Elixir runtime, multiple services) but offers deeper customization once running. Self-hosting gives you full control over your data but means you handle maintenance, scaling, and updates yourself.
 
+### What is the best Ethereum explorer?
+
+For browsing Ethereum mainnet, Etherscan is the most established Ethereum explorer and the one most users mean by "the ether explorer." For running your own explorer on an Ethereum L2 or app-chain, Ethernal and Blockscout are the strongest options because both are open-source and let you point an explorer at any EVM RPC URL. The right Ethereum explorer depends on whether you are reading a public chain or operating one of your own.
+
+### What is a multi-chain explorer?
+
+A multi-chain explorer is a single block explorer that indexes and serves data for many blockchains at once, so you can search transactions and addresses across several chains from one interface. Blockscan (the Etherscan group's multi-chain view) and Routescan are common hosted examples. If you run several EVM chains yourself, Ethernal lets you spin up a chain explorer per network and manage them from one account, which is the self-hosted equivalent of a multi-chain explorer.
+
+### What is a chain explorer?
+
+A chain explorer, also called a block explorer, is the search and analytics interface for a single blockchain. It lets users look up blocks, transactions, addresses, tokens, and verified smart contracts for that chain. Every production EVM chain needs one so that users, developers, and auditors can verify on-chain activity. For a custom or unified chain explorer across your own networks, Ethernal deploys one from an RPC URL in under five minutes.
+
 ---
 
 ## Key takeaways

--- a/blog/src/content/blog/the-commerce-layer-erc-8183.md
+++ b/blog/src/content/blog/the-commerce-layer-erc-8183.md
@@ -1,6 +1,6 @@
 ---
-title: "The Commerce Layer: How ERC-8183 Makes AI Agent Payments Verifiable"
-description: "ERC-8183 adds the missing verb to agent commerce: not 'I sent value' but 'I will pay when you deliver.' How the job lifecycle and evaluator work."
+title: "ERC-8183: How to Make AI Agent Payments Verifiable Onchain"
+description: "ERC-8183 lets an AI agent commit to pay-on-delivery instead of paying upfront. How its job lifecycle and onchain evaluator make agent commerce verifiable."
 date: 2026-03-16
 tags:
   - AI Agents

--- a/landing/public/llms.txt
+++ b/landing/public/llms.txt
@@ -18,6 +18,7 @@
 - [Features](https://tryethernal.com/features): Full feature list including contract verification, transaction tracing, token tracking, and analytics
 - [Transaction Tracing](https://tryethernal.com/transaction-tracing): Deep transaction trace visualization with call trees, state diffs, and gas profiling
 - [App Chains](https://tryethernal.com/app-chains): Block explorer for application-specific chains
+- [Launch a Custom EVM Block Explorer](https://tryethernal.com/launch-block-explorer): Launch a hosted or self-hosted EVM block explorer for any chain from an RPC URL in under 5 minutes. Block explorer hosting, white-label branding, MIT-licensed self-host.
 
 ## Developer Integrations
 

--- a/landing/src/components/LandingFooter.vue
+++ b/landing/src/components/LandingFooter.vue
@@ -17,6 +17,7 @@
                     <div class="d-flex flex-column ga-2">
                         <router-link to="/features" class="footer-link">Features</router-link>
                         <router-link to="/pricing" class="footer-link">Pricing</router-link>
+                        <router-link to="/launch-block-explorer" class="footer-link">Launch an Explorer</router-link>
                         <router-link to="/transaction-tracing" class="footer-link">Transaction Tracing</router-link>
                         <a href="https://doc.tryethernal.com" target="_blank" rel="noopener noreferrer" class="footer-link">Docs</a>
                         <a :href="`${appUrl}/auth?utm_source=landing&utm_medium=footer&utm_campaign=signin`" class="footer-link">Sign In</a>

--- a/landing/src/pages/LaunchBlockExplorerPage.vue
+++ b/landing/src/pages/LaunchBlockExplorerPage.vue
@@ -161,6 +161,19 @@
                     </div>
                 </template>
             </FeatureSection>
+
+            <!-- FAQ (visible content mirrors the FAQPage JSON-LD below) -->
+            <div class="my-16" style="max-width: 760px; margin-left: auto; margin-right: auto;">
+                <h2 class="font-heading mb-6" style="font-size: 1.6rem; color: var(--text-primary);">
+                    Frequently asked questions
+                </h2>
+                <div class="lbe-faq-list">
+                    <div v-for="(faq, i) in faqs" :key="i" class="lbe-faq-item">
+                        <h3 class="lbe-faq-q">{{ faq.q }}</h3>
+                        <p class="lbe-faq-a">{{ faq.a }}</p>
+                    </div>
+                </div>
+            </div>
         </v-container>
 
         <LandingCTA flow="public" />
@@ -174,6 +187,24 @@ import FeatureSection from '@/components/FeatureSection.vue';
 import LandingCTA from '@/components/LandingCTA.vue';
 
 const appUrl = __APP_URL__;
+
+// Single source of truth: rendered in the visible FAQ section above AND in the
+// FAQPage JSON-LD below, so the structured data always matches on-page content
+// (a Google FAQPage eligibility requirement).
+const faqs = [
+    {
+        q: 'What is block explorer hosting?',
+        a: 'Block explorer hosting is a managed service where a provider runs the indexer, database, and frontend that power a block explorer for your chain. With Ethernal you provide an EVM RPC URL and the hosted explorer is live in minutes, with no infrastructure for you to operate.'
+    },
+    {
+        q: 'How do I launch a custom block explorer for my EVM chain?',
+        a: 'Paste your EVM RPC URL and chain ID into Ethernal, set your branding and custom domain, and the explorer indexes your chain and goes live in under five minutes. You can use the hosted version or self-host the MIT-licensed explorer via Docker.'
+    },
+    {
+        q: 'Is there a self-hosted EVM scan alternative to Etherscan?',
+        a: 'Yes. Ethernal is an open-source, MIT-licensed EVM block explorer (an EVM scan) that you can self-host on your own infrastructure, or run as a hosted service. It supports transaction decoding, contract verification, and an Etherscan-compatible API.'
+    }
+];
 
 useHead({
     title: 'Launch a Custom EVM Block Explorer | Explorer Hosting',
@@ -209,23 +240,11 @@ useHead({
             children: JSON.stringify({
                 "@context": "https://schema.org",
                 "@type": "FAQPage",
-                "mainEntity": [
-                    {
-                        "@type": "Question",
-                        "name": "What is block explorer hosting?",
-                        "acceptedAnswer": { "@type": "Answer", "text": "Block explorer hosting is a managed service where a provider runs the indexer, database, and frontend that power a block explorer for your chain. With Ethernal you provide an EVM RPC URL and the hosted explorer is live in minutes, with no infrastructure for you to operate." }
-                    },
-                    {
-                        "@type": "Question",
-                        "name": "How do I launch a custom block explorer for my EVM chain?",
-                        "acceptedAnswer": { "@type": "Answer", "text": "Paste your EVM RPC URL and chain ID into Ethernal, set your branding and custom domain, and the explorer indexes your chain and goes live in under five minutes. You can use the hosted version or self-host the MIT-licensed explorer via Docker." }
-                    },
-                    {
-                        "@type": "Question",
-                        "name": "Is there a self-hosted EVM scan alternative to Etherscan?",
-                        "acceptedAnswer": { "@type": "Answer", "text": "Yes. Ethernal is an open-source, MIT-licensed EVM block explorer (an EVM scan) that you can self-host on your own infrastructure, or run as a hosted service. It supports transaction decoding, contract verification, and an Etherscan-compatible API." }
-                    }
-                ]
+                "mainEntity": faqs.map(f => ({
+                    "@type": "Question",
+                    "name": f.q,
+                    "acceptedAnswer": { "@type": "Answer", "text": f.a }
+                }))
             })
         },
         {
@@ -300,4 +319,10 @@ useHead({
 .trace-method { color: #CBD5E1; font-size: 11px; }
 .status-chip { padding: 2px 10px; border-radius: 4px; font-size: 10px; font-weight: 600; }
 .status-chip.ok { background: rgba(34, 197, 94, 0.1); color: #22C55E; border: 1px solid rgba(34, 197, 94, 0.2); }
+
+/* FAQ */
+.lbe-faq-list { display: flex; flex-direction: column; gap: 12px; }
+.lbe-faq-item { background: rgba(17, 24, 39, 0.4); border: 1px solid rgba(30, 41, 59, 0.5); border-radius: 10px; padding: 18px 20px; }
+.lbe-faq-q { color: var(--text-primary); font-size: 15px; font-weight: 600; margin: 0 0 8px; }
+.lbe-faq-a { color: var(--text-secondary); font-size: 14px; line-height: 1.7; margin: 0; }
 </style>

--- a/landing/src/pages/LaunchBlockExplorerPage.vue
+++ b/landing/src/pages/LaunchBlockExplorerPage.vue
@@ -1,0 +1,303 @@
+<!--
+  @fileoverview Landing page targeting EVM block-explorer hosting intent.
+  @component LaunchBlockExplorerPage
+  Targets GSC quick-win queries (pos 5-15, ~0% CTR): "evm explorer", "evm scan",
+  "block explorer hosting", "launch custom block explorer". Follows the
+  HardhatPage.vue wedge-landing pattern (hero + FeatureSection blocks + HowTo/
+  BreadcrumbList JSON-LD).
+-->
+<template>
+    <LandingLayout>
+        <v-container style="max-width: 1200px; padding-top: 100px; padding-bottom: 60px;">
+            <div class="page-title-bar">
+                <div class="text-overline mb-1" style="letter-spacing: 0.1em; color: #5DAAE0; font-size: 11px;">BLOCK EXPLORER HOSTING</div>
+                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Launch a Custom EVM Block Explorer</h1>
+                <p style="color: var(--text-secondary); max-width: 560px; line-height: 1.6; font-size: 0.95rem;">
+                    Point Ethernal at any EVM RPC URL and get a hosted block explorer in under five minutes. Transaction decoding, contract verification, and full white-label branding, hosted for you or self-hosted under an MIT license.
+                </p>
+                <div class="mt-4 d-flex ga-3 flex-wrap">
+                    <a :href="`${appUrl}/auth?flow=public`" class="btn-primary">Launch your explorer</a>
+                    <a href="/build-vs-buy-block-explorer" class="btn-secondary">Compare hosting vs building</a>
+                </div>
+            </div>
+
+            <FeatureSection
+                inline-icon
+                compact
+                icon="mdi-rocket-launch"
+                title="From RPC URL to live explorer in 5 minutes"
+                description="Launching a custom block explorer normally means standing up an indexer, a database, and a frontend. With Ethernal you paste your EVM RPC URL and the explorer is live. No indexer to operate, no DevOps team required."
+            >
+                <template #visual>
+                    <div class="browser-preview">
+                        <div class="preview-header">
+                            <div class="d-flex align-center ga-2">
+                                <span class="dot red"></span>
+                                <span class="dot yellow"></span>
+                                <span class="dot green"></span>
+                            </div>
+                            <div class="preview-url-bar">
+                                <v-icon size="12" style="color: var(--text-muted);">mdi-lock</v-icon>
+                                app.tryethernal.com/onboarding
+                            </div>
+                            <div style="width: 42px;"></div>
+                        </div>
+                        <div class="preview-body terminal-mock">
+                            <div><span class="t-comment"># Add your chain</span></div>
+                            <div><span class="t-prompt">RPC URL  </span><span class="t-str">https://rpc.yourchain.com</span></div>
+                            <div><span class="t-prompt">Chain ID </span><span class="t-cmd">84532</span></div>
+                            <div class="mt-3"><span class="t-success">&#10003; Connected to chain</span></div>
+                            <div><span class="t-success">&#10003; Indexing blocks...</span></div>
+                            <div><span class="t-success">&#10003; Explorer live at explorer.yourchain.com</span></div>
+                        </div>
+                    </div>
+                </template>
+            </FeatureSection>
+
+            <FeatureSection
+                inline-icon
+                compact
+                icon="mdi-palette-outline"
+                title="Your brand, your domain, your EVM scan"
+                description="Full white-label branding means your users see your logo, colors, and custom domain, not a provider's chrome. The result is an Etherscan-style EVM scan for your chain that looks like it was built in-house."
+                :reverse="true"
+            >
+                <template #visual>
+                    <div class="browser-preview">
+                        <div class="preview-header">
+                            <div class="d-flex align-center ga-2">
+                                <span class="dot red"></span>
+                                <span class="dot yellow"></span>
+                                <span class="dot green"></span>
+                            </div>
+                            <div class="preview-url-bar">
+                                <v-icon size="12" style="color: var(--text-muted);">mdi-lock</v-icon>
+                                explorer.yourchain.com
+                            </div>
+                            <div style="width: 42px;"></div>
+                        </div>
+                        <div class="preview-body">
+                            <div class="mock-contract-sync">
+                                <div class="mock-verified-banner">
+                                    <span class="mock-check">&#10003;</span>
+                                    White-label explorer live
+                                </div>
+                                <div class="mock-meta-grid">
+                                    <div class="mock-meta-item"><span class="mock-meta-label">Domain</span><span class="mock-meta-val">explorer.yourchain.com</span></div>
+                                    <div class="mock-meta-item"><span class="mock-meta-label">Branding</span><span class="mock-meta-val badge">Custom logo + theme</span></div>
+                                    <div class="mock-meta-item"><span class="mock-meta-label">Native token</span><span class="mock-meta-val">YOUR</span></div>
+                                    <div class="mock-meta-item"><span class="mock-meta-label">Ads</span><span class="mock-meta-val">None</span></div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </template>
+            </FeatureSection>
+
+            <FeatureSection
+                inline-icon
+                compact
+                icon="mdi-server"
+                title="Hosted for you, or self-host it yourself"
+                description="Choose managed block explorer hosting and Ethernal runs the infrastructure, scaling, and updates. Need data sovereignty? The same explorer is MIT-licensed and self-hostable via Docker, so you can run it on your own infrastructure with one command."
+            >
+                <template #visual>
+                    <div class="browser-preview">
+                        <div class="preview-header">
+                            <div class="d-flex align-center ga-2">
+                                <span class="dot red"></span>
+                                <span class="dot yellow"></span>
+                                <span class="dot green"></span>
+                            </div>
+                            <div class="preview-url-bar">
+                                <v-icon size="12" style="color: var(--text-muted);">mdi-lock</v-icon>
+                                terminal
+                            </div>
+                            <div style="width: 42px;"></div>
+                        </div>
+                        <div class="preview-body terminal-mock">
+                            <div><span class="t-prompt">$ </span><span class="t-cmd">git clone https://github.com/tryethernal/ethernal</span></div>
+                            <div><span class="t-prompt">$ </span><span class="t-cmd">cd ethernal && make start</span></div>
+                            <div class="mt-3"><span class="t-comment"># MIT-licensed, runs on your infrastructure</span></div>
+                            <div><span class="t-success">&#10003; Explorer running at localhost:8080</span></div>
+                        </div>
+                    </div>
+                </template>
+            </FeatureSection>
+
+            <FeatureSection
+                inline-icon
+                compact
+                icon="mdi-magnify"
+                title="A full EVM explorer, not just a block feed"
+                description="Decoded transactions, full call traces, verified contracts you can read and write to, token and NFT tracking, and an Etherscan-compatible API so your existing tooling keeps working. Everything users and developers expect from an EVM block explorer."
+                :reverse="true"
+            >
+                <template #visual>
+                    <div class="browser-preview">
+                        <div class="preview-header">
+                            <div class="d-flex align-center ga-2">
+                                <span class="dot red"></span>
+                                <span class="dot yellow"></span>
+                                <span class="dot green"></span>
+                            </div>
+                            <div class="preview-url-bar">
+                                <v-icon size="12" style="color: var(--text-muted);">mdi-lock</v-icon>
+                                explorer.yourchain.com/tx/0x1b14…
+                            </div>
+                            <div style="width: 42px;"></div>
+                        </div>
+                        <div class="preview-body">
+                            <div class="mock-trace">
+                                <div class="d-flex justify-space-between align-center mb-3">
+                                    <span style="color: var(--text-primary); font-weight: 600; font-size: 13px;">Call Trace</span>
+                                    <span class="status-chip ok">Success</span>
+                                </div>
+                                <div class="trace-node"><span class="trace-op call">CALL</span><span class="trace-addr">0x7a25…f832</span><span class="trace-method">swap(uint256)</span></div>
+                                <div class="trace-node indent"><span class="trace-op static">STATICCALL</span><span class="trace-addr">0x1f98…4e23</span><span class="trace-method">getReserves()</span></div>
+                                <div class="trace-node indent"><span class="trace-op call">CALL</span><span class="trace-addr">0xdac1…1ec7</span><span class="trace-method">transfer(address,uint256)</span></div>
+                            </div>
+                        </div>
+                    </div>
+                </template>
+            </FeatureSection>
+        </v-container>
+
+        <LandingCTA flow="public" />
+    </LandingLayout>
+</template>
+
+<script setup>
+import { useHead } from '@vueuse/head';
+import LandingLayout from '@/components/LandingLayout.vue';
+import FeatureSection from '@/components/FeatureSection.vue';
+import LandingCTA from '@/components/LandingCTA.vue';
+
+const appUrl = __APP_URL__;
+
+useHead({
+    title: 'Launch a Custom EVM Block Explorer | Explorer Hosting',
+    meta: [
+        { name: 'description', content: 'Launch a custom EVM block explorer in 5 minutes. Point Ethernal at any RPC URL for hosted block explorer hosting, or self-host the MIT-licensed EVM scan yourself.' },
+        { property: 'og:type', content: 'website' },
+        { property: 'og:title', content: 'Launch a Custom EVM Block Explorer | Explorer Hosting' },
+        { property: 'og:description', content: 'Launch a custom EVM block explorer in 5 minutes. Point Ethernal at any RPC URL for hosted block explorer hosting, or self-host the MIT-licensed EVM scan yourself.' },
+        { property: 'og:url', content: 'https://tryethernal.com/launch-block-explorer' },
+        { property: 'og:image', content: 'https://tryethernal.com/images/og-image.png' },
+        { name: 'twitter:card', content: 'summary_large_image' },
+    ],
+    link: [
+        { rel: 'canonical', href: 'https://tryethernal.com/launch-block-explorer' }
+    ],
+    script: [
+        {
+            type: 'application/ld+json',
+            children: JSON.stringify({
+                "@context": "https://schema.org",
+                "@type": "HowTo",
+                "name": "Launch a custom EVM block explorer with Ethernal",
+                "description": "Stand up a hosted or self-hosted EVM block explorer for your chain in under five minutes.",
+                "step": [
+                    { "@type": "HowToStep", "name": "Add your chain", "text": "Paste your EVM RPC URL and chain ID into Ethernal onboarding." },
+                    { "@type": "HowToStep", "name": "Brand it", "text": "Set your custom domain, logo, colors, and native token for a white-label explorer." },
+                    { "@type": "HowToStep", "name": "Go live", "text": "Ethernal indexes your chain and serves the explorer, hosted for you or self-hosted via Docker under an MIT license." }
+                ]
+            })
+        },
+        {
+            type: 'application/ld+json',
+            children: JSON.stringify({
+                "@context": "https://schema.org",
+                "@type": "FAQPage",
+                "mainEntity": [
+                    {
+                        "@type": "Question",
+                        "name": "What is block explorer hosting?",
+                        "acceptedAnswer": { "@type": "Answer", "text": "Block explorer hosting is a managed service where a provider runs the indexer, database, and frontend that power a block explorer for your chain. With Ethernal you provide an EVM RPC URL and the hosted explorer is live in minutes, with no infrastructure for you to operate." }
+                    },
+                    {
+                        "@type": "Question",
+                        "name": "How do I launch a custom block explorer for my EVM chain?",
+                        "acceptedAnswer": { "@type": "Answer", "text": "Paste your EVM RPC URL and chain ID into Ethernal, set your branding and custom domain, and the explorer indexes your chain and goes live in under five minutes. You can use the hosted version or self-host the MIT-licensed explorer via Docker." }
+                    },
+                    {
+                        "@type": "Question",
+                        "name": "Is there a self-hosted EVM scan alternative to Etherscan?",
+                        "acceptedAnswer": { "@type": "Answer", "text": "Yes. Ethernal is an open-source, MIT-licensed EVM block explorer (an EVM scan) that you can self-host on your own infrastructure, or run as a hosted service. It supports transaction decoding, contract verification, and an Etherscan-compatible API." }
+                    }
+                ]
+            })
+        },
+        {
+            type: 'application/ld+json',
+            children: JSON.stringify({
+                "@context": "https://schema.org",
+                "@type": "BreadcrumbList",
+                "itemListElement": [
+                    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://tryethernal.com/" },
+                    { "@type": "ListItem", "position": 2, "name": "Launch a Custom EVM Block Explorer", "item": "https://tryethernal.com/launch-block-explorer" }
+                ]
+            })
+        }
+    ]
+});
+</script>
+
+<style scoped>
+.page-title-bar {
+    padding-bottom: 24px;
+    margin-bottom: 8px;
+    border-bottom: 1px solid var(--drawer-divider);
+}
+.btn-primary {
+    display: inline-flex; align-items: center; justify-content: center;
+    padding: 10px 24px; border-radius: 8px; font-size: 14px; font-weight: 600;
+    cursor: pointer; text-decoration: none; white-space: nowrap;
+    background: #3D95CE; color: #fff;
+}
+.btn-primary:hover { background: #357fb0; }
+.btn-secondary {
+    display: inline-flex; align-items: center; justify-content: center;
+    padding: 10px 24px; border-radius: 8px; font-size: 14px; font-weight: 600;
+    cursor: pointer; text-decoration: none; white-space: nowrap;
+    background: transparent; color: var(--text-secondary); border: 1px solid var(--border-subtle);
+}
+.btn-secondary:hover { color: var(--text-primary); border-color: rgba(61,149,206,0.4); }
+.browser-preview { background: var(--glass-bg); backdrop-filter: blur(16px); border: 1px solid var(--border-subtle); border-radius: 16px; overflow: hidden; box-shadow: var(--shadow-card); }
+.preview-header { background: var(--bg-surface); padding: 12px 16px; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid var(--border-subtle); }
+.preview-url-bar { display: flex; align-items: center; gap: 6px; background: var(--glass-bg-strong); border-radius: 6px; padding: 4px 12px; color: var(--text-muted); font-size: 11px; font-family: 'JetBrains Mono', monospace; }
+.dot { width: 10px; height: 10px; border-radius: 50%; }
+.dot.red { background: #ff5f56; }
+.dot.yellow { background: #febc2e; }
+.dot.green { background: #28c840; }
+.preview-body { padding: 20px; font-family: 'JetBrains Mono', 'Roboto', sans-serif; font-size: 12px; }
+
+/* Terminal mock */
+.terminal-mock { font-family: 'JetBrains Mono', monospace; font-size: 12px; line-height: 1.8; }
+.t-prompt { color: #58A6FF; }
+.t-cmd { color: #E6EDF3; }
+.t-comment { color: #484F58; }
+.t-str { color: #A5D6FF; }
+.t-success { color: #22C55E; font-size: 11px; }
+
+/* Contract sync / meta grid */
+.mock-verified-banner { display: flex; align-items: center; gap: 8px; padding: 10px 14px; border-radius: 8px; background: rgba(34, 197, 94, 0.08); border: 1px solid rgba(34, 197, 94, 0.2); color: #22C55E; font-size: 12px; font-weight: 600; margin-bottom: 16px; }
+.mock-check { font-size: 14px; }
+.mock-meta-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+.mock-meta-item { display: flex; flex-direction: column; gap: 3px; padding: 10px 12px; border-radius: 8px; background: var(--glass-bg); border: 1px solid var(--drawer-divider); }
+.mock-meta-label { color: var(--text-muted); font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em; }
+.mock-meta-val { color: #CBD5E1; font-size: 12px; }
+.mock-meta-val.badge { color: #5DAAE0; }
+
+/* Trace */
+.mock-trace { font-size: 12px; }
+.trace-node { display: flex; align-items: center; gap: 8px; padding: 5px 0; }
+.trace-node.indent { padding-left: 20px; }
+.trace-op { padding: 2px 8px; border-radius: 4px; font-size: 10px; font-weight: 700; letter-spacing: 0.04em; }
+.trace-op.call { background: rgba(61, 149, 206, 0.12); color: #3D95CE; border: 1px solid rgba(61, 149, 206, 0.25); }
+.trace-op.static { background: rgba(167, 139, 250, 0.12); color: #A78BFA; border: 1px solid rgba(167, 139, 250, 0.25); }
+.trace-addr { color: #5DAAE0; font-size: 11px; }
+.trace-method { color: #CBD5E1; font-size: 11px; }
+.status-chip { padding: 2px 10px; border-radius: 4px; font-size: 10px; font-weight: 600; }
+.status-chip.ok { background: rgba(34, 197, 94, 0.1); color: #22C55E; border: 1px solid rgba(34, 197, 94, 0.2); }
+</style>

--- a/landing/src/pages/chains/ArbitrumOnePage.vue
+++ b/landing/src/pages/chains/ArbitrumOnePage.vue
@@ -11,7 +11,7 @@
                     <span class="current">Arbitrum One</span>
                 </nav>
                 <div class="text-overline mb-1" style="letter-spacing: 0.1em; color: #5DAAE0; font-size: 11px;">L2 ROLLUP · ARBITRUM ORBIT</div>
-                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Block Explorer for Arbitrum One</h1>
+                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Arbitrum Explorer for Arbitrum One</h1>
                 <p style="color: var(--text-secondary); max-width: 560px; line-height: 1.6; font-size: 0.95rem;">
                             Ethernal is a hosted block explorer for Arbitrum One that provides real-time transaction decoding, contract verification, and Nitro-native features. Connect your RPC, configure your Orbit settings, and have a branded explorer running in minutes.
                         </p>
@@ -342,12 +342,12 @@ import ChainFeatureGrid from '@/components/ChainFeatureGrid.vue';
 import LandingCTA from '@/components/LandingCTA.vue';
 
 useHead({
-    title: 'Block Explorer for Arbitrum One — Ethernal',
+    title: 'Arbitrum Explorer: Block Explorer for Arbitrum One | Ethernal',
     meta: [
-        { name: 'description', content: 'Hosted block explorer for Arbitrum One (Nitro). Transaction decoding, contract verification, retryable ticket tracking, and Orbit bridge monitoring.' },
+        { name: 'description', content: 'An Arbitrum One explorer with transaction decoding, contract verification, retryable ticket tracking, and Orbit bridge monitoring. Hosted or self-host your own in 5 minutes.' },
         { property: 'og:type', content: 'website' },
-        { property: 'og:title', content: 'Block Explorer for Arbitrum One — Ethernal' },
-        { property: 'og:description', content: 'Hosted block explorer for Arbitrum One (Nitro). Transaction decoding, contract verification, retryable ticket tracking, and Orbit bridge monitoring.' },
+        { property: 'og:title', content: 'Arbitrum Explorer: Block Explorer for Arbitrum One | Ethernal' },
+        { property: 'og:description', content: 'An Arbitrum One explorer with transaction decoding, contract verification, retryable ticket tracking, and Orbit bridge monitoring. Hosted or self-host your own in 5 minutes.' },
         { property: 'og:url', content: 'https://tryethernal.com/chains/arbitrum-one' },
         { property: 'og:image', content: 'https://tryethernal.com/images/og-chains-arbitrum-one.png' },
         { name: 'twitter:card', content: 'summary_large_image' },

--- a/landing/src/pages/chains/OptimismPage.vue
+++ b/landing/src/pages/chains/OptimismPage.vue
@@ -11,7 +11,7 @@
                     <span class="current">Optimism</span>
                 </nav>
                 <div class="text-overline mb-1" style="letter-spacing: 0.1em; color: #5DAAE0; font-size: 11px;">L2 ROLLUP · OP STACK</div>
-                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Block Explorer for Optimism</h1>
+                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Optimism Explorer for the OP Network</h1>
                 <p style="color: var(--text-secondary); max-width: 560px; line-height: 1.6; font-size: 0.95rem;">
                             Ethernal is a hosted block explorer for Optimism (chain ID 10) that connects to your RPC endpoint and provides real-time transaction decoding, contract verification, and L2-to-L1 withdrawal tracking. Optimism is the original OP Stack chain built by OP Labs, powering the Superchain vision. Deploy a full-featured explorer in under 5 minutes.
                         </p>
@@ -339,12 +339,12 @@ import ChainFeatureGrid from '@/components/ChainFeatureGrid.vue';
 import LandingCTA from '@/components/LandingCTA.vue';
 
 useHead({
-    title: 'Block Explorer for Optimism — Ethernal',
+    title: 'Optimism Explorer: Block Explorer for the OP Network | Ethernal',
     meta: [
-        { name: 'description', content: 'Hosted block explorer for Optimism (OP Stack). Transaction decoding, contract verification, L2-to-L1 withdrawal tracking, fault proof monitoring, and EIP-4844 blob batches.' },
+        { name: 'description', content: 'An Optimism network explorer with transaction decoding, contract verification, L2-to-L1 withdrawal tracking, and fault proof monitoring. Hosted or self-host your own in 5 minutes.' },
         { property: 'og:type', content: 'website' },
-        { property: 'og:title', content: 'Block Explorer for Optimism — Ethernal' },
-        { property: 'og:description', content: 'Hosted block explorer for Optimism (OP Stack). Transaction decoding, contract verification, L2-to-L1 withdrawal tracking, fault proof monitoring, and EIP-4844 blob batches.' },
+        { property: 'og:title', content: 'Optimism Explorer: Block Explorer for the OP Network | Ethernal' },
+        { property: 'og:description', content: 'An Optimism network explorer with transaction decoding, contract verification, L2-to-L1 withdrawal tracking, and fault proof monitoring. Hosted or self-host your own in 5 minutes.' },
         { property: 'og:url', content: 'https://tryethernal.com/chains/optimism' },
         { property: 'og:image', content: 'https://tryethernal.com/images/og-chains-optimism.png' },
         { name: 'twitter:card', content: 'summary_large_image' },

--- a/landing/src/pages/compare/BlockscoutAlternativePage.vue
+++ b/landing/src/pages/compare/BlockscoutAlternativePage.vue
@@ -367,12 +367,12 @@ import LandingLayout from '@/components/LandingLayout.vue';
 import LandingCTA from '@/components/LandingCTA.vue';
 
 useHead({
-    title: 'Blockscout Alternative: Ethernal vs Blockscout Compared',
+    title: 'Blockscout Alternative: Deploy in 5 Min, No DevOps',
     meta: [
-        { name: 'description', content: 'Compare Ethernal and Blockscout: two open-source block explorers for EVM chains. Setup, architecture, L2 support, and pricing side by side.' },
+        { name: 'description', content: 'Blockscout needs a Postgres, indexer, and frontend to self-host. Ethernal is one Docker command and live in 5 minutes. See the full Ethernal vs Blockscout comparison.' },
         { property: 'og:type', content: 'website' },
-        { property: 'og:title', content: 'Blockscout Alternative: Ethernal vs Blockscout Compared' },
-        { property: 'og:description', content: 'Compare Ethernal and Blockscout: two open-source block explorers for EVM chains. Setup, architecture, L2 support, and pricing side by side.' },
+        { property: 'og:title', content: 'Blockscout Alternative: Deploy in 5 Min, No DevOps' },
+        { property: 'og:description', content: 'Blockscout needs a Postgres, indexer, and frontend to self-host. Ethernal is one Docker command and live in 5 minutes. See the full Ethernal vs Blockscout comparison.' },
         { property: 'og:url', content: 'https://tryethernal.com/blockscout-alternative' },
         { name: 'twitter:card', content: 'summary_large_image' },
     ],

--- a/landing/src/pages/compare/EtherscanAlternativePage.vue
+++ b/landing/src/pages/compare/EtherscanAlternativePage.vue
@@ -362,12 +362,12 @@ import LandingLayout from '@/components/LandingLayout.vue';
 import LandingCTA from '@/components/LandingCTA.vue';
 
 useHead({
-    title: 'Etherscan Alternative for Custom EVM Chains | Ethernal',
+    title: 'Etherscan Alternative: Self-Host Your Explorer for $0',
     meta: [
-        { name: 'description', content: 'Need an Etherscan-style block explorer for your L2 or app-chain? Ethernal is open-source, deploys in 5 minutes, and starts at $0. Compare features.' },
+        { name: 'description', content: 'Etherscan has no public self-host and quotes enterprise pricing. Ethernal is open-source, runs on your own chain in 5 minutes, and starts free. See the comparison.' },
         { property: 'og:type', content: 'website' },
-        { property: 'og:title', content: 'Etherscan Alternative for Custom EVM Chains | Ethernal' },
-        { property: 'og:description', content: 'Need an Etherscan-style block explorer for your L2 or app-chain? Ethernal is open-source, deploys in 5 minutes, and starts at $0. Compare features.' },
+        { property: 'og:title', content: 'Etherscan Alternative: Self-Host Your Explorer for $0' },
+        { property: 'og:description', content: 'Etherscan has no public self-host and quotes enterprise pricing. Ethernal is open-source, runs on your own chain in 5 minutes, and starts free. See the comparison.' },
         { property: 'og:url', content: 'https://tryethernal.com/etherscan-alternative' },
         { name: 'twitter:card', content: 'summary_large_image' },
     ],

--- a/landing/src/pages/compare/RoutescanAlternativePage.vue
+++ b/landing/src/pages/compare/RoutescanAlternativePage.vue
@@ -290,12 +290,12 @@ import LandingLayout from '@/components/LandingLayout.vue';
 import LandingCTA from '@/components/LandingCTA.vue';
 
 useHead({
-    title: 'Routescan Alternative: Open-Source Block Explorer',
+    title: 'Routescan Alternative You Can Self-Host (MIT)',
     meta: [
-        { name: 'description', content: 'Self-hostable block explorer for Avalanche L1s, Subnets, and any EVM chain. MIT-licensed, transparent pricing, 5-minute deploy. Compare to Routescan.' },
+        { name: 'description', content: 'Routescan is a hosted multi-chain explorer you cannot run yourself. Ethernal is MIT-licensed, self-hostable on any Avalanche L1, Subnet, or EVM chain, and deploys in 5 minutes.' },
         { property: 'og:type', content: 'website' },
-        { property: 'og:title', content: 'Routescan Alternative: Open-Source Block Explorer' },
-        { property: 'og:description', content: 'Self-hostable block explorer for Avalanche L1s, Subnets, and any EVM chain. MIT-licensed, transparent pricing, 5-minute deploy. Compare to Routescan.' },
+        { property: 'og:title', content: 'Routescan Alternative You Can Self-Host (MIT)' },
+        { property: 'og:description', content: 'Routescan is a hosted multi-chain explorer you cannot run yourself. Ethernal is MIT-licensed, self-hostable on any Avalanche L1, Subnet, or EVM chain, and deploys in 5 minutes.' },
         { property: 'og:url', content: 'https://tryethernal.com/routescan-alternative' },
         { name: 'twitter:card', content: 'summary_large_image' },
     ],

--- a/landing/src/pages/tools/UnitConverterPage.vue
+++ b/landing/src/pages/tools/UnitConverterPage.vue
@@ -58,6 +58,27 @@
                 </v-col>
             </v-row>
 
+            <!-- Common conversions reference (always rendered for SEO/extractability) -->
+            <div class="my-16" style="max-width: 720px; margin-left: auto; margin-right: auto;">
+                <h2 class="font-heading mb-3" style="font-size: 1.6rem; color: var(--text-primary);">
+                    Common Ethereum unit conversions
+                </h2>
+                <p style="color: var(--text-secondary); font-size: 0.95rem; line-height: 1.7; margin-bottom: 20px;">
+                    Wei is the smallest unit of Ether and Gwei is the unit used for gas prices. To convert Wei to ETH, divide by 10<sup>18</sup>. To convert ETH to Wei, multiply by 10<sup>18</sup>. Gwei sits in between at 10<sup>9</sup> Wei. The reference values below cover the most common conversions.
+                </p>
+                <table class="conv-table">
+                    <thead>
+                        <tr><th>Conversion</th><th>Value</th></tr>
+                    </thead>
+                    <tbody>
+                        <tr v-for="row in conversionRows" :key="row.label">
+                            <td>{{ row.label }}</td>
+                            <td class="conv-value">{{ row.value }}</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
             <!-- FAQ -->
             <div class="my-16">
                 <h2 class="font-heading text-center mb-8" style="font-size: 1.8rem; color: var(--text-primary);">
@@ -137,12 +158,39 @@ async function copyToClipboard(text) {
     try { await navigator.clipboard.writeText(text); } catch {}
 }
 
+// --- Common conversions reference table (static, extractable content) ---
+const conversionRows = [
+    { label: '1 Wei to ETH', value: '0.000000000000000001 ETH (10\u207B\u00B9\u2078)' },
+    { label: '1 Gwei to ETH', value: '0.000000001 ETH (10\u207B\u2079)' },
+    { label: '1 Gwei to Wei', value: '1,000,000,000 Wei (10\u2079)' },
+    { label: '1 ETH to Wei', value: '1,000,000,000,000,000,000 Wei (10\u00B9\u2078)' },
+    { label: '1 ETH to Gwei', value: '1,000,000,000 Gwei (10\u2079)' },
+    { label: '1 ETH to Finney', value: '1,000 Finney (10\u00B3)' },
+    { label: '1 ETH to Szabo', value: '1,000,000 Szabo (10\u2076)' },
+];
+
 // --- FAQ ---
 const openFaqs = ref([]);
 const faqs = [
     {
-        q: 'What is Wei?',
-        a: 'Wei is the smallest denomination of Ether. 1 Ether = 10^18 Wei. The EVM internally represents all values in Wei. Named after Wei Dai, the cryptographer who created b-money.'
+        q: 'How much is 1 ETH in Wei?',
+        a: '1 ETH equals 1,000,000,000,000,000,000 Wei (10^18 Wei, or one quintillion Wei). Wei is the smallest unit of Ether, so every ETH amount is just this number scaled up or down. To convert ETH to Wei, multiply by 10^18; to convert Wei to ETH, divide by 10^18.'
+    },
+    {
+        q: 'How much is 1 Wei in ETH?',
+        a: '1 Wei equals 0.000000000000000001 ETH (10^-18 ETH). Wei is the smallest indivisible unit of Ether, so 1 Wei is the smallest amount of value the EVM can represent. You cannot send a fraction of a Wei.'
+    },
+    {
+        q: 'How much is 1 Gwei in Wei and ETH?',
+        a: '1 Gwei equals 1,000,000,000 Wei (10^9 Wei) and 0.000000001 ETH (10^-9 ETH). Gwei is the denomination most people use to read gas prices: a 20 Gwei gas price means each unit of gas costs 20,000,000,000 Wei.'
+    },
+    {
+        q: 'How much is 1 Wei in dollars?',
+        a: '1 Wei is 10^-18 ETH, so to get its dollar value you divide the current ETH price by 10^18 (one quintillion). For example, divide whatever ETH trades at today by 10^18. The result is far smaller than a cent, which is why Wei is never priced in dollars directly and gas costs are read in Gwei instead.'
+    },
+    {
+        q: 'What is Wei in Ethereum?',
+        a: 'Wei is the smallest denomination of Ether. 1 Ether = 10^18 Wei. The EVM internally represents all values in Wei, so contracts and transactions always work in whole Wei integers. Named after Wei Dai, the cryptographer who created b-money.'
     },
     {
         q: 'What is Gwei?',
@@ -202,12 +250,12 @@ const structuredData = [
 ];
 
 useHead({
-    title: 'Ethereum Unit Converter - Wei, Gwei, ETH | Ethernal',
+    title: 'Wei to ETH & Gwei Converter | Ethereum Unit Converter',
     meta: [
-        { name: 'description', content: 'Free Ethereum unit converter. Convert between Wei, Gwei, Ether, Finney, Szabo, and all EVM denominations. Arbitrary-precision, runs in your browser.' },
+        { name: 'description', content: 'Convert Wei to ETH, Gwei to ETH, ETH to Wei, and every Ethereum denomination instantly. Free, arbitrary-precision, runs in your browser with no rounding errors.' },
         { property: 'og:type', content: 'website' },
-        { property: 'og:title', content: 'Ethereum Unit Converter - Wei, Gwei, ETH | Ethernal' },
-        { property: 'og:description', content: 'Convert between Wei, Gwei, Ether, and all Ethereum denominations. Free, runs in your browser.' },
+        { property: 'og:title', content: 'Wei to ETH & Gwei Converter | Ethereum Unit Converter' },
+        { property: 'og:description', content: 'Convert Wei to ETH, Gwei to ETH, ETH to Wei, and every Ethereum denomination instantly. Free and runs in your browser.' },
         { property: 'og:url', content: 'https://tryethernal.com/tools/unit-converter' },
         { name: 'twitter:card', content: 'summary_large_image' }
     ],
@@ -262,6 +310,13 @@ useHead({
 }
 .inline-cta p { color: var(--text-secondary); font-size: 14px; margin: 0; }
 .btn-sm { padding: 8px 18px !important; font-size: 13px !important; white-space: nowrap; }
+
+/* Common conversions table */
+.conv-table { width: 100%; border-collapse: collapse; font-size: 14px; }
+.conv-table th { text-align: left; color: var(--text-muted); font-weight: 600; font-size: 12px; text-transform: uppercase; letter-spacing: 0.05em; padding: 10px 12px; border-bottom: 1px solid rgba(30,41,59,0.6); }
+.conv-table td { color: var(--text-secondary); padding: 12px; border-bottom: 1px solid rgba(30,41,59,0.4); }
+.conv-table td:first-child { color: var(--text-primary); font-weight: 500; }
+.conv-value { font-family: 'SF Mono', 'Fira Code', 'Courier New', monospace; font-size: 13px; }
 
 /* FAQ */
 .faq-list { max-width: 720px; margin: 0 auto; display: flex; flex-direction: column; gap: 8px; }

--- a/landing/src/router.js
+++ b/landing/src/router.js
@@ -17,6 +17,7 @@ export const routes = [
     { path: '/privacy', name: 'privacy', component: () => import('./pages/PrivacyPage.vue') },
     { path: '/arbitrum-orbit', name: 'arbitrum-orbit', component: () => import('./pages/OrbitPage.vue') },
     { path: '/op-stack', name: 'op-stack', component: () => import('./pages/OpStackPage.vue') },
+    { path: '/launch-block-explorer', name: 'launch-block-explorer', component: () => import('./pages/LaunchBlockExplorerPage.vue') },
 
     // Competitor comparison pages
     { path: '/blockscout-alternative', name: 'blockscout-alternative', component: () => import('./pages/compare/BlockscoutAlternativePage.vue') },

--- a/landing/src/sitemap.js
+++ b/landing/src/sitemap.js
@@ -11,6 +11,7 @@ const PRIORITY_MAP = {
     '/': { priority: '1.0', changefreq: 'weekly' },
     '/pricing': { priority: '0.8', changefreq: 'monthly' },
     '/features': { priority: '0.8', changefreq: 'monthly' },
+    '/launch-block-explorer': { priority: '0.8', changefreq: 'monthly' },
     '/developers': { priority: '0.7', changefreq: 'monthly' },
     '/teams': { priority: '0.7', changefreq: 'monthly' },
     '/contact-us': { priority: '0.5', changefreq: 'yearly' },


### PR DESCRIPTION
## What

A search-feedback SEO sprint driven by a live Google Search Console + DataForSEO run against \`tryethernal.com\`. Every change traces to a concrete GSC signal (impressions, position, CTR). Full findings in \`.claude/references/SERP-RESEARCH-FINDINGS.md\`.

## Changes

**CTR rewrites (page-1, ~0% CTR pages)** — title/meta only, no body edits
- \`the-commerce-layer-erc-8183\` (815 impr / 0% CTR @ pos 9): question-intent title
- \`etherscan/blockscout/routescan-alternative\` (250-385 impr / ~0% CTR @ pos 8-9): concrete differentiator hooks (self-host, \$0, 5-min, MIT)

**Converter tool SEO** (\`UnitConverterPage.vue\`)
- Retarget title to the actual GSC queries (wei to eth, gwei to eth)
- Answer the People-Also-Ask questions as FAQs
- Add a static, SSR-crawlable common-conversions table
- wei-in-dollars answer gives the formula, no hardcoded ETH price

**Explorer-discovery queries**
- Arbitrum/Optimism chain pages lead with "Arbitrum/Optimism Explorer" in title/H1/meta (also removes an em dash, per marketing copy style)
- \`best-block-explorers\` post: added ethereum/multi-chain/chain explorer FAQ entries for query-variant coverage

**New landing page** \`/launch-block-explorer\`
- Targets GSC quick-wins ranking pos 5-15 @ ~0% CTR (evm explorer, evm scan, block explorer hosting, launch custom block explorer)
- HowTo + FAQPage + BreadcrumbList JSON-LD; wired into router, sitemap, llms.txt, footer

**Docs**
- \`SERP-INTEGRATION-PLAN.md\` — plan to port ronda's GSC/DataForSEO feedback loop into this pipeline
- \`SERP-RESEARCH-FINDINGS.md\` — the live run that scoped this sprint

## Verification

- \`blog\` build: pass (astro build, 45 pages, Zod frontmatter validates)
- \`landing\` build: pass (vite-ssg, 49 sitemap URLs, new page renders, em-dash titles confirmed gone)
- Secret scan: clean (creds referenced by path only)

## Notes

- Branched fresh from \`develop\`; contains only this sprint's 5 commits.
- Follow-up (not in this PR): 19 more \`/chains/*\` pages share the same em-dash + buried-keyword title pattern — clean batch fix for later.