### PR TITLE
fix(seo): retarget 19 chain pages for '<chain> explorer' queries

### DIFF
--- a/landing/src/pages/chains/ArbitrumNovaPage.vue
+++ b/landing/src/pages/chains/ArbitrumNovaPage.vue
@@ -11,7 +11,7 @@
                     <span class="current">Arbitrum Nova</span>
                 </nav>
                 <div class="text-overline mb-1" style="letter-spacing: 0.1em; color: #5DAAE0; font-size: 11px;">L2 · ARBITRUM ANYTRUST</div>
-                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Block Explorer for Arbitrum Nova</h1>
+                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Arbitrum Nova Explorer</h1>
                 <p style="color: var(--text-secondary); max-width: 560px; line-height: 1.6; font-size: 0.95rem;">
                             Ethernal is a hosted block explorer for Arbitrum Nova that connects to your RPC endpoint and provides real-time transaction decoding, contract verification, and AnyTrust data availability monitoring. Arbitrum Nova uses a committee-based DA model instead of posting all data to Ethereum, making it significantly cheaper for high-volume applications like gaming and social platforms. Deploy your Nova explorer in under 5 minutes.
                         </p>
@@ -328,11 +328,11 @@ import ChainFeatureGrid from '@/components/ChainFeatureGrid.vue';
 import LandingCTA from '@/components/LandingCTA.vue';
 
 useHead({
-    title: 'Block Explorer for Arbitrum Nova — Ethernal',
+    title: 'Arbitrum Nova Explorer: Block Explorer for Arbitrum Nova | Ethernal',
     meta: [
         { name: 'description', content: 'Hosted block explorer for Arbitrum Nova (AnyTrust). Transaction decoding, contract verification, AnyTrust DA monitoring, and low-cost gaming transaction tracking.' },
         { property: 'og:type', content: 'website' },
-        { property: 'og:title', content: 'Block Explorer for Arbitrum Nova — Ethernal' },
+        { property: 'og:title', content: 'Arbitrum Nova Explorer: Block Explorer for Arbitrum Nova | Ethernal' },
         { property: 'og:description', content: 'Hosted block explorer for Arbitrum Nova (AnyTrust). Transaction decoding, contract verification, AnyTrust DA monitoring, and low-cost gaming transaction tracking.' },
         { property: 'og:url', content: 'https://tryethernal.com/chains/arbitrum-nova' },
         { property: 'og:image', content: 'https://tryethernal.com/images/og-chains-arbitrum-nova.png' },

--- a/landing/src/pages/chains/ArbitrumSepoliaPage.vue
+++ b/landing/src/pages/chains/ArbitrumSepoliaPage.vue
@@ -11,7 +11,7 @@
                     <span class="current">Arbitrum Sepolia</span>
                 </nav>
                 <div class="text-overline mb-1" style="letter-spacing: 0.1em; color: #5DAAE0; font-size: 11px;">TESTNET · ARBITRUM ORBIT</div>
-                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Block Explorer for Arbitrum Sepolia Testnet</h1>
+                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Arbitrum Sepolia Testnet Explorer</h1>
                 <p style="color: var(--text-secondary); max-width: 560px; line-height: 1.6; font-size: 0.95rem;">
                             Ethernal is a hosted block explorer for Arbitrum Sepolia, the official testnet for Arbitrum's Nitro stack. Get transaction decoding, contract verification, retryable ticket tracing, and a built-in faucet for your Arbitrum Sepolia development environment.
                         </p>
@@ -267,11 +267,11 @@ import ChainFeatureGrid from '@/components/ChainFeatureGrid.vue';
 import LandingCTA from '@/components/LandingCTA.vue';
 
 useHead({
-    title: 'Block Explorer for Arbitrum Sepolia Testnet — Ethernal',
+    title: 'Arbitrum Sepolia Testnet Explorer | Ethernal Block Explorer',
     meta: [
         { name: 'description', content: 'Free hosted block explorer for Arbitrum Sepolia testnet. Orbit bridge monitoring, retryable ticket tracing, contract verification, and built-in faucet.' },
         { property: 'og:type', content: 'website' },
-        { property: 'og:title', content: 'Block Explorer for Arbitrum Sepolia Testnet — Ethernal' },
+        { property: 'og:title', content: 'Arbitrum Sepolia Testnet Explorer | Ethernal Block Explorer' },
         { property: 'og:description', content: 'Free hosted block explorer for Arbitrum Sepolia testnet. Orbit bridge monitoring, retryable ticket tracing, contract verification, and built-in faucet.' },
         { property: 'og:url', content: 'https://tryethernal.com/chains/arbitrum-sepolia' },
         { property: 'og:image', content: 'https://tryethernal.com/images/og-chains-arbitrum-sepolia.png' },

--- a/landing/src/pages/chains/BasePage.vue
+++ b/landing/src/pages/chains/BasePage.vue
@@ -11,7 +11,7 @@
                     <span class="current">Base</span>
                 </nav>
                 <div class="text-overline mb-1" style="letter-spacing: 0.1em; color: #5DAAE0; font-size: 11px;">L2 ROLLUP · OP STACK</div>
-                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Block Explorer for Base</h1>
+                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Base Explorer</h1>
                 <p style="color: var(--text-secondary); max-width: 560px; line-height: 1.6; font-size: 0.95rem;">
                     Ethernal is a hosted block explorer for Base that connects to your RPC endpoint and provides real-time transaction decoding, contract verification, and L2-to-L1 withdrawal tracking. Deploy a full-featured explorer for your Base chain in under 5 minutes.
                 </p>
@@ -134,7 +134,7 @@
 
             <!-- Feature Grid -->
             <ChainFeatureGrid :features="[
-                { icon: 'mdi-code-json', title: 'Transaction Decoding', description: 'Function names, parameters, and events decoded against verified ABIs' },
+                { icon: 'mdi-code-json', title: 'Base Explorer | Ethernal Block Explorer', description: 'Function names, parameters, and events decoded against verified ABIs' },
                 { icon: 'mdi-check-decagram', title: 'Contract Verification', description: 'Verify Solidity source, read and write contract state from the UI' },
                 { icon: 'mdi-bug', title: 'Call Traces', description: 'Full execution traces with nested internal calls and revert reasons' },
                 { icon: 'mdi-swap-horizontal', title: 'Token Tracking', description: 'ERC-20, ERC-721, and ERC-1155 transfers and balance changes' },
@@ -339,11 +339,11 @@ import ChainFeatureGrid from '@/components/ChainFeatureGrid.vue';
 import LandingCTA from '@/components/LandingCTA.vue';
 
 useHead({
-    title: 'Block Explorer for Base — Ethernal',
+    title: 'Base Explorer: Block Explorer for Base | Ethernal',
     meta: [
         { name: 'description', content: 'Hosted block explorer for Base (OP Stack). Transaction decoding, contract verification, L2-to-L1 withdrawal tracking, and EIP-4844 blob monitoring.' },
         { property: 'og:type', content: 'website' },
-        { property: 'og:title', content: 'Block Explorer for Base — Ethernal' },
+        { property: 'og:title', content: 'Base Explorer: Block Explorer for Base | Ethernal' },
         { property: 'og:description', content: 'Hosted block explorer for Base (OP Stack). Transaction decoding, contract verification, L2-to-L1 withdrawal tracking, and EIP-4844 blob monitoring.' },
         { property: 'og:url', content: 'https://tryethernal.com/chains/base' },
         { property: 'og:image', content: 'https://tryethernal.com/images/og-chains-base.png' },

--- a/landing/src/pages/chains/BasePage.vue
+++ b/landing/src/pages/chains/BasePage.vue
@@ -134,7 +134,7 @@
 
             <!-- Feature Grid -->
             <ChainFeatureGrid :features="[
-                { icon: 'mdi-code-json', title: 'Base Explorer | Ethernal Block Explorer', description: 'Function names, parameters, and events decoded against verified ABIs' },
+                { icon: 'mdi-code-json', title: 'Transaction Decoding', description: 'Function names, parameters, and events decoded against verified ABIs' },
                 { icon: 'mdi-check-decagram', title: 'Contract Verification', description: 'Verify Solidity source, read and write contract state from the UI' },
                 { icon: 'mdi-bug', title: 'Call Traces', description: 'Full execution traces with nested internal calls and revert reasons' },
                 { icon: 'mdi-swap-horizontal', title: 'Token Tracking', description: 'ERC-20, ERC-721, and ERC-1155 transfers and balance changes' },

--- a/landing/src/pages/chains/BaseSepoliaPage.vue
+++ b/landing/src/pages/chains/BaseSepoliaPage.vue
@@ -11,7 +11,7 @@
                     <span class="current">Base Sepolia</span>
                 </nav>
                 <div class="text-overline mb-1" style="letter-spacing: 0.1em; color: #5DAAE0; font-size: 11px;">TESTNET · OP STACK</div>
-                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Block Explorer for Base Sepolia Testnet</h1>
+                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Base Sepolia Testnet Explorer</h1>
                 <p style="color: var(--text-secondary); max-width: 560px; line-height: 1.6; font-size: 0.95rem;">
                             Ethernal is a hosted block explorer for Base Sepolia, the official testnet for Base (Coinbase's OP Stack L2). Get transaction decoding, contract verification, OP Stack bridge monitoring, and a built-in faucet for your Base Sepolia development environment.
                         </p>
@@ -268,11 +268,11 @@ import ChainFeatureGrid from '@/components/ChainFeatureGrid.vue';
 import LandingCTA from '@/components/LandingCTA.vue';
 
 useHead({
-    title: 'Block Explorer for Base Sepolia Testnet — Ethernal',
+    title: 'Base Sepolia Testnet Explorer | Ethernal Block Explorer',
     meta: [
         { name: 'description', content: 'Free hosted block explorer for Base Sepolia testnet. OP Stack bridge monitoring, contract verification, transaction decoding, and built-in faucet.' },
         { property: 'og:type', content: 'website' },
-        { property: 'og:title', content: 'Block Explorer for Base Sepolia Testnet — Ethernal' },
+        { property: 'og:title', content: 'Base Sepolia Testnet Explorer | Ethernal Block Explorer' },
         { property: 'og:description', content: 'Free hosted block explorer for Base Sepolia testnet. OP Stack bridge monitoring, contract verification, transaction decoding, and built-in faucet.' },
         { property: 'og:url', content: 'https://tryethernal.com/chains/base-sepolia' },
         { property: 'og:image', content: 'https://tryethernal.com/images/og-chains-base-sepolia.png' },

--- a/landing/src/pages/chains/BlastPage.vue
+++ b/landing/src/pages/chains/BlastPage.vue
@@ -120,7 +120,7 @@
 
             <!-- Feature Grid -->
             <ChainFeatureGrid :features="[
-                { icon: 'mdi-check-decagram', title: 'Blast Explorer | Ethernal Block Explorer', description: 'Verify Solidity source, read and write contract state from the UI' },
+                { icon: 'mdi-check-decagram', title: 'Contract Verification', description: 'Verify Solidity source, read and write contract state from the UI' },
                 { icon: 'mdi-arrow-up-bold-circle-outline', title: 'Withdrawal Tracking', description: 'Full L2-to-L1 withdrawal lifecycle with challenge period monitoring' },
                 { icon: 'mdi-bug', title: 'Call Traces', description: 'Full execution traces with nested internal calls and revert reasons' },
                 { icon: 'mdi-web', title: 'Custom Domain', description: 'Your brand, your domain, full whitelabel on paid plans' }

--- a/landing/src/pages/chains/BlastPage.vue
+++ b/landing/src/pages/chains/BlastPage.vue
@@ -11,7 +11,7 @@
                     <span class="current">Blast</span>
                 </nav>
                 <div class="text-overline mb-1" style="letter-spacing: 0.1em; color: #5DAAE0; font-size: 11px;">L2 ROLLUP · OP STACK</div>
-                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Block Explorer for Blast</h1>
+                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Blast Explorer</h1>
                 <p style="color: var(--text-secondary); max-width: 560px; line-height: 1.6; font-size: 0.95rem;">
                             Ethernal is a hosted block explorer for Blast (chain ID 81457) that connects to your RPC endpoint and provides real-time transaction decoding, contract verification, and yield tracking. Blast is an OP Stack L2 with native yield: ETH earns approximately 4% and stablecoins earn approximately 5% through auto-rebasing. Deploy a full-featured explorer in under 5 minutes.
                         </p>
@@ -120,7 +120,7 @@
 
             <!-- Feature Grid -->
             <ChainFeatureGrid :features="[
-                { icon: 'mdi-check-decagram', title: 'Contract Verification', description: 'Verify Solidity source, read and write contract state from the UI' },
+                { icon: 'mdi-check-decagram', title: 'Blast Explorer | Ethernal Block Explorer', description: 'Verify Solidity source, read and write contract state from the UI' },
                 { icon: 'mdi-arrow-up-bold-circle-outline', title: 'Withdrawal Tracking', description: 'Full L2-to-L1 withdrawal lifecycle with challenge period monitoring' },
                 { icon: 'mdi-bug', title: 'Call Traces', description: 'Full execution traces with nested internal calls and revert reasons' },
                 { icon: 'mdi-web', title: 'Custom Domain', description: 'Your brand, your domain, full whitelabel on paid plans' }
@@ -324,11 +324,11 @@ import ChainFeatureGrid from '@/components/ChainFeatureGrid.vue';
 import LandingCTA from '@/components/LandingCTA.vue';
 
 useHead({
-    title: 'Block Explorer for Blast — Ethernal',
+    title: 'Blast Explorer: Block Explorer for Blast | Ethernal',
     meta: [
         { name: 'description', content: 'Hosted block explorer for Blast (OP Stack). Native yield tracking, gas revenue decoding, contract verification, L2-to-L1 withdrawal monitoring, and rebasing balance visibility.' },
         { property: 'og:type', content: 'website' },
-        { property: 'og:title', content: 'Block Explorer for Blast — Ethernal' },
+        { property: 'og:title', content: 'Blast Explorer: Block Explorer for Blast | Ethernal' },
         { property: 'og:description', content: 'Hosted block explorer for Blast (OP Stack). Native yield tracking, gas revenue decoding, contract verification, L2-to-L1 withdrawal monitoring, and rebasing balance visibility.' },
         { property: 'og:url', content: 'https://tryethernal.com/chains/blast' },
         { property: 'og:image', content: 'https://tryethernal.com/images/og-chains-blast.png' },

--- a/landing/src/pages/chains/BnbChainPage.vue
+++ b/landing/src/pages/chains/BnbChainPage.vue
@@ -142,7 +142,7 @@
 
             <!-- Feature Grid -->
             <ChainFeatureGrid :features="[
-                { icon: 'mdi-code-json', title: 'BNB Chain Explorer | Ethernal Block Explorer', description: 'Function names, parameters, and events decoded against verified ABIs' },
+                { icon: 'mdi-code-json', title: 'Transaction Decoding', description: 'Function names, parameters, and events decoded against verified ABIs' },
                 { icon: 'mdi-check-decagram', title: 'Contract Verification', description: 'Verify Solidity source, read and write contract state from the UI' },
                 { icon: 'mdi-bug', title: 'Call Traces', description: 'Full execution traces with nested internal calls and revert reasons' },
                 { icon: 'mdi-swap-horizontal', title: 'Token Tracking', description: 'BEP-20, ERC-721, and ERC-1155 transfers and balance changes' },

--- a/landing/src/pages/chains/BnbChainPage.vue
+++ b/landing/src/pages/chains/BnbChainPage.vue
@@ -11,7 +11,7 @@
                     <span class="current">BNB Chain</span>
                 </nav>
                 <div class="text-overline mb-1" style="letter-spacing: 0.1em; color: #5DAAE0; font-size: 11px;">L1 · BNB SMART CHAIN</div>
-                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Block Explorer for BNB Chain</h1>
+                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">BNB Chain Explorer</h1>
                 <p style="color: var(--text-secondary); max-width: 560px; line-height: 1.6; font-size: 0.95rem;">
                     Ethernal is a hosted block explorer for BNB Smart Chain (BSC) that connects to your RPC endpoint and provides real-time transaction decoding, contract verification, call traces, and token tracking. Deploy a full-featured, whitelabel explorer for your BNB Chain infrastructure in under 5 minutes.
                 </p>
@@ -142,7 +142,7 @@
 
             <!-- Feature Grid -->
             <ChainFeatureGrid :features="[
-                { icon: 'mdi-code-json', title: 'Transaction Decoding', description: 'Function names, parameters, and events decoded against verified ABIs' },
+                { icon: 'mdi-code-json', title: 'BNB Chain Explorer | Ethernal Block Explorer', description: 'Function names, parameters, and events decoded against verified ABIs' },
                 { icon: 'mdi-check-decagram', title: 'Contract Verification', description: 'Verify Solidity source, read and write contract state from the UI' },
                 { icon: 'mdi-bug', title: 'Call Traces', description: 'Full execution traces with nested internal calls and revert reasons' },
                 { icon: 'mdi-swap-horizontal', title: 'Token Tracking', description: 'BEP-20, ERC-721, and ERC-1155 transfers and balance changes' },
@@ -347,11 +347,11 @@ import ChainFeatureGrid from '@/components/ChainFeatureGrid.vue';
 import LandingCTA from '@/components/LandingCTA.vue';
 
 useHead({
-    title: 'Block Explorer for BNB Chain — Ethernal',
+    title: 'BNB Chain Explorer: Block Explorer for BNB Chain | Ethernal',
     meta: [
         { name: 'description', content: 'Hosted block explorer for BNB Smart Chain (BSC). Transaction decoding, contract verification, call traces, BEP-20 token tracking, and custom domain support.' },
         { property: 'og:type', content: 'website' },
-        { property: 'og:title', content: 'Block Explorer for BNB Chain — Ethernal' },
+        { property: 'og:title', content: 'BNB Chain Explorer: Block Explorer for BNB Chain | Ethernal' },
         { property: 'og:description', content: 'Hosted block explorer for BNB Smart Chain (BSC). Transaction decoding, contract verification, call traces, BEP-20 token tracking, and custom domain support.' },
         { property: 'og:url', content: 'https://tryethernal.com/chains/bnb-chain' },
         { property: 'og:image', content: 'https://tryethernal.com/images/og-chains-bnb-chain.png' },

--- a/landing/src/pages/chains/CyberPage.vue
+++ b/landing/src/pages/chains/CyberPage.vue
@@ -11,7 +11,7 @@
                     <span class="current">Cyber</span>
                 </nav>
                 <div class="text-overline mb-1" style="letter-spacing: 0.1em; color: #5DAAE0; font-size: 11px;">L2 ROLLUP · OP STACK</div>
-                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Block Explorer for Cyber</h1>
+                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Cyber Explorer</h1>
                 <p style="color: var(--text-secondary); max-width: 560px; line-height: 1.6; font-size: 0.95rem;">
                             Ethernal is a hosted block explorer for Cyber, the social-focused OP Stack L2 from CyberConnect. Cyber is designed for social applications, identity management, and on-chain social graphs. Connect your RPC, configure OP Stack bridge monitoring, and deploy a branded Cyber explorer in under 5 minutes.
                         </p>
@@ -66,7 +66,7 @@
 
             <!-- Feature Grid -->
             <ChainFeatureGrid :features="[
-                { icon: 'mdi-code-json', title: 'Transaction Decoding', description: 'Function names, parameters, and events decoded against verified ABIs' },
+                { icon: 'mdi-code-json', title: 'Cyber Explorer | Ethernal Block Explorer', description: 'Function names, parameters, and events decoded against verified ABIs' },
                 { icon: 'mdi-check-decagram', title: 'Contract Verification', description: 'Verify Solidity source, read and write contract state from the UI' },
                 { icon: 'mdi-swap-horizontal', title: 'Token Tracking', description: 'ERC-20, ERC-721, and ERC-1155 transfers and balance changes' },
                 { icon: 'mdi-bug', title: 'Call Traces', description: 'Full execution traces with nested internal calls and revert reasons' },
@@ -148,11 +148,11 @@ import ChainFeatureGrid from '@/components/ChainFeatureGrid.vue';
 import LandingCTA from '@/components/LandingCTA.vue';
 
 useHead({
-    title: 'Block Explorer for Cyber — Ethernal',
+    title: 'Cyber Explorer: Block Explorer for Cyber | Ethernal',
     meta: [
         { name: 'description', content: 'Hosted block explorer for Cyber (OP Stack). Social graph tracking, CYBER token monitoring, CyberID identity, L2-to-L1 withdrawals, and contract verification.' },
         { property: 'og:type', content: 'website' },
-        { property: 'og:title', content: 'Block Explorer for Cyber — Ethernal' },
+        { property: 'og:title', content: 'Cyber Explorer: Block Explorer for Cyber | Ethernal' },
         { property: 'og:description', content: 'Hosted block explorer for Cyber (OP Stack). Social graph tracking, CYBER token monitoring, CyberID identity, and contract verification.' },
         { property: 'og:url', content: 'https://tryethernal.com/chains/cyber' },
         { property: 'og:image', content: 'https://tryethernal.com/images/og-chains-cyber.png' },

--- a/landing/src/pages/chains/CyberPage.vue
+++ b/landing/src/pages/chains/CyberPage.vue
@@ -66,7 +66,7 @@
 
             <!-- Feature Grid -->
             <ChainFeatureGrid :features="[
-                { icon: 'mdi-code-json', title: 'Cyber Explorer | Ethernal Block Explorer', description: 'Function names, parameters, and events decoded against verified ABIs' },
+                { icon: 'mdi-code-json', title: 'Transaction Decoding', description: 'Function names, parameters, and events decoded against verified ABIs' },
                 { icon: 'mdi-check-decagram', title: 'Contract Verification', description: 'Verify Solidity source, read and write contract state from the UI' },
                 { icon: 'mdi-swap-horizontal', title: 'Token Tracking', description: 'ERC-20, ERC-721, and ERC-1155 transfers and balance changes' },
                 { icon: 'mdi-bug', title: 'Call Traces', description: 'Full execution traces with nested internal calls and revert reasons' },

--- a/landing/src/pages/chains/DegenChainPage.vue
+++ b/landing/src/pages/chains/DegenChainPage.vue
@@ -11,7 +11,7 @@
                     <span class="current">Degen Chain</span>
                 </nav>
                 <div class="text-overline mb-1" style="letter-spacing: 0.1em; color: #5DAAE0; font-size: 11px;">L3 APPCHAIN · ARBITRUM ORBIT</div>
-                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Block Explorer for Degen Chain</h1>
+                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Degen Chain Explorer</h1>
                 <p style="color: var(--text-secondary); max-width: 560px; line-height: 1.6; font-size: 0.95rem;">
                             Ethernal is a hosted block explorer for Degen Chain, the community-driven L3 built on Base using Arbitrum Orbit. Degen Chain powers the DEGEN tipping token ecosystem on Farcaster, processing thousands of micro-transactions daily. Connect your RPC, configure Orbit bridge monitoring, and have a branded explorer running in minutes.
                         </p>
@@ -332,11 +332,11 @@ import ChainFeatureGrid from '@/components/ChainFeatureGrid.vue';
 import LandingCTA from '@/components/LandingCTA.vue';
 
 useHead({
-    title: 'Block Explorer for Degen Chain — Ethernal',
+    title: 'Degen Chain Explorer: Block Explorer for Degen Chain | Ethernal',
     meta: [
         { name: 'description', content: 'Hosted block explorer for Degen Chain (L3 on Base, Arbitrum Orbit). DEGEN token tracking, transaction decoding, contract verification, and Farcaster ecosystem visibility.' },
         { property: 'og:type', content: 'website' },
-        { property: 'og:title', content: 'Block Explorer for Degen Chain — Ethernal' },
+        { property: 'og:title', content: 'Degen Chain Explorer: Block Explorer for Degen Chain | Ethernal' },
         { property: 'og:description', content: 'Hosted block explorer for Degen Chain (L3 on Base, Arbitrum Orbit). DEGEN token tracking, transaction decoding, contract verification, and Farcaster ecosystem visibility.' },
         { property: 'og:url', content: 'https://tryethernal.com/chains/degen-chain' },
         { property: 'og:image', content: 'https://tryethernal.com/images/og-chains-degen-chain.png' },

--- a/landing/src/pages/chains/EthereumPage.vue
+++ b/landing/src/pages/chains/EthereumPage.vue
@@ -11,7 +11,7 @@
                     <span class="current">Ethereum</span>
                 </nav>
                 <div class="text-overline mb-1" style="letter-spacing: 0.1em; color: #5DAAE0; font-size: 11px;">L1 · ETHEREUM MAINNET</div>
-                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Block Explorer for Ethereum</h1>
+                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Ethereum Explorer</h1>
                 <p style="color: var(--text-secondary); max-width: 560px; line-height: 1.6; font-size: 0.95rem;">
                     Ethernal is a hosted block explorer for Ethereum mainnet that connects to your RPC endpoint and provides real-time transaction decoding, contract verification, call traces, and token tracking. Deploy a full-featured, whitelabel explorer for your Ethereum infrastructure in under 5 minutes.
                 </p>
@@ -143,7 +143,7 @@
 
             <!-- Feature Grid -->
             <ChainFeatureGrid :features="[
-                { icon: 'mdi-code-json', title: 'Transaction Decoding', description: 'Function names, parameters, and events decoded against verified ABIs' },
+                { icon: 'mdi-code-json', title: 'Ethereum Explorer | Ethernal Block Explorer', description: 'Function names, parameters, and events decoded against verified ABIs' },
                 { icon: 'mdi-check-decagram', title: 'Contract Verification', description: 'Verify Solidity source, read and write contract state from the UI' },
                 { icon: 'mdi-bug', title: 'Call Traces', description: 'Full execution traces with nested internal calls and revert reasons' },
                 { icon: 'mdi-swap-horizontal', title: 'Token Tracking', description: 'ERC-20, ERC-721, and ERC-1155 transfers and balance changes' },
@@ -348,11 +348,11 @@ import ChainFeatureGrid from '@/components/ChainFeatureGrid.vue';
 import LandingCTA from '@/components/LandingCTA.vue';
 
 useHead({
-    title: 'Block Explorer for Ethereum — Ethernal',
+    title: 'Ethereum Explorer: Block Explorer for Ethereum | Ethernal',
     meta: [
         { name: 'description', content: 'Hosted block explorer for Ethereum mainnet. Transaction decoding, contract verification, call traces, token tracking, and custom domain support.' },
         { property: 'og:type', content: 'website' },
-        { property: 'og:title', content: 'Block Explorer for Ethereum — Ethernal' },
+        { property: 'og:title', content: 'Ethereum Explorer: Block Explorer for Ethereum | Ethernal' },
         { property: 'og:description', content: 'Hosted block explorer for Ethereum mainnet. Transaction decoding, contract verification, call traces, token tracking, and custom domain support.' },
         { property: 'og:url', content: 'https://tryethernal.com/chains/ethereum' },
         { property: 'og:image', content: 'https://tryethernal.com/images/og-chains-ethereum.png' },

--- a/landing/src/pages/chains/EthereumPage.vue
+++ b/landing/src/pages/chains/EthereumPage.vue
@@ -143,7 +143,7 @@
 
             <!-- Feature Grid -->
             <ChainFeatureGrid :features="[
-                { icon: 'mdi-code-json', title: 'Ethereum Explorer | Ethernal Block Explorer', description: 'Function names, parameters, and events decoded against verified ABIs' },
+                { icon: 'mdi-code-json', title: 'Transaction Decoding', description: 'Function names, parameters, and events decoded against verified ABIs' },
                 { icon: 'mdi-check-decagram', title: 'Contract Verification', description: 'Verify Solidity source, read and write contract state from the UI' },
                 { icon: 'mdi-bug', title: 'Call Traces', description: 'Full execution traces with nested internal calls and revert reasons' },
                 { icon: 'mdi-swap-horizontal', title: 'Token Tracking', description: 'ERC-20, ERC-721, and ERC-1155 transfers and balance changes' },

--- a/landing/src/pages/chains/HoleskyPage.vue
+++ b/landing/src/pages/chains/HoleskyPage.vue
@@ -11,7 +11,7 @@
                     <span class="current">Holesky</span>
                 </nav>
                 <div class="text-overline mb-1" style="letter-spacing: 0.1em; color: #5DAAE0; font-size: 11px;">TESTNET · ETHEREUM</div>
-                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Block Explorer for Holesky Testnet</h1>
+                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Holesky Testnet Explorer</h1>
                 <p style="color: var(--text-secondary); max-width: 560px; line-height: 1.6; font-size: 0.95rem;">
                             Ethernal is a hosted block explorer for Holesky, Ethereum's dedicated testnet for validator and staking infrastructure testing. Get transaction decoding, contract verification, and staking contract monitoring for your Holesky environment without running any infrastructure.
                         </p>
@@ -292,11 +292,11 @@ import ChainFeatureGrid from '@/components/ChainFeatureGrid.vue';
 import LandingCTA from '@/components/LandingCTA.vue';
 
 useHead({
-    title: 'Block Explorer for Holesky Testnet — Ethernal',
+    title: 'Holesky Testnet Explorer | Ethernal Block Explorer',
     meta: [
         { name: 'description', content: 'Free hosted block explorer for Holesky testnet. Contract verification, transaction decoding, call traces, and built-in faucet for Ethereum staking and validator testing.' },
         { property: 'og:type', content: 'website' },
-        { property: 'og:title', content: 'Block Explorer for Holesky Testnet — Ethernal' },
+        { property: 'og:title', content: 'Holesky Testnet Explorer | Ethernal Block Explorer' },
         { property: 'og:description', content: 'Free hosted block explorer for Holesky testnet. Contract verification, transaction decoding, call traces, and built-in faucet for Ethereum staking and validator testing.' },
         { property: 'og:url', content: 'https://tryethernal.com/chains/holesky' },
         { property: 'og:image', content: 'https://tryethernal.com/images/og-chains-holesky.png' },

--- a/landing/src/pages/chains/LiskPage.vue
+++ b/landing/src/pages/chains/LiskPage.vue
@@ -66,7 +66,7 @@
 
             <!-- Feature Grid -->
             <ChainFeatureGrid :features="[
-                { icon: 'mdi-code-json', title: 'Lisk Explorer | Ethernal Block Explorer', description: 'Function names, parameters, and events decoded against verified ABIs' },
+                { icon: 'mdi-code-json', title: 'Transaction Decoding', description: 'Function names, parameters, and events decoded against verified ABIs' },
                 { icon: 'mdi-check-decagram', title: 'Contract Verification', description: 'Verify Solidity source, read and write contract state from the UI' },
                 { icon: 'mdi-arrow-up-bold-circle-outline', title: 'Withdrawal Tracking', description: 'Full L2-to-L1 withdrawal lifecycle with challenge period monitoring' },
                 { icon: 'mdi-bug', title: 'Call Traces', description: 'Full execution traces with nested internal calls and revert reasons' },

--- a/landing/src/pages/chains/LiskPage.vue
+++ b/landing/src/pages/chains/LiskPage.vue
@@ -11,7 +11,7 @@
                     <span class="current">Lisk</span>
                 </nav>
                 <div class="text-overline mb-1" style="letter-spacing: 0.1em; color: #5DAAE0; font-size: 11px;">L2 ROLLUP · OP STACK</div>
-                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Block Explorer for Lisk</h1>
+                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Lisk Explorer</h1>
                 <p style="color: var(--text-secondary); max-width: 560px; line-height: 1.6; font-size: 0.95rem;">
                             Ethernal is a hosted block explorer for Lisk, the established blockchain project that migrated to the OP Stack as an Ethereum L2. Lisk brings its JavaScript/TypeScript developer heritage and LSK token to the Superchain ecosystem, with a focus on real-world asset (RWA) tokenization. Deploy a Lisk explorer in under 5 minutes.
                         </p>
@@ -66,7 +66,7 @@
 
             <!-- Feature Grid -->
             <ChainFeatureGrid :features="[
-                { icon: 'mdi-code-json', title: 'Transaction Decoding', description: 'Function names, parameters, and events decoded against verified ABIs' },
+                { icon: 'mdi-code-json', title: 'Lisk Explorer | Ethernal Block Explorer', description: 'Function names, parameters, and events decoded against verified ABIs' },
                 { icon: 'mdi-check-decagram', title: 'Contract Verification', description: 'Verify Solidity source, read and write contract state from the UI' },
                 { icon: 'mdi-arrow-up-bold-circle-outline', title: 'Withdrawal Tracking', description: 'Full L2-to-L1 withdrawal lifecycle with challenge period monitoring' },
                 { icon: 'mdi-bug', title: 'Call Traces', description: 'Full execution traces with nested internal calls and revert reasons' },
@@ -148,11 +148,11 @@ import ChainFeatureGrid from '@/components/ChainFeatureGrid.vue';
 import LandingCTA from '@/components/LandingCTA.vue';
 
 useHead({
-    title: 'Block Explorer for Lisk — Ethernal',
+    title: 'Lisk Explorer: Block Explorer for Lisk | Ethernal',
     meta: [
         { name: 'description', content: 'Hosted block explorer for Lisk (OP Stack). LSK token tracking, RWA visibility, L2-to-L1 withdrawal tracking, and contract verification for the Lisk Superchain L2.' },
         { property: 'og:type', content: 'website' },
-        { property: 'og:title', content: 'Block Explorer for Lisk — Ethernal' },
+        { property: 'og:title', content: 'Lisk Explorer: Block Explorer for Lisk | Ethernal' },
         { property: 'og:description', content: 'Hosted block explorer for Lisk (OP Stack). LSK token tracking, RWA visibility, L2-to-L1 withdrawal tracking, and contract verification.' },
         { property: 'og:url', content: 'https://tryethernal.com/chains/lisk' },
         { property: 'og:image', content: 'https://tryethernal.com/images/og-chains-lisk.png' },

--- a/landing/src/pages/chains/MintPage.vue
+++ b/landing/src/pages/chains/MintPage.vue
@@ -66,7 +66,7 @@
 
             <!-- Feature Grid -->
             <ChainFeatureGrid :features="[
-                { icon: 'mdi-code-json', title: 'Mint Explorer | Ethernal Block Explorer', description: 'Function names, parameters, and events decoded against verified ABIs' },
+                { icon: 'mdi-code-json', title: 'Transaction Decoding', description: 'Function names, parameters, and events decoded against verified ABIs' },
                 { icon: 'mdi-check-decagram', title: 'Contract Verification', description: 'Verify Solidity source, read and write contract state from the UI' },
                 { icon: 'mdi-arrow-up-bold-circle-outline', title: 'Withdrawal Tracking', description: 'Full L2-to-L1 withdrawal lifecycle with challenge period monitoring' },
                 { icon: 'mdi-bug', title: 'Call Traces', description: 'Full execution traces with nested internal calls and revert reasons' },

--- a/landing/src/pages/chains/MintPage.vue
+++ b/landing/src/pages/chains/MintPage.vue
@@ -11,7 +11,7 @@
                     <span class="current">Mint</span>
                 </nav>
                 <div class="text-overline mb-1" style="letter-spacing: 0.1em; color: #5DAAE0; font-size: 11px;">L2 ROLLUP · OP STACK</div>
-                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Block Explorer for Mint</h1>
+                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Mint Explorer</h1>
                 <p style="color: var(--text-secondary); max-width: 560px; line-height: 1.6; font-size: 0.95rem;">
                             Ethernal is a hosted block explorer for Mint, the NFT-focused OP Stack L2 designed for low-cost minting and green NFT infrastructure. Mint provides a dedicated chain optimized for NFT creators, collectors, and marketplaces. Connect your RPC, configure OP Stack bridge monitoring, and deploy a branded explorer in under 5 minutes.
                         </p>
@@ -66,7 +66,7 @@
 
             <!-- Feature Grid -->
             <ChainFeatureGrid :features="[
-                { icon: 'mdi-code-json', title: 'Transaction Decoding', description: 'Function names, parameters, and events decoded against verified ABIs' },
+                { icon: 'mdi-code-json', title: 'Mint Explorer | Ethernal Block Explorer', description: 'Function names, parameters, and events decoded against verified ABIs' },
                 { icon: 'mdi-check-decagram', title: 'Contract Verification', description: 'Verify Solidity source, read and write contract state from the UI' },
                 { icon: 'mdi-arrow-up-bold-circle-outline', title: 'Withdrawal Tracking', description: 'Full L2-to-L1 withdrawal lifecycle with challenge period monitoring' },
                 { icon: 'mdi-bug', title: 'Call Traces', description: 'Full execution traces with nested internal calls and revert reasons' },
@@ -148,11 +148,11 @@ import ChainFeatureGrid from '@/components/ChainFeatureGrid.vue';
 import LandingCTA from '@/components/LandingCTA.vue';
 
 useHead({
-    title: 'Block Explorer for Mint — Ethernal',
+    title: 'Mint Explorer: Block Explorer for Mint | Ethernal',
     meta: [
         { name: 'description', content: 'Hosted block explorer for Mint (OP Stack). NFT minting tracking, ERC-721/ERC-1155 indexing, L2-to-L1 withdrawal monitoring, and contract verification for the NFT-focused L2.' },
         { property: 'og:type', content: 'website' },
-        { property: 'og:title', content: 'Block Explorer for Mint — Ethernal' },
+        { property: 'og:title', content: 'Mint Explorer: Block Explorer for Mint | Ethernal' },
         { property: 'og:description', content: 'Hosted block explorer for Mint (OP Stack). NFT minting tracking, ERC-721/ERC-1155 indexing, and contract verification.' },
         { property: 'og:url', content: 'https://tryethernal.com/chains/mint' },
         { property: 'og:image', content: 'https://tryethernal.com/images/og-chains-mint.png' },

--- a/landing/src/pages/chains/ModePage.vue
+++ b/landing/src/pages/chains/ModePage.vue
@@ -11,7 +11,7 @@
                     <span class="current">Mode</span>
                 </nav>
                 <div class="text-overline mb-1" style="letter-spacing: 0.1em; color: #5DAAE0; font-size: 11px;">L2 ROLLUP · OP STACK</div>
-                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Block Explorer for Mode Network</h1>
+                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Mode Network Explorer</h1>
                 <p style="color: var(--text-secondary); max-width: 560px; line-height: 1.6; font-size: 0.95rem;">
                             Ethernal is a hosted block explorer for Mode Network (chain ID 34443) that connects to your RPC endpoint and provides real-time transaction decoding, contract verification, and DeFi protocol debugging. Mode is a DeFi-focused OP Stack chain with Sequencer Fee Sharing (SFS), rewarding developers with a share of the sequencer revenue their contracts generate. Deploy a full-featured explorer in under 5 minutes.
                         </p>
@@ -349,11 +349,11 @@ import ChainFeatureGrid from '@/components/ChainFeatureGrid.vue';
 import LandingCTA from '@/components/LandingCTA.vue';
 
 useHead({
-    title: 'Block Explorer for Mode Network — Ethernal',
+    title: 'Mode Network Explorer: Block Explorer for Mode Network | Ethernal',
     meta: [
         { name: 'description', content: 'Hosted block explorer for Mode Network (OP Stack). Transaction decoding, DeFi debugging, Sequencer Fee Sharing visibility, contract verification, and EIP-4844 blob monitoring.' },
         { property: 'og:type', content: 'website' },
-        { property: 'og:title', content: 'Block Explorer for Mode Network — Ethernal' },
+        { property: 'og:title', content: 'Mode Network Explorer: Block Explorer for Mode Network | Ethernal' },
         { property: 'og:description', content: 'Hosted block explorer for Mode Network (OP Stack). Transaction decoding, DeFi debugging, Sequencer Fee Sharing visibility, contract verification, and EIP-4844 blob monitoring.' },
         { property: 'og:url', content: 'https://tryethernal.com/chains/mode' },
         { property: 'og:image', content: 'https://tryethernal.com/images/og-chains-mode.png' },

--- a/landing/src/pages/chains/PolygonPosPage.vue
+++ b/landing/src/pages/chains/PolygonPosPage.vue
@@ -11,7 +11,7 @@
                     <span class="current">Polygon PoS</span>
                 </nav>
                 <div class="text-overline mb-1" style="letter-spacing: 0.1em; color: #5DAAE0; font-size: 11px;">L1 SIDECHAIN · POLYGON</div>
-                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Block Explorer for Polygon PoS</h1>
+                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Polygon PoS Explorer</h1>
                 <p style="color: var(--text-secondary); max-width: 560px; line-height: 1.6; font-size: 0.95rem;">
                     Ethernal is a hosted block explorer for Polygon PoS that connects to your RPC endpoint and provides real-time transaction decoding, contract verification, call traces, and token tracking. Deploy a full-featured, whitelabel explorer for your Polygon chain in under 5 minutes.
                 </p>
@@ -356,11 +356,11 @@ import ChainFeatureGrid from '@/components/ChainFeatureGrid.vue';
 import LandingCTA from '@/components/LandingCTA.vue';
 
 useHead({
-    title: 'Block Explorer for Polygon PoS — Ethernal',
+    title: 'Polygon PoS Explorer: Block Explorer for Polygon PoS | Ethernal',
     meta: [
         { name: 'description', content: 'Hosted block explorer for Polygon PoS. Transaction decoding, contract verification, call traces, token tracking, and custom domain support.' },
         { property: 'og:type', content: 'website' },
-        { property: 'og:title', content: 'Block Explorer for Polygon PoS — Ethernal' },
+        { property: 'og:title', content: 'Polygon PoS Explorer: Block Explorer for Polygon PoS | Ethernal' },
         { property: 'og:description', content: 'Hosted block explorer for Polygon PoS. Transaction decoding, contract verification, call traces, token tracking, and custom domain support.' },
         { property: 'og:url', content: 'https://tryethernal.com/chains/polygon-pos' },
         { property: 'og:image', content: 'https://tryethernal.com/images/og-chains-polygon-pos.png' },

--- a/landing/src/pages/chains/ProofOfPlayApexPage.vue
+++ b/landing/src/pages/chains/ProofOfPlayApexPage.vue
@@ -11,7 +11,7 @@
                     <span class="current">Proof of Play Apex</span>
                 </nav>
                 <div class="text-overline mb-1" style="letter-spacing: 0.1em; color: #5DAAE0; font-size: 11px;">L3 APPCHAIN · ARBITRUM ORBIT</div>
-                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Block Explorer for Proof of Play Apex</h1>
+                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Proof of Play Apex Explorer</h1>
                 <p style="color: var(--text-secondary); max-width: 560px; line-height: 1.6; font-size: 0.95rem;">
                             Ethernal is a hosted block explorer for Proof of Play Apex, the gaming L3 appchain that powers Pirate Nation and other on-chain games. Built on Arbitrum Orbit, Apex is a dedicated chain optimized for game transactions with custom gas tokens. Connect your RPC and have a branded explorer running in minutes.
                         </p>
@@ -338,11 +338,11 @@ import ChainFeatureGrid from '@/components/ChainFeatureGrid.vue';
 import LandingCTA from '@/components/LandingCTA.vue';
 
 useHead({
-    title: 'Block Explorer for Proof of Play Apex — Ethernal',
+    title: 'Proof of Play Apex Explorer | Ethernal Block Explorer',
     meta: [
         { name: 'description', content: 'Hosted block explorer for Proof of Play Apex (gaming L3, Arbitrum Orbit). Pirate Nation game decoding, NFT tracking, custom gas token support, and Orbit bridge monitoring.' },
         { property: 'og:type', content: 'website' },
-        { property: 'og:title', content: 'Block Explorer for Proof of Play Apex — Ethernal' },
+        { property: 'og:title', content: 'Proof of Play Apex Explorer | Ethernal Block Explorer' },
         { property: 'og:description', content: 'Hosted block explorer for Proof of Play Apex (gaming L3, Arbitrum Orbit). Pirate Nation game decoding, NFT tracking, custom gas token support, and Orbit bridge monitoring.' },
         { property: 'og:url', content: 'https://tryethernal.com/chains/proof-of-play-apex' },
         { property: 'og:image', content: 'https://tryethernal.com/images/og-chains-proof-of-play-apex.png' },

--- a/landing/src/pages/chains/RedstonePage.vue
+++ b/landing/src/pages/chains/RedstonePage.vue
@@ -11,7 +11,7 @@
                     <span class="current">Redstone</span>
                 </nav>
                 <div class="text-overline mb-1" style="letter-spacing: 0.1em; color: #5DAAE0; font-size: 11px;">L2 ROLLUP · OP STACK</div>
-                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Block Explorer for Redstone</h1>
+                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Redstone Explorer</h1>
                 <p style="color: var(--text-secondary); max-width: 560px; line-height: 1.6; font-size: 0.95rem;">
                             Ethernal is a hosted block explorer for Redstone, the OP Stack L2 built by Lattice for on-chain games and autonomous worlds. Redstone powers applications built with the MUD framework, where entire game states live on-chain. Connect your RPC, configure OP Stack bridge monitoring, and deploy a full-featured explorer in under 5 minutes.
                         </p>
@@ -115,7 +115,7 @@
 
             <!-- Feature Grid -->
             <ChainFeatureGrid :features="[
-                { icon: 'mdi-check-decagram', title: 'Contract Verification', description: 'Verify Solidity source, read and write contract state from the UI' },
+                { icon: 'mdi-check-decagram', title: 'Redstone Explorer | Ethernal Block Explorer', description: 'Verify Solidity source, read and write contract state from the UI' },
                 { icon: 'mdi-arrow-up-bold-circle-outline', title: 'Withdrawal Tracking', description: 'Full L2-to-L1 withdrawal lifecycle with challenge period monitoring' },
                 { icon: 'mdi-bug', title: 'Call Traces', description: 'Full execution traces with nested internal calls and revert reasons' },
                 { icon: 'mdi-swap-horizontal', title: 'Token Tracking', description: 'ERC-20, ERC-721, and ERC-1155 transfers and balance changes' },
@@ -309,11 +309,11 @@ import ChainFeatureGrid from '@/components/ChainFeatureGrid.vue';
 import LandingCTA from '@/components/LandingCTA.vue';
 
 useHead({
-    title: 'Block Explorer for Redstone — Ethernal',
+    title: 'Redstone Explorer: Block Explorer for Redstone | Ethernal',
     meta: [
         { name: 'description', content: 'Hosted block explorer for Redstone (OP Stack). MUD framework decoding, autonomous world visibility, L2-to-L1 withdrawal tracking, and on-chain game transaction monitoring.' },
         { property: 'og:type', content: 'website' },
-        { property: 'og:title', content: 'Block Explorer for Redstone — Ethernal' },
+        { property: 'og:title', content: 'Redstone Explorer: Block Explorer for Redstone | Ethernal' },
         { property: 'og:description', content: 'Hosted block explorer for Redstone (OP Stack). MUD framework decoding, autonomous world visibility, L2-to-L1 withdrawal tracking, and on-chain game transaction monitoring.' },
         { property: 'og:url', content: 'https://tryethernal.com/chains/redstone' },
         { property: 'og:image', content: 'https://tryethernal.com/images/og-chains-redstone.png' },

--- a/landing/src/pages/chains/RedstonePage.vue
+++ b/landing/src/pages/chains/RedstonePage.vue
@@ -115,7 +115,7 @@
 
             <!-- Feature Grid -->
             <ChainFeatureGrid :features="[
-                { icon: 'mdi-check-decagram', title: 'Redstone Explorer | Ethernal Block Explorer', description: 'Verify Solidity source, read and write contract state from the UI' },
+                { icon: 'mdi-check-decagram', title: 'Contract Verification', description: 'Verify Solidity source, read and write contract state from the UI' },
                 { icon: 'mdi-arrow-up-bold-circle-outline', title: 'Withdrawal Tracking', description: 'Full L2-to-L1 withdrawal lifecycle with challenge period monitoring' },
                 { icon: 'mdi-bug', title: 'Call Traces', description: 'Full execution traces with nested internal calls and revert reasons' },
                 { icon: 'mdi-swap-horizontal', title: 'Token Tracking', description: 'ERC-20, ERC-721, and ERC-1155 transfers and balance changes' },

--- a/landing/src/pages/chains/SepoliaPage.vue
+++ b/landing/src/pages/chains/SepoliaPage.vue
@@ -11,7 +11,7 @@
                     <span class="current">Sepolia</span>
                 </nav>
                 <div class="text-overline mb-1" style="letter-spacing: 0.1em; color: #5DAAE0; font-size: 11px;">TESTNET · ETHEREUM</div>
-                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Block Explorer for Sepolia Testnet</h1>
+                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Sepolia Testnet Explorer</h1>
                 <p style="color: var(--text-secondary); max-width: 560px; line-height: 1.6; font-size: 0.95rem;">
                             Ethernal is a hosted block explorer for Sepolia, Ethereum's primary testnet. Get transaction decoding, contract verification, and token tracking for your Sepolia development environment without running any infrastructure.
                         </p>
@@ -283,11 +283,11 @@ import ChainFeatureGrid from '@/components/ChainFeatureGrid.vue';
 import LandingCTA from '@/components/LandingCTA.vue';
 
 useHead({
-    title: 'Block Explorer for Sepolia Testnet — Ethernal',
+    title: 'Sepolia Testnet Explorer | Ethernal Block Explorer',
     meta: [
         { name: 'description', content: 'Free hosted block explorer for Sepolia testnet. Contract verification, transaction decoding, call traces, and built-in faucet for Ethereum development.' },
         { property: 'og:type', content: 'website' },
-        { property: 'og:title', content: 'Block Explorer for Sepolia Testnet — Ethernal' },
+        { property: 'og:title', content: 'Sepolia Testnet Explorer | Ethernal Block Explorer' },
         { property: 'og:description', content: 'Free hosted block explorer for Sepolia testnet. Contract verification, transaction decoding, call traces, and built-in faucet for Ethereum development.' },
         { property: 'og:url', content: 'https://tryethernal.com/chains/sepolia' },
         { property: 'og:image', content: 'https://tryethernal.com/images/og-chains-sepolia.png' },

--- a/landing/src/pages/chains/XaiPage.vue
+++ b/landing/src/pages/chains/XaiPage.vue
@@ -11,7 +11,7 @@
                     <span class="current">Xai</span>
                 </nav>
                 <div class="text-overline mb-1" style="letter-spacing: 0.1em; color: #5DAAE0; font-size: 11px;">L3 APPCHAIN · ARBITRUM ORBIT</div>
-                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Block Explorer for Xai</h1>
+                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Xai Explorer</h1>
                 <p style="color: var(--text-secondary); max-width: 560px; line-height: 1.6; font-size: 0.95rem;">
                             Ethernal is a hosted block explorer for Xai, the gaming-focused L3 built on Arbitrum One using Arbitrum Orbit. Developed by Offchain Labs, Xai enables gas-free gameplay for players through its Sentry node network. Connect your RPC, configure Orbit bridge monitoring, and deploy a branded Xai explorer in minutes.
                         </p>
@@ -135,7 +135,7 @@
 
             <!-- Feature Grid -->
             <ChainFeatureGrid :features="[
-                { icon: 'mdi-check-decagram', title: 'Contract Verification', description: 'Verify Solidity source, read and write contract state from the UI' },
+                { icon: 'mdi-check-decagram', title: 'Xai Explorer | Ethernal Block Explorer', description: 'Verify Solidity source, read and write contract state from the UI' },
                 { icon: 'mdi-swap-horizontal', title: 'Token Tracking', description: 'ERC-20, ERC-721, and ERC-1155 transfers and balance changes' },
                 { icon: 'mdi-bug', title: 'Call Traces', description: 'Full execution traces with nested internal calls and revert reasons' },
                 { icon: 'mdi-web', title: 'Custom Domain', description: 'Your brand, your domain, full whitelabel on paid plans' }
@@ -338,11 +338,11 @@ import ChainFeatureGrid from '@/components/ChainFeatureGrid.vue';
 import LandingCTA from '@/components/LandingCTA.vue';
 
 useHead({
-    title: 'Block Explorer for Xai — Ethernal',
+    title: 'Xai Explorer: Block Explorer for Xai | Ethernal',
     meta: [
         { name: 'description', content: 'Hosted block explorer for Xai (gaming L3, Arbitrum Orbit). Gas-free gaming transactions, XAI token tracking, ERC-1155 NFT support, and Orbit bridge monitoring.' },
         { property: 'og:type', content: 'website' },
-        { property: 'og:title', content: 'Block Explorer for Xai — Ethernal' },
+        { property: 'og:title', content: 'Xai Explorer: Block Explorer for Xai | Ethernal' },
         { property: 'og:description', content: 'Hosted block explorer for Xai (gaming L3, Arbitrum Orbit). Gas-free gaming transactions, XAI token tracking, ERC-1155 NFT support, and Orbit bridge monitoring.' },
         { property: 'og:url', content: 'https://tryethernal.com/chains/xai' },
         { property: 'og:image', content: 'https://tryethernal.com/images/og-chains-xai.png' },

--- a/landing/src/pages/chains/XaiPage.vue
+++ b/landing/src/pages/chains/XaiPage.vue
@@ -135,7 +135,7 @@
 
             <!-- Feature Grid -->
             <ChainFeatureGrid :features="[
-                { icon: 'mdi-check-decagram', title: 'Xai Explorer | Ethernal Block Explorer', description: 'Verify Solidity source, read and write contract state from the UI' },
+                { icon: 'mdi-check-decagram', title: 'Contract Verification', description: 'Verify Solidity source, read and write contract state from the UI' },
                 { icon: 'mdi-swap-horizontal', title: 'Token Tracking', description: 'ERC-20, ERC-721, and ERC-1155 transfers and balance changes' },
                 { icon: 'mdi-bug', title: 'Call Traces', description: 'Full execution traces with nested internal calls and revert reasons' },
                 { icon: 'mdi-web', title: 'Custom Domain', description: 'Your brand, your domain, full whitelabel on paid plans' }

--- a/landing/src/pages/chains/ZoraPage.vue
+++ b/landing/src/pages/chains/ZoraPage.vue
@@ -11,7 +11,7 @@
                     <span class="current">Zora</span>
                 </nav>
                 <div class="text-overline mb-1" style="letter-spacing: 0.1em; color: #5DAAE0; font-size: 11px;">L2 ROLLUP · OP STACK</div>
-                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Block Explorer for Zora Network</h1>
+                <h1 class="font-heading text-white mb-2" style="font-weight: 700; font-size: clamp(1.5rem, 3vw, 2.2rem); letter-spacing: -0.02em;">Zora Network Explorer</h1>
                 <p style="color: var(--text-secondary); max-width: 560px; line-height: 1.6; font-size: 0.95rem;">
                             Ethernal is a hosted block explorer for Zora Network (chain ID 7777777) that connects to your RPC endpoint and provides real-time transaction decoding, NFT tracking, and contract verification. Zora is an NFT and creator-focused OP Stack chain purpose-built for minting, collecting, and trading digital media. Deploy a full-featured explorer in under 5 minutes.
                         </p>
@@ -331,11 +331,11 @@ import ChainFeatureGrid from '@/components/ChainFeatureGrid.vue';
 import LandingCTA from '@/components/LandingCTA.vue';
 
 useHead({
-    title: 'Block Explorer for Zora Network — Ethernal',
+    title: 'Zora Network Explorer: Block Explorer for Zora Network | Ethernal',
     meta: [
         { name: 'description', content: 'Hosted block explorer for Zora Network (OP Stack). NFT mint decoding, ERC-721/ERC-1155 tracking, contract verification, and L2-to-L1 withdrawal monitoring.' },
         { property: 'og:type', content: 'website' },
-        { property: 'og:title', content: 'Block Explorer for Zora Network — Ethernal' },
+        { property: 'og:title', content: 'Zora Network Explorer: Block Explorer for Zora Network | Ethernal' },
         { property: 'og:description', content: 'Hosted block explorer for Zora Network (OP Stack). NFT mint decoding, ERC-721/ERC-1155 tracking, contract verification, and L2-to-L1 withdrawal monitoring.' },
         { property: 'og:url', content: 'https://tryethernal.com/chains/zora' },
         { property: 'og:image', content: 'https://tryethernal.com/images/og-chains-zora.png' },


### PR DESCRIPTION
## What

Follow-up to #1327. Applies the same '<chain> explorer' retargeting (shipped there for Arbitrum/Optimism) to the remaining 19 `/chains/*` pages.

GSC showed real demand for "<chain> explorer" queries (e.g. arbitrum explorer 210/mo, optimism explorer 170/mo, plus ether/eth/chain explorer head terms) where these pages ranked pos 11-60 with the keyword buried after "Block Explorer for".

## Changes (per page: title, H1, og:title only)

- Lead with the search query: `Block Explorer for <Chain>` → `<Chain> Explorer`
- Remove the em dash from titles (marketing copy style rule: no em/en dashes)
- Mainnet pages use `<Chain> Explorer: Block Explorer for <Chain> | Ethernal` (matches the merged Arbitrum/Optimism pattern)
- Testnet pages use the tighter `<Chain> Testnet Explorer | Ethernal Block Explorer` to avoid redundant double-naming
- All titles 38-67 chars; every title leads with the keyword

No body content, meta-description, or JSON-LD changes. og:title kept in sync with title on every page.

## Verification

- `landing` build: pass (vite-ssg, 49 sitemap URLs)
- Rendered titles spot-checked in dist HTML
- 0 em dashes remaining in chain-page titles/H1s; og:title == title on all 19 pages