### PR TITLE
feat(blog-pipeline): wire keyword + SERP grounding into the draft flow (Phase 3)

### DIFF
--- a/blog/pipeline/draft.sh
+++ b/blog/pipeline/draft.sh
@@ -133,8 +133,36 @@ cd "$REPO_DIR"
 # Write card body to file for Claude to read (avoids shell interpolation)
 printf '**Topic:** %s\n**Content Type:** %s\n\n%s' "$TOPIC" "$CONTENT_TYPE" "$CARD_BODY" > blog/pipeline/.card-body.md
 
-# Clean up any previous research notes
-rm -f blog/pipeline/.research-notes.md
+# Clean up any previous research notes + stale SERP hints
+rm -f blog/pipeline/.research-notes.md blog/pipeline/.serp-terms.json
+
+# ------------------------------------------------------------
+# SERP coverage pre-flight (best-effort, never fatal).
+# If the picked card carries a primary keyword (from the weekly DataForSEO
+# enrichment), fetch top-SERP term/entity coverage hints for the draft phase.
+# Writes blog/pipeline/.serp-terms.json. Degrades to a clean no-op when no
+# primary keyword is present or DATAFORSEO_* creds are unset — the prompts
+# treat a missing/skip file as "draft without coverage grounding".
+# ------------------------------------------------------------
+PRIMARY_KW=$(CARD_BODY="$CARD_BODY" node --input-type=module -e "
+  import { parsePrimaryKeyword } from './blog/pipeline/project.js';
+  process.stdout.write(parsePrimaryKeyword(process.env.CARD_BODY || ''));
+" 2>/dev/null || true)
+
+if [ -n "$PRIMARY_KW" ]; then
+  log "Primary keyword: $PRIMARY_KW — fetching SERP coverage hints..."
+  if node blog/pipeline/serp-terms.mjs --keyword "$PRIMARY_KW" > blog/pipeline/.serp-terms.json 2>>"$LOG_FILE"; then
+    SERP_STATUS=$(jq -r '.status // "unknown"' blog/pipeline/.serp-terms.json 2>/dev/null || echo unknown)
+    log "SERP coverage: $SERP_STATUS"
+    # On skip (no creds / quota), remove the file so prompts see "absent" cleanly.
+    [ "$SERP_STATUS" != "ok" ] && rm -f blog/pipeline/.serp-terms.json
+  else
+    log "SERP coverage fetch failed (non-fatal); drafting without it"
+    rm -f blog/pipeline/.serp-terms.json
+  fi
+else
+  log "No primary keyword on card — drafting without SERP coverage hints"
+fi
 
 # ============================================================
 # PHASE 1: Research

--- a/blog/pipeline/project.js
+++ b/blog/pipeline/project.js
@@ -125,6 +125,21 @@ function buildKeywordBlock(topic) {
 }
 
 /**
+ * Extract the primary keyword from a card body's "Top keywords" block.
+ * The block (written by buildKeywordBlock) marks the primary row with
+ * "(primary)". Returns the phrase, or '' when the card wasn't enriched.
+ * Used by draft.sh to seed serp-terms.mjs and the draft prompts.
+ * @param {string} body
+ * @returns {string}
+ */
+export function parsePrimaryKeyword(body) {
+  if (!body || typeof body !== 'string') return '';
+  // Match: "- **<phrase>** — <vol>/mo, <COMP> (primary)"
+  const m = body.match(/^-\s+\*\*(.+?)\*\*\s+[—-].*\(primary\)\s*$/m);
+  return m ? m[1].trim() : '';
+}
+
+/**
  * Build the card body markdown.
  * @param {{label: string, score: number, items: Array, contentType: string, counts: object}} topic
  * @returns {string}

--- a/blog/pipeline/prompts/1-research.md
+++ b/blog/pipeline/prompts/1-research.md
@@ -8,7 +8,9 @@ Ethernal is an open-source block explorer for EVM-based chains. Target audience:
 
 ## Your Task
 
-Read `blog/pipeline/.card-body.md` for the topic and source links.
+Read `blog/pipeline/.card-body.md` for the topic and source links. If the card body has a `### Top keywords (search intent)` section, those are real Google search phrases your audience types — note which appear in the sources you read; they're the natural vocabulary to ground the post in (not a checklist).
+
+**SERP context (optional):** if `blog/pipeline/.serp-terms.json` exists and has `"status": "ok"`, skim its `relatedSearches[]` and `peopleAlsoAsk[]` — they reveal the real questions readers ask around the primary keyword. Use them to spot 1-2 angles or sub-questions worth covering. The `entities[]` list shows which tools/products competitors mention. If the file is absent or `"status": "skipped"`, just research normally — no coverage grounding is available and that's fine.
 
 1. **WebSearch** each source link from the card. For EIP/ERC GitHub PRs, fetch the actual proposal content. Also search for 2-3 additional authoritative sources (official docs, dev blogs from OpenZeppelin/Trail of Bits/Paradigm/Consensys, research papers).
 

--- a/blog/pipeline/prompts/2-draft.md
+++ b/blog/pipeline/prompts/2-draft.md
@@ -16,6 +16,30 @@ Read 2-3 existing articles in `blog/src/content/blog/` to match the tone. Antoin
 
 Read `blog/pipeline/.research-notes.md` for the research brief (sources, outline, angle). Read `blog/pipeline/.card-body.md` for the Content Type.
 
+## Search grounding (read before drafting)
+
+The card body (`blog/pipeline/.card-body.md`) may include a `### Top keywords (search intent)` section listing real Google search phrases with monthly volume, one marked `(primary)`. These come from DataForSEO keyword data — the phrases your audience actually types.
+
+**When a `(primary)` keyword is present:**
+1. It MUST appear in the article `title:` frontmatter.
+2. It SHOULD appear once in the first 150 words of the body, in a sentence that genuinely uses the phrase.
+3. Weave 1-3 of the other listed phrases into headings/body **only where they fit naturally**. Drop any that would require contorted phrasing — Phase 3 flags keyword-stuffing.
+4. Put the primary keyword first in the `keywords:` frontmatter array, followed by the other phrases you actually used.
+
+**If the primary keyword doesn't fit the strongest angle from research:** don't contort the post. Use the next-best listed phrase in the title and opening instead. Editorial quality beats any keyword heuristic.
+
+**When there is no keyword section** (enrichment unavailable): draft normally and set `keywords: []` in frontmatter. Same voice, same quality bar.
+
+### SERP coverage hints (soft — optional)
+
+If `blog/pipeline/.serp-terms.json` exists with `"status": "ok"`, it has:
+- `terms[]` — vocabulary competitors use most (a reading list, not a checklist)
+- `entities[]` — tools/products that appear in competing pages (mention if relevant, ignore if not)
+- `peopleAlsoAsk[]` — reader questions; answering one or two directly in a section is a strong AI-citation win
+- `relatedSearches[]` — adjacent angles readers care about
+
+**Anti-stuffing (non-negotiable):** coverage is SOFT. Use a term only if it fits a sentence you'd write anyway. If the file is absent or `"status": "skipped"`, draft without it — same quality bar. Never mention the skip in the post.
+
 **Content Type formats:**
 - "ERC Tutorial": Code-heavy, working Solidity, deploy instructions, practical examples
 - "EIP Explainer": What it changes, why it matters, before/after code examples
@@ -92,11 +116,16 @@ date: YYYY-MM-DD
 tags:
   - Tag1
   - Tag2
+keywords:
+  - primary search phrase (from the card's Top keywords, marked primary)
+  - other phrases you actually wove into the body, in volume order
 image: "/blog/images/<slug>.png"
 ogImage: "/blog/images/<slug>-og.png"
 status: published
 readingTime: N
 ---
 ```
+
+`keywords:` is the SEO-grounding array (separate from reader-facing `tags`). Populate it from the card's Top keywords section — primary first, then any others you genuinely used. If there was no keyword section, write `keywords: []`. It renders into JSON-LD `BlogPosting.keywords`, not as UI chips.
 
 Then output the file path on a line starting with `::article-path::`

--- a/blog/src/layouts/PostLayout.astro
+++ b/blog/src/layouts/PostLayout.astro
@@ -23,7 +23,10 @@ interface Props {
 }
 
 const { post } = Astro.props;
-const { title, date, description, tags, image, ogImage, readingTime } = post.data;
+const { title, date, description, tags, keywords, image, ogImage, readingTime } = post.data;
+// JSON-LD keywords: prefer the dedicated SEO `keywords` field (populated by the
+// enrichment pipeline); fall back to reader-facing `tags` for posts without it.
+const jsonLdKeywords = (Array.isArray(keywords) && keywords.length > 0 ? keywords : tags).join(", ");
 
 const formattedDate = date.toLocaleDateString('en-US', {
   year: 'numeric',
@@ -118,7 +121,7 @@ if (has('Comparison') || /alternative|vs |best/i.test(title)) {
       "url": "https://tryethernal.com",
       "logo": { "@type": "ImageObject", "url": "https://tryethernal.com/favicon.ico" }
     },
-    "keywords": tags.join(", "),
+    "keywords": jsonLdKeywords,
     "wordCount": readingTime ? readingTime * 250 : undefined,
     "mainEntityOfPage": {
       "@type": "WebPage",


### PR DESCRIPTION
## What

Connects the search-feedback layer (#1329) to the **draft side** of the pipeline (`draft.sh` + prompts), so enriched keywords and SERP hints actually shape the posts that get written. Until this PR, enrichment ran in the weekly trend scan but `draft.sh` ignored it.

## Changes

- **`draft.sh` pre-flight** — after picking a card, parse its primary keyword (`parsePrimaryKeyword` in `project.js`) and run `serp-terms.mjs` to fetch top-SERP term/entity coverage into `.serp-terms.json`. Best-effort: no primary keyword or no `DATAFORSEO_*` creds → clean no-op, draft proceeds exactly as before.
- **`prompts/1-research.md`** — read the card's `### Top keywords` + `.serp-terms.json` (`relatedSearches`/`peopleAlsoAsk`) as research angles.
- **`prompts/2-draft.md`** — ground the title, first 150 words, and `keywords:` frontmatter in the primary keyword; weave SERP terms softly (anti-stuffing already enforced in Phase 3 humanize). Honest escape hatch when the keyword doesn't fit the angle.
- **`PostLayout.astro`** — render the dedicated `keywords[]` field into JSON-LD `BlogPosting.keywords` (falls back to `tags` for posts that don't have it).

## Verification

- `draft.sh`: `bash -n` clean
- `parsePrimaryKeyword`: unit-tested (parses primary row, returns '' when absent/empty)
- `blog` build: pass (45 pages); existing posts fall back to `tags` in JSON-LD as expected
- Graceful no-op confirmed: missing primary keyword / creds → draft unchanged

## Scope

Phase 4 (GSC-driven refresh-vs-new pick + `refresh.mjs` + `updatedDate`) is the next, separate PR. This PR makes the **new-post** draft path fully keyword/SERP-grounded.