### PR TITLE
ci(blog): activate search-feedback layer in trend-scan workflow

### DIFF
--- a/.github/workflows/blog-trend-scan.yml
+++ b/.github/workflows/blog-trend-scan.yml
@@ -28,10 +28,13 @@ jobs:
         working-directory: blog/pipeline
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
-          # Search-feedback layer (best-effort). If any of these are absent the
-          # pipeline degrades to editorial scoring only — see
-          # .claude/references/MARKETING.md "Search-feedback layer".
+          # Search-feedback layer (best-effort; degrades to editorial scoring
+          # only if absent). See .claude/references/MARKETING.md.
+          # DataForSEO is consumed NOW by enrich-keywords.mjs (keyword volume).
           DATAFORSEO_LOGIN: ${{ secrets.DATAFORSEO_LOGIN }}
           DATAFORSEO_PASSWORD: ${{ secrets.DATAFORSEO_PASSWORD }}
+          # GSC is NOT yet read by `node index.js` — its consumers (refresh /
+          # content-gap selection) land in Phase 4. Provisioned here so the
+          # secret is ready and `gsc.mjs` can be run standalone in the meantime.
           GSC_SERVICE_ACCOUNT_JSON_B64: ${{ secrets.GSC_SERVICE_ACCOUNT_JSON_B64 }}
         run: node index.js

--- a/.github/workflows/blog-trend-scan.yml
+++ b/.github/workflows/blog-trend-scan.yml
@@ -28,4 +28,10 @@ jobs:
         working-directory: blog/pipeline
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
+          # Search-feedback layer (best-effort). If any of these are absent the
+          # pipeline degrades to editorial scoring only — see
+          # .claude/references/MARKETING.md "Search-feedback layer".
+          DATAFORSEO_LOGIN: ${{ secrets.DATAFORSEO_LOGIN }}
+          DATAFORSEO_PASSWORD: ${{ secrets.DATAFORSEO_PASSWORD }}
+          GSC_SERVICE_ACCOUNT_JSON_B64: ${{ secrets.GSC_SERVICE_ACCOUNT_JSON_B64 }}
         run: node index.js


### PR DESCRIPTION
Passes the search-feedback secrets into the Blog Trend Scan workflow's `node index.js` step.

**Active now:** `DATAFORSEO_LOGIN` / `DATAFORSEO_PASSWORD` — consumed by `enrich-keywords.mjs` for keyword-volume enrichment (the layer added in #1329).

**Provisioned but not yet consumed:** `GSC_SERVICE_ACCOUNT_JSON_B64` — `index.js` does not import `gsc.mjs` yet; its consumers (GSC-driven refresh / content-gap selection) are Phase 4. The secret is set now so it's ready for Phase 4 and so `gsc.mjs` can be run standalone. (Thanks Greptile for catching the overstatement.)

Best-effort: missing secrets → graceful no-op, pipeline behaves as today. Workflow env only, no code changes. DataForSEO cost is cents/week (30d cache).