### PR TITLE
feat(blog-pipeline): search-feedback layer — SERP draft grounding + GSC refresh mode (Phases 3+4)

### DIFF
--- a/.claude/references/SERP-INTEGRATION-PLAN.md
+++ b/.claude/references/SERP-INTEGRATION-PLAN.md
@@ -3,7 +3,11 @@
 Plan to port ronda's search-feedback blog pipeline (GSC signals, DataForSEO keyword
 enrichment, SERP coverage hints, refresh-mode) into ethernal-marketing's pipeline.
 
-**Status:** Proposal. Not yet implemented.
+**Status:** Phases 0–4 implemented on `seo-refresh-mode`. Phase 5 (sitemap re-ping)
+and Phase 6 (quality gates) remain. Phase 4 (GSC-driven pick + refresh-mode) wired:
+`refresh.mjs`, `findRefreshCandidate`/`slugFromPageUrl`/`postExists` in `project.js`,
+the `--pick` refresh branch in `index.js`, the `draft.sh` refresh-mode branch, and
+`updatedDate` in `content.config.ts` + `PostLayout.astro`.
 **Source of truth studied:** `~/projects/ronda/blog/pipeline/` + ronda design docs
 (`docs/superpowers/specs/2026-05-25-blog-keyword-enrichment-design.md`,
 `docs/superpowers/handoffs/2026-05-27-blog-pipeline-sensai-integration.md`) +

--- a/blog/pipeline/draft.sh
+++ b/blog/pipeline/draft.sh
@@ -133,8 +133,36 @@ cd "$REPO_DIR"
 # Write card body to file for Claude to read (avoids shell interpolation)
 printf '**Topic:** %s\n**Content Type:** %s\n\n%s' "$TOPIC" "$CONTENT_TYPE" "$CARD_BODY" > blog/pipeline/.card-body.md
 
-# Clean up any previous research notes
-rm -f blog/pipeline/.research-notes.md
+# Clean up any previous research notes + stale SERP hints
+rm -f blog/pipeline/.research-notes.md blog/pipeline/.serp-terms.json
+
+# ------------------------------------------------------------
+# SERP coverage pre-flight (best-effort, never fatal).
+# If the picked card carries a primary keyword (from the weekly DataForSEO
+# enrichment), fetch top-SERP term/entity coverage hints for the draft phase.
+# Writes blog/pipeline/.serp-terms.json. Degrades to a clean no-op when no
+# primary keyword is present or DATAFORSEO_* creds are unset — the prompts
+# treat a missing/skip file as "draft without coverage grounding".
+# ------------------------------------------------------------
+PRIMARY_KW=$(CARD_BODY="$CARD_BODY" node --input-type=module -e "
+  import { parsePrimaryKeyword } from './blog/pipeline/project.js';
+  process.stdout.write(parsePrimaryKeyword(process.env.CARD_BODY || ''));
+" 2>/dev/null || true)
+
+if [ -n "$PRIMARY_KW" ]; then
+  log "Primary keyword: $PRIMARY_KW — fetching SERP coverage hints..."
+  if node blog/pipeline/serp-terms.mjs --keyword "$PRIMARY_KW" > blog/pipeline/.serp-terms.json 2>>"$LOG_FILE"; then
+    SERP_STATUS=$(jq -r '.status // "unknown"' blog/pipeline/.serp-terms.json 2>/dev/null || echo unknown)
+    log "SERP coverage: $SERP_STATUS"
+    # On skip (no creds / quota), remove the file so prompts see "absent" cleanly.
+    [ "$SERP_STATUS" != "ok" ] && rm -f blog/pipeline/.serp-terms.json
+  else
+    log "SERP coverage fetch failed (non-fatal); drafting without it"
+    rm -f blog/pipeline/.serp-terms.json
+  fi
+else
+  log "No primary keyword on card — drafting without SERP coverage hints"
+fi
 
 # ============================================================
 # PHASE 1: Research

--- a/blog/pipeline/draft.sh
+++ b/blog/pipeline/draft.sh
@@ -117,6 +117,11 @@ echo "$PICK_OUTPUT" | tee -a "$LOG_FILE"
 # ============================================================
 REFRESH=$(echo "$PICK_OUTPUT" | grep '::refresh::' | sed 's/::refresh:://' || true)
 if [ -n "$REFRESH" ]; then
+  # The pick ran from blog/pipeline (cd on line 102). Return to the repo root so
+  # every path in this block (refresh.mjs, .refresh-plan.json, the Claude prompt,
+  # git add of the repo-root-relative filePath) resolves correctly, mirroring the
+  # `cd "$REPO_DIR"` the new-post path does before using repo-relative paths.
+  cd "$REPO_DIR"
   REFRESH_SLUG=$(echo "$REFRESH" | jq -r '.slug')
   REFRESH_SIGNAL=$(echo "$REFRESH" | jq -r '.signal')
   REFRESH_FILE=$(echo "$REFRESH" | jq -r '.filePath')

--- a/blog/pipeline/draft.sh
+++ b/blog/pipeline/draft.sh
@@ -102,10 +102,118 @@ git pull --ff-only origin develop 2>&1 | tee -a "$LOG_FILE"
 cd blog/pipeline
 npm ci --silent 2>&1 | tee -a "$LOG_FILE"
 
-# Pick the next topic
+# Pick the next action — either a GSC-driven refresh of an existing post
+# (::refresh::) or a new draft from the backlog (::picked::).
 log "Picking next topic..."
 PICK_OUTPUT=$(node index.js --pick 2>&1)
 echo "$PICK_OUTPUT" | tee -a "$LOG_FILE"
+
+# ============================================================
+# REFRESH MODE (Phase 4): a Search Console signal mapped to an existing post.
+# Refresh it in place per the structured plan from refresh.mjs, then commit
+# directly to develop with a `chore(blog): refresh` message (ethernal
+# publishes directly — no review PR). Self-contained: this branch exits when
+# done and never falls through to the new-post flow below.
+# ============================================================
+REFRESH=$(echo "$PICK_OUTPUT" | grep '::refresh::' | sed 's/::refresh:://' || true)
+if [ -n "$REFRESH" ]; then
+  REFRESH_SLUG=$(echo "$REFRESH" | jq -r '.slug')
+  REFRESH_SIGNAL=$(echo "$REFRESH" | jq -r '.signal')
+  REFRESH_FILE=$(echo "$REFRESH" | jq -r '.filePath')
+  TOPIC="refresh:$REFRESH_SLUG"
+  log "Refresh mode: $REFRESH_SLUG (signal: $REFRESH_SIGNAL, file: $REFRESH_FILE)"
+
+  if [ ! -f "$REPO_DIR/$REFRESH_FILE" ]; then
+    log "ERROR: refresh target file not found: $REFRESH_FILE"
+    report_failure "Refresh (target file missing)"
+    exit 1
+  fi
+
+  # Build the structured refresh plan. refresh.mjs reads the envelope from the
+  # pick and emits a deterministic plan (strategy, target paragraphs, checks,
+  # frontmatter set/preserve, commit message). Best-effort: a non-zero exit
+  # aborts the refresh cleanly without touching the post.
+  echo "$REFRESH" > /tmp/blog-refresh-pick.json
+  REFRESH_PLAN=$(node blog/pipeline/refresh.mjs --input /tmp/blog-refresh-pick.json 2>>"$LOG_FILE") || {
+    log "ERROR: refresh.mjs failed to produce a plan"
+    report_failure "Refresh (plan generation)"
+    exit 1
+  }
+  echo "$REFRESH_PLAN" > blog/pipeline/.refresh-plan.json
+  log "Refresh plan: $(echo "$REFRESH_PLAN" | jq -r '.plan.strategy')"
+
+  # Single Claude call to execute the plan against the post in place.
+  log "Refresh: applying plan with Claude..."
+  REFRESH_OUTPUT=$(claude -p "Refresh the existing blog post at $REFRESH_FILE in place, following the structured plan in blog/pipeline/.refresh-plan.json.
+
+The plan was produced from a Google Search Console signal. Read blog/pipeline/.refresh-plan.json: it contains the refresh \`strategy\`, the \`targetParagraphs\` to edit (with rationale), the \`checks\` you MUST satisfy, the GSC \`metrics\` that triggered this, and \`frontmatter.set\` / \`frontmatter.preserve\`.
+
+Rules:
+- Execute exactly the plan's strategy. Do NOT restructure or rewrite the whole post.
+- Set every frontmatter field in \`frontmatter.set\` (notably updatedDate). Do NOT change any field listed in \`frontmatter.preserve\`.
+- Satisfy every item in \`checks\`. No em-dashes anywhere in changed text.
+- description must stay <= 160 characters.
+- Edit ONLY the file $REFRESH_FILE. Do not create new files." \
+    --dangerously-skip-permissions \
+    --mcp-config "$MCP_CONFIG" \
+    --max-turns 30 \
+    2>&1)
+  echo "$REFRESH_OUTPUT" | tee -a "$LOG_FILE"
+
+  # Confirm the refresh actually bumped updatedDate (the plan's required edit).
+  if ! grep -q '^updatedDate:' "$REPO_DIR/$REFRESH_FILE"; then
+    log "ERROR: refresh did not set updatedDate in $REFRESH_FILE"
+    report_failure "Refresh (no updatedDate set)"
+    exit 1
+  fi
+
+  # Hard safety net: strip any em dashes that survived.
+  if grep -q '—' "$REPO_DIR/$REFRESH_FILE"; then
+    log "WARNING: Em dashes survived refresh — stripping with sed"
+    sed -i 's/—/,/g' "$REPO_DIR/$REFRESH_FILE"
+  fi
+
+  # Validate the build (Zod schema: description <=160, valid dates, etc.).
+  log "Refresh: validating blog build..."
+  cd "$REPO_DIR/blog"
+  if ! npx astro sync 2>&1 | tee -a "$LOG_FILE"; then
+    log "ERROR: refresh failed Astro validation"
+    report_failure "Refresh (build validation)"
+    exit 1
+  fi
+  cd "$REPO_DIR"
+  log "Refresh: build validation passed."
+
+  # Commit directly to develop with the plan's `chore(blog): refresh` message.
+  REFRESH_MSG=$(echo "$REFRESH_PLAN" | jq -r '.plan.commit.message')
+  git add "$REFRESH_FILE"
+  git commit -m "$REFRESH_MSG" 2>&1 | tee -a "$LOG_FILE"
+
+  # Push with the same rebase-retry the publish path uses.
+  PUSH_ATTEMPTS=0
+  PUSH_MAX_ATTEMPTS=3
+  until git push origin develop 2>&1 | tee -a "$LOG_FILE"; do
+    PUSH_ATTEMPTS=$((PUSH_ATTEMPTS + 1))
+    log "Push rejected (attempt $PUSH_ATTEMPTS/$PUSH_MAX_ATTEMPTS)."
+    if [ "$PUSH_ATTEMPTS" -ge "$PUSH_MAX_ATTEMPTS" ]; then
+      log "ERROR: refresh push failed after $PUSH_MAX_ATTEMPTS attempts"
+      report_failure "Refresh git push (exhausted retries)"
+      exit 1
+    fi
+    log "Rebasing onto latest develop and retrying..."
+    git fetch origin develop 2>&1 | tee -a "$LOG_FILE"
+    git rebase origin/develop 2>&1 | tee -a "$LOG_FILE" || {
+      log "ERROR: rebase failed — aborting"
+      git rebase --abort 2>&1 | tee -a "$LOG_FILE" || true
+      report_failure "Refresh git rebase"
+      exit 1
+    }
+  done
+
+  rm -f blog/pipeline/.refresh-plan.json /tmp/blog-refresh-pick.json
+  log "Refresh complete: https://tryethernal.com/blog/$REFRESH_SLUG"
+  exit 0
+fi
 
 PICKED=$(echo "$PICK_OUTPUT" | grep '::picked::' | sed 's/::picked:://' || true)
 if [ -z "$PICKED" ]; then

--- a/blog/pipeline/index.js
+++ b/blog/pipeline/index.js
@@ -19,18 +19,54 @@ import {
 } from './collect.js';
 import { classifyAndScore } from './classify.js';
 import { enrichCandidates } from './enrich-keywords.mjs';
-import { createProjectCard, pickNextTopic, getProjectItems } from './project.js';
+import { createProjectCard, pickNextTopic, getProjectItems, findRefreshCandidate } from './project.js';
+import { fetchGscSignals } from './gsc.mjs';
 import { CLUSTERS } from './config.js';
 
 const dryRun = process.argv.includes('--dry-run');
 const pickMode = process.argv.includes('--pick');
+// --skip-refresh forces new-post mode (bypasses the GSC signal lookup). Used
+// when the consumer can't yet handle a refresh, or to force a fresh draft.
+const skipRefresh = process.argv.includes('--skip-refresh');
 
 async function main() {
   console.log(`Blog Trend Pipeline — ${new Date().toISOString()}`);
 
-  // --pick mode: just pick the next topic for drafting (every-2-day cadence)
+  // --pick mode: decide the next blog action for the every-2-day cadence.
+  // First try GSC-driven refresh-mode (Phase 4): if a Search Console signal
+  // (quick-win / decay / ctr-opportunity) maps to an existing post, refreshing
+  // it beats drafting new. Otherwise fall through to new-post round-robin.
   if (pickMode) {
     console.log(dryRun ? '(DRY RUN — pick mode)\n' : '(Pick mode)\n');
+
+    // GSC refresh lookup. Best-effort + graceful no-op: when credentials are
+    // absent or the API is down, fetchGscSignals() returns { status:'skipped' }
+    // and findRefreshCandidate() returns null — we simply pick a new topic, so
+    // behavior is byte-identical to pre-Phase-4 when GSC isn't wired.
+    if (!skipRefresh) {
+      let gsc = { status: 'skipped', reason: 'unknown' };
+      try {
+        gsc = await fetchGscSignals();
+      } catch (err) {
+        // fetchGscSignals shouldn't throw (graceful-no-op contract); defense in depth.
+        console.warn(`  GSC fetch threw unexpectedly (${err.message}); skipping refresh-mode`);
+        gsc = { status: 'skipped', reason: `unexpected: ${err.message}` };
+      }
+      if (gsc.status === 'ok') {
+        const refresh = await findRefreshCandidate(gsc);
+        if (refresh) {
+          console.log(`  Refresh-mode: ${refresh.slug} (signal: ${refresh.signal})`);
+          if (!dryRun) {
+            console.log(`\n::refresh::${JSON.stringify(refresh)}`);
+          }
+          return;
+        }
+        console.log('  No GSC refresh candidate mapped to an existing post — picking a new topic');
+      } else {
+        console.log(`  GSC signals skipped (${gsc.reason}) — picking a new topic`);
+      }
+    }
+
     const picked = pickNextTopic(dryRun);
     if (picked) {
       // Output the picked topic as JSON for downstream consumption

--- a/blog/pipeline/package.json
+++ b/blog/pipeline/package.json
@@ -7,7 +7,8 @@
     "scan:dry": "node index.js --dry-run",
     "gsc": "node gsc.mjs --site sc-domain:tryethernal.com",
     "enrich": "node enrich-keywords.mjs",
-    "serp-terms": "node serp-terms.mjs"
+    "serp-terms": "node serp-terms.mjs",
+    "refresh": "node refresh.mjs"
   },
   "dependencies": {
     "google-trends-api": "^4.9.2",

--- a/blog/pipeline/project.js
+++ b/blog/pipeline/project.js
@@ -5,12 +5,15 @@
 
 import { execSync } from 'child_process';
 import { readFileSync, existsSync } from 'fs';
+import { access } from 'fs/promises';
 import { join } from 'path';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 import { PROJECT } from './config.js';
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+// Astro blog posts live at blog/src/content/blog/<slug>.{md,mdx}.
+const BLOG_POSTS_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', 'src', 'content', 'blog');
 
 /**
  * Reads `date:` from a published article's frontmatter. Returns ISO date or '' if
@@ -28,6 +31,128 @@ function getArticleDate(articlePath) {
   } catch {
     return '';
   }
+}
+
+/**
+ * Derive a blog post slug from a GSC `page` URL. GSC returns canonical URLs
+ * like `https://tryethernal.com/blog/<slug>` (with or without a trailing
+ * slash). Only URLs under `/blog/` with a single non-empty slug segment map
+ * to a post. Returns the slug, or null when the URL isn't a blog post page.
+ * @param {string} pageUrl
+ * @returns {string|null}
+ */
+export function slugFromPageUrl(pageUrl) {
+  if (!pageUrl || typeof pageUrl !== 'string') return null;
+  let u;
+  try {
+    u = new URL(pageUrl);
+  } catch {
+    return null;
+  }
+  const m = u.pathname.match(/^\/blog\/([^/]+)\/?$/);
+  if (!m) return null;
+  const slug = m[1];
+  // Defensive: GSC URLs are sanitized, but only accept slug-shaped segments.
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(slug)) return null;
+  return slug;
+}
+
+/**
+ * Verify a slug maps to an existing post file (.md or .mdx). Returns the
+ * absolute path when found, else null.
+ * @param {string} slug
+ * @returns {Promise<string|null>}
+ */
+export async function postExists(slug) {
+  for (const ext of ['md', 'mdx']) {
+    const p = join(BLOG_POSTS_DIR, `${slug}.${ext}`);
+    try {
+      await access(p);
+      return p;
+    } catch {
+      /* keep looking */
+    }
+  }
+  return null;
+}
+
+/**
+ * Find a refresh candidate from GSC signals, in priority order:
+ *   1. quickWins        — query at position 4–15, >=50 impressions
+ *                         (almost-ranking; highest leverage).
+ *   2. contentDecay     — page lost >=30% clicks vs prior 28d (defensive).
+ *   3. ctrOpportunities — page ranks (>=100 impressions) but CTR <= 50% of
+ *                         position-expected (cheapest fix — title/meta only).
+ *
+ * Content signals (1 + 2) outrank the copy signal (3): a page whose clicks are
+ * falling needs substance; a page that merely under-clicks needs a better
+ * title. For each candidate, the `page` URL must map to a slug whose post file
+ * exists in the repo — otherwise the signal is meaningless and we skip it.
+ *
+ * Returns the refresh envelope `{ slug, filePath, signal, page, metrics }`, or
+ * null when GSC was skipped, no signals fired, or none mapped to a real post.
+ * Caller then falls through to pickNextTopic() (new-post mode).
+ * @param {object} gsc - Envelope from fetchGscSignals() in gsc.mjs.
+ * @returns {Promise<object|null>}
+ */
+export async function findRefreshCandidate(gsc) {
+  if (!gsc || gsc.status !== 'ok') return null;
+
+  const rel = (p) => p.slice(REPO_ROOT.length + 1);
+
+  // Priority 1: quickWins (signal carries both query and page).
+  for (const w of Array.isArray(gsc.quickWins) ? gsc.quickWins : []) {
+    const slug = slugFromPageUrl(w.page);
+    if (!slug) continue;
+    const filePath = await postExists(slug);
+    if (!filePath) continue;
+    return {
+      slug,
+      filePath: rel(filePath),
+      signal: 'quick_win',
+      page: w.page,
+      metrics: { query: w.query, clicks: w.clicks, impressions: w.impressions, ctr: w.ctr, position: w.position },
+    };
+  }
+
+  // Priority 2: contentDecay.
+  for (const d of Array.isArray(gsc.contentDecay) ? gsc.contentDecay : []) {
+    const slug = slugFromPageUrl(d.page);
+    if (!slug) continue;
+    const filePath = await postExists(slug);
+    if (!filePath) continue;
+    return {
+      slug,
+      filePath: rel(filePath),
+      signal: 'decay',
+      page: d.page,
+      metrics: { clicksRecent: d.clicksRecent, clicksPrior: d.clicksPrior, deltaPct: d.deltaPct },
+    };
+  }
+
+  // Priority 3: ctrOpportunities (sorted worst-gap-first by gsc.mjs).
+  for (const c of Array.isArray(gsc.ctrOpportunities) ? gsc.ctrOpportunities : []) {
+    const slug = slugFromPageUrl(c.page);
+    if (!slug) continue;
+    const filePath = await postExists(slug);
+    if (!filePath) continue;
+    return {
+      slug,
+      filePath: rel(filePath),
+      signal: 'ctr_opportunity',
+      page: c.page,
+      metrics: {
+        clicks: c.clicks,
+        impressions: c.impressions,
+        ctr: c.ctr,
+        position: c.position,
+        expectedCtr: c.expectedCtr,
+        gap: c.gap,
+      },
+    };
+  }
+
+  return null;
 }
 
 /**

--- a/blog/pipeline/project.js
+++ b/blog/pipeline/project.js
@@ -125,6 +125,21 @@ function buildKeywordBlock(topic) {
 }
 
 /**
+ * Extract the primary keyword from a card body's "Top keywords" block.
+ * The block (written by buildKeywordBlock) marks the primary row with
+ * "(primary)". Returns the phrase, or '' when the card wasn't enriched.
+ * Used by draft.sh to seed serp-terms.mjs and the draft prompts.
+ * @param {string} body
+ * @returns {string}
+ */
+export function parsePrimaryKeyword(body) {
+  if (!body || typeof body !== 'string') return '';
+  // Match: "- **<phrase>** — <vol>/mo, <COMP> (primary)"
+  const m = body.match(/^-\s+\*\*(.+?)\*\*\s+[—-].*\(primary\)\s*$/m);
+  return m ? m[1].trim() : '';
+}
+
+/**
  * Build the card body markdown.
  * @param {{label: string, score: number, items: Array, contentType: string, counts: object}} topic
  * @returns {string}

--- a/blog/pipeline/prompts/1-research.md
+++ b/blog/pipeline/prompts/1-research.md
@@ -8,7 +8,9 @@ Ethernal is an open-source block explorer for EVM-based chains. Target audience:
 
 ## Your Task
 
-Read `blog/pipeline/.card-body.md` for the topic and source links.
+Read `blog/pipeline/.card-body.md` for the topic and source links. If the card body has a `### Top keywords (search intent)` section, those are real Google search phrases your audience types — note which appear in the sources you read; they're the natural vocabulary to ground the post in (not a checklist).
+
+**SERP context (optional):** if `blog/pipeline/.serp-terms.json` exists and has `"status": "ok"`, skim its `relatedSearches[]` and `peopleAlsoAsk[]` — they reveal the real questions readers ask around the primary keyword. Use them to spot 1-2 angles or sub-questions worth covering. The `entities[]` list shows which tools/products competitors mention. If the file is absent or `"status": "skipped"`, just research normally — no coverage grounding is available and that's fine.
 
 1. **WebSearch** each source link from the card. For EIP/ERC GitHub PRs, fetch the actual proposal content. Also search for 2-3 additional authoritative sources (official docs, dev blogs from OpenZeppelin/Trail of Bits/Paradigm/Consensys, research papers).
 

--- a/blog/pipeline/prompts/2-draft.md
+++ b/blog/pipeline/prompts/2-draft.md
@@ -16,6 +16,30 @@ Read 2-3 existing articles in `blog/src/content/blog/` to match the tone. Antoin
 
 Read `blog/pipeline/.research-notes.md` for the research brief (sources, outline, angle). Read `blog/pipeline/.card-body.md` for the Content Type.
 
+## Search grounding (read before drafting)
+
+The card body (`blog/pipeline/.card-body.md`) may include a `### Top keywords (search intent)` section listing real Google search phrases with monthly volume, one marked `(primary)`. These come from DataForSEO keyword data — the phrases your audience actually types.
+
+**When a `(primary)` keyword is present:**
+1. It MUST appear in the article `title:` frontmatter.
+2. It SHOULD appear once in the first 150 words of the body, in a sentence that genuinely uses the phrase.
+3. Weave 1-3 of the other listed phrases into headings/body **only where they fit naturally**. Drop any that would require contorted phrasing — Phase 3 flags keyword-stuffing.
+4. Put the primary keyword first in the `keywords:` frontmatter array, followed by the other phrases you actually used.
+
+**If the primary keyword doesn't fit the strongest angle from research:** don't contort the post. Use the next-best listed phrase in the title and opening instead. Editorial quality beats any keyword heuristic.
+
+**When there is no keyword section** (enrichment unavailable): draft normally and set `keywords: []` in frontmatter. Same voice, same quality bar.
+
+### SERP coverage hints (soft — optional)
+
+If `blog/pipeline/.serp-terms.json` exists with `"status": "ok"`, it has:
+- `terms[]` — vocabulary competitors use most (a reading list, not a checklist)
+- `entities[]` — tools/products that appear in competing pages (mention if relevant, ignore if not)
+- `peopleAlsoAsk[]` — reader questions; answering one or two directly in a section is a strong AI-citation win
+- `relatedSearches[]` — adjacent angles readers care about
+
+**Anti-stuffing (non-negotiable):** coverage is SOFT. Use a term only if it fits a sentence you'd write anyway. If the file is absent or `"status": "skipped"`, draft without it — same quality bar. Never mention the skip in the post.
+
 **Content Type formats:**
 - "ERC Tutorial": Code-heavy, working Solidity, deploy instructions, practical examples
 - "EIP Explainer": What it changes, why it matters, before/after code examples
@@ -92,11 +116,16 @@ date: YYYY-MM-DD
 tags:
   - Tag1
   - Tag2
+keywords:
+  - primary search phrase (from the card's Top keywords, marked primary)
+  - other phrases you actually wove into the body, in volume order
 image: "/blog/images/<slug>.png"
 ogImage: "/blog/images/<slug>-og.png"
 status: published
 readingTime: N
 ---
 ```
+
+`keywords:` is the SEO-grounding array (separate from reader-facing `tags`). Populate it from the card's Top keywords section — primary first, then any others you genuinely used. If there was no keyword section, write `keywords: []`. It renders into JSON-LD `BlogPosting.keywords`, not as UI chips.
 
 Then output the file path on a line starting with `::article-path::`

--- a/blog/pipeline/refresh.mjs
+++ b/blog/pipeline/refresh.mjs
@@ -1,0 +1,410 @@
+#!/usr/bin/env node
+/**
+ * @fileoverview refresh.mjs — produces a structured refresh plan for an existing
+ * blog post based on the GSC signal that surfaced it.
+ *
+ * Phase 4b of the search-feedback rollout (see
+ * .claude/references/SERP-INTEGRATION-PLAN.md). Ported from the ronda blog
+ * pipeline and adapted to ethernal-marketing:
+ *
+ *   - Posts live at blog/src/content/blog/<slug>.{md,mdx} (same layout as ronda).
+ *   - ethernal publishes directly to develop with no review PR, so a refresh is a
+ *     direct `chore(blog): refresh` commit on develop — NOT a draft PR. The plan
+ *     therefore carries a `commit` block (prefix + message) instead of a `pr` block.
+ *   - The frontmatter `preserve` list matches ethernal's Zod schema
+ *     (content.config.ts): title, description, date, tags, keywords, image,
+ *     ogImage, readingTime, status. There is no `author` field (posts hardcode
+ *     "by Antoine" in PostLayout).
+ *
+ * Consumes the `mode: 'refresh'` envelope emitted by `index.js --pick`
+ * (Phase 4c, findRefreshCandidate in project.js). draft.sh's refresh-mode
+ * branch (Phase 4d) invokes this helper to get the plan, then executes it
+ * (read post, edit targeted sections, re-run humanize on changed paragraphs,
+ * set `updatedDate`, commit + push).
+ *
+ * Why a structured plan and not free-form analysis:
+ *
+ *   GSC signals are quantitative — a query at position 8 with 47 impressions
+ *   tells you exactly which paragraphs need depth and which keyword to lean
+ *   into. Producing a free-form goal loses that information; a structured plan
+ *   moves the deterministic work into code and keeps the agent focused on the
+ *   editorial judgment that actually benefits from LLM reasoning.
+ *
+ * CLI:
+ *   node refresh.mjs --input /tmp/pick.json           # reads the pick envelope
+ *   node refresh.mjs --slug <slug> --signal quick_win # synthetic; for testing
+ *
+ * Output (stdout, JSON): see buildPlan() return shape.
+ *
+ * Exit codes:
+ *   0 — plan emitted on stdout
+ *   2 — bad input (missing file, malformed JSON, no slug, unknown signal)
+ *   1 — internal error
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// refresh.mjs lives at blog/pipeline/; posts live at blog/src/content/blog/.
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const BLOG_POSTS_DIR = path.resolve(__dirname, '..', 'src', 'content', 'blog');
+
+function log(...args) {
+  process.stderr.write(args.map(String).join(' ') + '\n');
+}
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--input') out.input = argv[++i];
+    else if (a === '--slug') out.slug = argv[++i];
+    else if (a === '--signal') out.signal = argv[++i];
+    else if (a === '--page') out.page = argv[++i];
+    else if (a === '--help' || a === '-h') out.help = true;
+  }
+  return out;
+}
+
+/**
+ * Parse YAML frontmatter (the simple subset our posts use: scalar `k: v` +
+ * arrays of strings via `key:` followed by indented `- item` lines).
+ * Returns { frontmatter, body }. Defensive: never throws — returns empty
+ * frontmatter on parse failure.
+ * @param {string} text
+ * @returns {{frontmatter: object, body: string}}
+ */
+export function parseFrontmatter(text) {
+  if (!text.startsWith('---\n')) return { frontmatter: {}, body: text };
+  const end = text.indexOf('\n---\n', 4);
+  if (end === -1) return { frontmatter: {}, body: text };
+  const raw = text.slice(4, end);
+  const body = text.slice(end + 5);
+  const fm = {};
+  const lines = raw.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const m = line.match(/^([a-zA-Z][a-zA-Z0-9_]*):\s*(.*)$/);
+    if (!m) continue;
+    const [, key, valRaw] = m;
+    const val = valRaw.trim();
+    if (val === '') {
+      // Array-of-strings on subsequent indented lines.
+      const arr = [];
+      while (i + 1 < lines.length && /^\s+-\s+/.test(lines[i + 1])) {
+        i++;
+        arr.push(lines[i].replace(/^\s+-\s+/, '').replace(/^["']|["']$/g, ''));
+      }
+      fm[key] = arr;
+    } else {
+      // Scalar — strip surrounding quotes if any.
+      fm[key] = val.replace(/^["']|["']$/g, '');
+    }
+  }
+  return { frontmatter: fm, body };
+}
+
+/**
+ * Extract every H2 + the first paragraph beneath it. Used to surface
+ * `targetParagraphs` — paragraph anchors the agent will know how to find.
+ * @param {string} body
+ * @returns {Array<{heading: string, startLine: number, snippet: string}>}
+ */
+export function extractStructure(body) {
+  const lines = body.split('\n');
+  const sections = [];
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/^##\s+(.+?)\s*$/);
+    if (!m) continue;
+    const heading = m[1];
+    let snippet = '';
+    for (let j = i + 1; j < lines.length && j < i + 12; j++) {
+      const t = lines[j].trim();
+      if (!t) continue;
+      if (/^#{1,6}\s/.test(t)) break; // hit the next heading
+      snippet = t.slice(0, 180);
+      break;
+    }
+    sections.push({ heading, startLine: i + 1, snippet });
+  }
+  return sections;
+}
+
+/**
+ * Find which H2 sections best match a search query (for the quick_win signal —
+ * expand the section(s) most semantically close to the query so the page
+ * becomes more answer-y for it). Lightweight token-overlap heuristic, no LLM.
+ * @param {Array} sections
+ * @param {string} query
+ * @returns {Array}
+ */
+export function matchSectionsToQuery(sections, query) {
+  if (!query) return [];
+  const stop = new Set(['a','an','and','as','at','be','but','by','for','from','has','have','in','is','it','its','of','on','or','the','to','with','this','that','how','why','what','when','where','vs','vs.']);
+  const tokenize = (s) =>
+    new Set(
+      s
+        .toLowerCase()
+        .replace(/[^a-z0-9\s]/g, ' ')
+        .split(/\s+/)
+        .filter((t) => t && !stop.has(t)),
+    );
+  const qTokens = tokenize(query);
+  if (qTokens.size === 0) return [];
+  const scored = sections.map((s) => {
+    const sTokens = tokenize(s.heading + ' ' + s.snippet);
+    let overlap = 0;
+    for (const t of qTokens) if (sTokens.has(t)) overlap++;
+    return { ...s, overlap };
+  });
+  const max = Math.max(...scored.map((s) => s.overlap));
+  if (max === 0) return [];
+  return scored.filter((s) => s.overlap === max).slice(0, 3);
+}
+
+async function gitLastModified(filePath) {
+  return new Promise((resolve) => {
+    const child = spawn('git', ['log', '-1', '--format=%aI', '--', filePath], {
+      cwd: REPO_ROOT,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    let out = '';
+    child.stdout.on('data', (d) => (out += d));
+    child.on('close', () => resolve(out.trim() || null));
+    child.on('error', () => resolve(null));
+  });
+}
+
+function countWords(body) {
+  return body
+    .replace(/```[\s\S]*?```/g, '') // strip code blocks
+    .replace(/\[[^\]]*\]\([^)]*\)/g, '$1') // unwrap links
+    .split(/\s+/)
+    .filter(Boolean).length;
+}
+
+/**
+ * Build the refresh plan given the signal envelope + the post's parsed state.
+ * Pure function; no I/O.
+ * @param {{slug: string, signal: string, page: string, metrics: object, post: object}} args
+ * @returns {object}
+ */
+export function buildPlan({ slug, signal, page, metrics, post }) {
+  const today = new Date().toISOString().slice(0, 10);
+
+  let strategy;
+  let targetParagraphs = [];
+  let checks = [];
+
+  if (signal === 'quick_win') {
+    strategy = 'expand_for_query';
+    // Find which existing H2(s) best match the query the post is almost
+    // ranking for. The agent deepens those paragraphs and adds 1–2 citations.
+    const matches = metrics?.query ? matchSectionsToQuery(post.sections, metrics.query) : [];
+    targetParagraphs = matches.map((m) => ({
+      headingPath: [post.title, m.heading],
+      lineHint: m.startLine,
+      rationale: `H2 best matches the GSC query "${metrics.query}" (token overlap=${m.overlap}). Expand with 100–200 more words of depth, add 1–2 citations from primary sources, weave the query phrase naturally into the body once.`,
+    }));
+    // If no section matched, the post may not actually serve the query well —
+    // the agent should consider adding a NEW H2 rather than torturing one.
+    if (targetParagraphs.length === 0) {
+      targetParagraphs.push({
+        headingPath: [post.title],
+        lineHint: null,
+        rationale: `No existing H2 strongly matches the GSC query "${metrics?.query || '<unknown>'}". Consider either (a) adding a new H2 section that directly addresses the query, or (b) declining the refresh and commenting that the post doesn't actually serve this query well.`,
+      });
+    }
+    checks = [
+      'For every numerical claim added to changed paragraphs, WebFetch the source URL and verify the stat appears there (source-claim check, scoped to changes).',
+      'The GSC query phrase appears in the body once, naturally — not stuffed.',
+      `If the existing title doesn't contain the query "${metrics?.query || ''}" AND the average position from GSC is > 12, also tighten the title to better match intent. Otherwise leave it untouched.`,
+      'No em-dashes in any added/changed text. No banned phrases (delve into, in today\'s digital landscape, additionally, crucial, diverse, robust as praise). No subtle AI scaffolding ("The practical implication is...", "That\'s real.", spelled-out percentages).',
+      `Set frontmatter updatedDate: ${today}.`,
+    ];
+  } else if (signal === 'decay') {
+    strategy = 'verify_and_update';
+    // Decay is structural — the post is slipping but we don't know which
+    // section is responsible. Re-verify every cited number against its source
+    // and update anything stale. Target every H2; the agent prunes the rest.
+    targetParagraphs = post.sections.map((s) => ({
+      headingPath: [post.title, s.heading],
+      lineHint: s.startLine,
+      rationale: `Decay signal — clicks dropped ${metrics?.deltaPct != null ? (metrics.deltaPct * 100).toFixed(0) + '%' : '?'} vs prior 28d. Re-verify every numerical claim, replace stale tool/product names, refresh any examples that have changed since the post shipped.`,
+    }));
+    checks = [
+      'For EVERY numerical claim in the post body (not just changed ones), WebFetch the source URL and verify the stat still appears there. If a source page changed the number, replace it. If the source is gone, find an equivalent or remove the claim.',
+      'For every named tool/product/study mentioned, verify it still exists and the name is current. Companies rebrand, products get sunset, studies get retracted. Replace stale references.',
+      'Do NOT rewrite the voice or restructure the post — decay-mode is surgical, not full-rewrite.',
+      'No em-dashes in changed text. Banned-phrase + AI-tell sweep on changed paragraphs only.',
+      `Set frontmatter updatedDate: ${today}.`,
+    ];
+  } else if (signal === 'ctr_opportunity') {
+    strategy = 'rewrite_title_meta_only';
+    // Page already ranks (>=100 impressions) but CTR is far below position-
+    // expected. The body is fine; only title + description need a rewrite.
+    targetParagraphs = [];
+    const ctrPct = metrics?.ctr != null ? (metrics.ctr * 100).toFixed(2) : '?';
+    const expCtrPct = metrics?.expectedCtr != null ? (metrics.expectedCtr * 100).toFixed(2) : '?';
+    const gapPct = metrics?.gap != null ? (metrics.gap * 100).toFixed(0) : '?';
+    checks = [
+      `Rewrite the frontmatter \`title\` to better match searcher intent for position ${metrics?.position ?? '?'}. Keep it under 65 characters for clean SERP display. Voice: em-dash-free, opinionated, specific — not generic.`,
+      `Rewrite the frontmatter \`description\` to lift CTR from the current ${ctrPct}% toward the position-expected ${expCtrPct}% (gap ratio ${gapPct}%). Hard limit: <=160 chars (Zod build cap — the build fails if exceeded, self-check before committing). Use a curiosity gap or concrete benefit; avoid repeating the title word-for-word.`,
+      'Do NOT touch the post body. This strategy rewrites exactly two frontmatter fields: title and description. Any other change is out of scope.',
+      `Set frontmatter updatedDate: ${today}.`,
+      'Run `cd blog && npx astro sync` after editing — the Zod schema validates description <=160 chars and the build fails hard over it.',
+    ];
+  } else {
+    // Unknown / future signal. Fail loudly rather than guess.
+    throw new Error(`unknown refresh signal: ${signal} (expected 'quick_win', 'decay', or 'ctr_opportunity')`);
+  }
+
+  // rewrite_title_meta_only: title + description are the TARGETS of the rewrite,
+  // so they must NOT be in preserve[]. All other fields stay intact.
+  // expand_for_query / verify_and_update: title + description are preserved (the
+  // title may be touched by expand_for_query only under the position>12 rule,
+  // governed by plan.checks, not the preserve list).
+  // Fields mirror ethernal's content.config.ts schema (no `author` field).
+  const preserveAlways = ['date', 'tags', 'keywords', 'image', 'ogImage', 'readingTime', 'status'];
+  const preserve =
+    strategy === 'rewrite_title_meta_only'
+      ? preserveAlways
+      : ['title', 'description', ...preserveAlways];
+
+  return {
+    strategy,
+    targetParagraphs,
+    checks,
+    frontmatter: {
+      set: { updatedDate: today },
+      preserve,
+    },
+    // ethernal publishes directly to develop (no review PR). A refresh is a
+    // direct commit with the `chore(blog): refresh` prefix so it's
+    // distinguishable from `blog: publish` commits in the log.
+    commit: {
+      prefix: 'chore(blog): refresh',
+      message: `chore(blog): refresh "${post.title}" (${signal})`,
+    },
+  };
+}
+
+/**
+ * Load a post by slug, parse its frontmatter + structure, and gather metadata.
+ * @param {string} slug
+ * @returns {Promise<object|null>}
+ */
+export async function loadPost(slug) {
+  for (const ext of ['md', 'mdx']) {
+    const p = path.join(BLOG_POSTS_DIR, `${slug}.${ext}`);
+    try {
+      const text = await fs.readFile(p, 'utf8');
+      const { frontmatter, body } = parseFrontmatter(text);
+      const sections = extractStructure(body);
+      const hasReferencesTable = /^##\s+References\s*$/m.test(body);
+      const wordCount = countWords(body);
+      const lastModifiedFromGit = await gitLastModified(p);
+      return {
+        filePath: path.relative(REPO_ROOT, p),
+        title: frontmatter.title || slug,
+        date: frontmatter.date || null,
+        description: frontmatter.description || '',
+        wordCount,
+        hasReferencesTable,
+        sections,
+        lastModifiedFromGit,
+      };
+    } catch {
+      /* keep looking */
+    }
+  }
+  return null;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(
+      'Usage:\n' +
+        '  node refresh.mjs --input /tmp/pick.json\n' +
+        '  node refresh.mjs --slug <slug> --signal quick_win [--page <url>]\n' +
+        '\nProduces a structured refresh plan for the draft.sh refresh-mode branch.\n',
+    );
+    return;
+  }
+
+  let envelope;
+  if (args.input) {
+    try {
+      const raw = await fs.readFile(args.input, 'utf8');
+      const j = JSON.parse(raw);
+      if (j.mode !== 'refresh') {
+        log(`input file is not a refresh envelope (mode=${j.mode}); nothing to do`);
+        process.exit(2);
+      }
+      envelope = { ...j.refresh };
+    } catch (err) {
+      log(`failed to read --input: ${err.message}`);
+      process.exit(2);
+    }
+  } else if (args.slug && args.signal) {
+    envelope = {
+      slug: args.slug,
+      signal: args.signal,
+      page: args.page || `https://tryethernal.com/blog/${args.slug}`,
+      metrics: {},
+    };
+  } else {
+    log('missing required input — pass --input <pick.json> OR --slug + --signal');
+    process.exit(2);
+  }
+
+  const post = await loadPost(envelope.slug);
+  if (!post) {
+    log(`post file not found for slug "${envelope.slug}" (looked in ${BLOG_POSTS_DIR})`);
+    process.exit(2);
+  }
+
+  let plan;
+  try {
+    plan = buildPlan({
+      slug: envelope.slug,
+      signal: envelope.signal,
+      page: envelope.page,
+      metrics: envelope.metrics || {},
+      post,
+    });
+  } catch (err) {
+    log(`buildPlan failed: ${err.message}`);
+    process.exit(2);
+  }
+
+  const out = {
+    slug: envelope.slug,
+    filePath: post.filePath,
+    signal: envelope.signal,
+    page: envelope.page,
+    metrics: envelope.metrics || {},
+    post: {
+      title: post.title,
+      date: post.date,
+      description: post.description,
+      wordCount: post.wordCount,
+      hasReferencesTable: post.hasReferencesTable,
+      lastModifiedFromGit: post.lastModifiedFromGit,
+    },
+    plan,
+  };
+  process.stdout.write(JSON.stringify(out, null, 2) + '\n');
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  main().catch((err) => {
+    log(`FATAL: ${err.stack || err.message}`);
+    process.exit(1);
+  });
+}

--- a/blog/src/content.config.ts
+++ b/blog/src/content.config.ts
@@ -7,6 +7,10 @@ const blog = defineCollection({
   schema: z.object({
     title: z.string(),
     date: z.coerce.date(),
+    // Set by the refresh pipeline when an existing post is updated in place.
+    // Renders as "Updated: <date>" and JSON-LD dateModified. Optional —
+    // existing posts default to dateModified === date.
+    updatedDate: z.coerce.date().optional(),
     description: z.string().max(160, 'Description must be 160 characters or fewer for optimal OG/SEO display'),
     tags: z.array(z.string()).default([]),
     // SEO keyword grounding (separate from reader-facing `tags`). Populated by

--- a/blog/src/layouts/PostLayout.astro
+++ b/blog/src/layouts/PostLayout.astro
@@ -23,7 +23,7 @@ interface Props {
 }
 
 const { post } = Astro.props;
-const { title, date, description, tags, keywords, image, ogImage, readingTime } = post.data;
+const { title, date, updatedDate, description, tags, keywords, image, ogImage, readingTime } = post.data;
 // JSON-LD keywords: prefer the dedicated SEO `keywords` field (populated by the
 // enrichment pipeline); fall back to reader-facing `tags` for posts without it.
 const jsonLdKeywords = (Array.isArray(keywords) && keywords.length > 0 ? keywords : tags).join(", ");
@@ -33,6 +33,11 @@ const formattedDate = date.toLocaleDateString('en-US', {
   month: 'long',
   day: 'numeric',
 });
+
+// Show an "Updated" date only when it's meaningfully after the publish date.
+const formattedUpdated = updatedDate && updatedDate.valueOf() > date.valueOf()
+  ? updatedDate.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
+  : null;
 
 const tag = tags[0] || 'Article';
 
@@ -104,7 +109,7 @@ if (has('Comparison') || /alternative|vs |best/i.test(title)) {
     "description": description,
     "url": `https://tryethernal.com/blog/${post.id}`,
     "datePublished": date.toISOString().split('T')[0],
-    "dateModified": date.toISOString().split('T')[0],
+    "dateModified": (updatedDate ?? date).toISOString().split('T')[0],
     "image": (ogImage || image) ? ((ogImage || image).startsWith('http') ? (ogImage || image) : `https://tryethernal.com${ogImage || image}`) : undefined,
     "author": {
       "@type": "Person",
@@ -177,6 +182,9 @@ if (has('Comparison') || /alternative|vs |best/i.test(title)) {
         <span class="text-xs font-medium text-primary bg-primary/10 px-2.5 py-1 rounded">{tag}</span>
         <span>by Antoine</span>
         <span>&middot; {formattedDate}</span>
+        {formattedUpdated && (
+          <span>&middot; <span class="text-text-secondary">Updated <time datetime={updatedDate.toISOString().split('T')[0]}>{formattedUpdated}</time></span></span>
+        )}
         {readingTime && <span>&middot; {readingTime} min read</span>}
       </div>
     </header>

--- a/blog/src/layouts/PostLayout.astro
+++ b/blog/src/layouts/PostLayout.astro
@@ -23,7 +23,10 @@ interface Props {
 }
 
 const { post } = Astro.props;
-const { title, date, description, tags, image, ogImage, readingTime } = post.data;
+const { title, date, description, tags, keywords, image, ogImage, readingTime } = post.data;
+// JSON-LD keywords: prefer the dedicated SEO `keywords` field (populated by the
+// enrichment pipeline); fall back to reader-facing `tags` for posts without it.
+const jsonLdKeywords = (Array.isArray(keywords) && keywords.length > 0 ? keywords : tags).join(", ");
 
 const formattedDate = date.toLocaleDateString('en-US', {
   year: 'numeric',
@@ -118,7 +121,7 @@ if (has('Comparison') || /alternative|vs |best/i.test(title)) {
       "url": "https://tryethernal.com",
       "logo": { "@type": "ImageObject", "url": "https://tryethernal.com/favicon.ico" }
     },
-    "keywords": tags.join(", "),
+    "keywords": jsonLdKeywords,
     "wordCount": readingTime ? readingTime * 250 : undefined,
     "mainEntityOfPage": {
       "@type": "WebPage",


### PR DESCRIPTION
## Search-feedback layer — Phases 3 + 4 (draft grounding + GSC refresh mode)

Completes the port of ronda's search-feedback blog pipeline into ethernal-marketing. Plan: `.claude/references/SERP-INTEGRATION-PLAN.md`. Supersedes #1331 (Phase 3) — this PR includes those commits plus Phase 4.

### Phase 3 — keyword + SERP grounding into the draft flow (`3a3c5ba4`)
- `draft.sh` pre-flight: parse the picked card's primary keyword (`parsePrimaryKeyword`) and fetch SERP coverage hints via `serp-terms.mjs` into `.serp-terms.json`. Best-effort: no primary keyword or no `DATAFORSEO_*` creds → clean no-op.
- `prompts/1-research.md` + `prompts/2-draft.md`: consume Top keywords + SERP `relatedSearches`/`peopleAlsoAsk` as research angles; ground title/opening/keywords[] in the primary keyword (anti-stuffing enforced).
- `PostLayout.astro`: render `keywords[]` into JSON-LD `BlogPosting.keywords` (falls back to tags).

### Phase 4 — GSC-driven refresh mode (`0562ad51`, `ab9be403`)
Closes the loop: when a Search Console signal maps to an existing post, refresh it in place instead of drafting new.

- **4a** — `content.config.ts`: optional `updatedDate`; `PostLayout.astro` renders `Updated <date>` (only when meaningfully after publish) + JSON-LD `dateModified` prefers `updatedDate`.
- **4b** — `refresh.mjs`: structured refresh plan from a pick envelope. Three strategies: `expand_for_query` (quick_win), `verify_and_update` (decay), `rewrite_title_meta_only` (ctr_opportunity). `preserve[]` matches ethernal's schema; emits a `chore(blog): refresh` commit block (ethernal publishes direct to develop, no review PR).
- **4c** — `project.js`: `slugFromPageUrl`, `postExists`, `findRefreshCandidate` (priority quickWins > contentDecay > ctrOpportunities). `index.js --pick` tries GSC refresh first → emits `::refresh::`, else falls through to `::picked::`. New `--skip-refresh` flag.
- **4d** — `draft.sh`: refresh-mode branch runs `refresh.mjs`, applies the plan via one Claude call, validates the build, commits `chore(blog): refresh` directly to develop with the same rebase-retry as publish.

### Safety / invariants
- **Graceful no-op throughout.** No GSC creds / API down → `fetchGscSignals()` returns `{status:'skipped'}`, `findRefreshCandidate()` returns null, `--pick` behaves byte-identically to pre-Phase-4 (new-post round-robin). Verified locally.
- `serp-terms.mjs` is draft-time grounding only — never touches classify scoring or card creation.
- Refresh is surgical per strategy; `updatedDate` bump is required and asserted in `draft.sh` before commit.

### Validation
- `npx astro build`: all 45 pages build; content collection + types generate clean.
- Rendered post **with** `updatedDate` → header shows `Updated <time>…`, JSON-LD `dateModified` = updatedDate; post **without** → no Updated line, `dateModified` = `datePublished`.
- `refresh.mjs` smoke-tested (3 strategies + bad-signal exit 2); `findRefreshCandidate`/`slugFromPageUrl`/`postExists` unit-tested; `index.js --pick --dry-run` end-to-end (graceful skip without creds); `draft.sh` passes `bash -n`.

Remaining (separate PRs): Phase 5 (sitemap re-ping), Phase 6 (optional quality gates).
