### PR TITLE
feat(blog-pipeline): sitemap re-ping to Search Console (Phase 5)

### DIFF
--- a/.claude/references/SERP-INTEGRATION-PLAN.md
+++ b/.claude/references/SERP-INTEGRATION-PLAN.md
@@ -3,11 +3,16 @@
 Plan to port ronda's search-feedback blog pipeline (GSC signals, DataForSEO keyword
 enrichment, SERP coverage hints, refresh-mode) into ethernal-marketing's pipeline.
 
-**Status:** Phases 0–4 implemented on `seo-refresh-mode`. Phase 5 (sitemap re-ping)
-and Phase 6 (quality gates) remain. Phase 4 (GSC-driven pick + refresh-mode) wired:
+**Status:** Phases 0–5 implemented and merged to develop (Phase 3+4 via #1332).
+Phase 6 (optional quality gates) remains. Phase 4 (GSC-driven pick + refresh-mode):
 `refresh.mjs`, `findRefreshCandidate`/`slugFromPageUrl`/`postExists` in `project.js`,
 the `--pick` refresh branch in `index.js`, the `draft.sh` refresh-mode branch, and
-`updatedDate` in `content.config.ts` + `PostLayout.astro`.
+`updatedDate` in `content.config.ts` + `PostLayout.astro`. Phase 5 (sitemap re-ping):
+`submit-sitemap.mjs` (reuses the gsc.mjs credential chain) + the
+`blog-submit-sitemap.yml` GH Action on push-to-develop touching blog content.
+**Outstanding ops:** the GSC service account must be promoted to **Owner** of
+`sc-domain:tryethernal.com` for `Sitemaps.submit` (PUT) to succeed — read access
+(already confirmed) is enough for signals but not for submit.
 **Source of truth studied:** `~/projects/ronda/blog/pipeline/` + ronda design docs
 (`docs/superpowers/specs/2026-05-25-blog-keyword-enrichment-design.md`,
 `docs/superpowers/handoffs/2026-05-27-blog-pipeline-sensai-integration.md`) +

--- a/.github/workflows/blog-submit-sitemap.yml
+++ b/.github/workflows/blog-submit-sitemap.yml
@@ -1,0 +1,46 @@
+name: Blog Submit Sitemap
+
+# Phase 5 of the search-feedback layer (see
+# .claude/references/SERP-INTEGRATION-PLAN.md). After blog content lands on
+# develop (the branch that auto-deploys the blog), re-ping Google Search
+# Console so it re-crawls the updated sitemaps promptly instead of waiting for
+# its natural crawl cadence. Best-effort: a GSC flake never fails the run.
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - 'blog/src/content/blog/**'
+  workflow_dispatch: # Manual trigger
+
+permissions:
+  contents: read
+
+# Serialize runs so two quick pushes don't double-submit concurrently.
+concurrency:
+  group: blog-submit-sitemap
+  cancel-in-progress: false
+
+jobs:
+  submit-sitemap:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install pipeline dependencies
+        working-directory: blog/pipeline
+        run: npm ci
+
+      - name: Re-ping Search Console with the sitemaps
+        working-directory: blog/pipeline
+        # Best-effort: the Sitemaps.submit endpoint is Owner-only and the SA may
+        # be merely a full-user, or GSC may flake. Never fail the workflow over
+        # a sitemap ping — Google still crawls naturally. `|| true` swallows the
+        # non-zero exit; the step log still records what happened.
+        env:
+          GSC_SERVICE_ACCOUNT_JSON_B64: ${{ secrets.GSC_SERVICE_ACCOUNT_JSON_B64 }}
+        run: node submit-sitemap.mjs || true

--- a/.github/workflows/blog-trend-scan.yml
+++ b/.github/workflows/blog-trend-scan.yml
@@ -33,8 +33,9 @@ jobs:
           # DataForSEO is consumed NOW by enrich-keywords.mjs (keyword volume).
           DATAFORSEO_LOGIN: ${{ secrets.DATAFORSEO_LOGIN }}
           DATAFORSEO_PASSWORD: ${{ secrets.DATAFORSEO_PASSWORD }}
-          # GSC is NOT yet read by `node index.js` — its consumers (refresh /
-          # content-gap selection) land in Phase 4. Provisioned here so the
-          # secret is ready and `gsc.mjs` can be run standalone in the meantime.
+          # GSC drives refresh-mode in `node index.js --pick` (Phase 4, merged).
+          # The weekly scan itself doesn't read GSC, but the secret is provided
+          # so `gsc.mjs` can run standalone here and to keep the env consistent
+          # with the draft cadence that does consume it.
           GSC_SERVICE_ACCOUNT_JSON_B64: ${{ secrets.GSC_SERVICE_ACCOUNT_JSON_B64 }}
         run: node index.js

--- a/blog/pipeline/package.json
+++ b/blog/pipeline/package.json
@@ -8,7 +8,8 @@
     "gsc": "node gsc.mjs --site sc-domain:tryethernal.com",
     "enrich": "node enrich-keywords.mjs",
     "serp-terms": "node serp-terms.mjs",
-    "refresh": "node refresh.mjs"
+    "refresh": "node refresh.mjs",
+    "submit-sitemap": "node submit-sitemap.mjs"
   },
   "dependencies": {
     "google-trends-api": "^4.9.2",

--- a/blog/pipeline/submit-sitemap.mjs
+++ b/blog/pipeline/submit-sitemap.mjs
@@ -1,0 +1,332 @@
+#!/usr/bin/env node
+/**
+ * @fileoverview submit-sitemap.mjs — submit (re-ping) the Ethernal sitemaps to
+ * Google Search Console via the Search Console API, then read back their status.
+ *
+ * Phase 5 of the search-feedback rollout (see
+ * .claude/references/SERP-INTEGRATION-PLAN.md). Ported from the ronda blog
+ * pipeline and adapted to ethernal:
+ *
+ *   - Default site is `sc-domain:tryethernal.com`.
+ *   - Default sitemaps are the two tryethernal.com exposes in prod:
+ *       1. https://tryethernal.com/sitemap.xml            (landing, vite-ssg)
+ *       2. https://tryethernal.com/blog/sitemap-index.xml (Astro blog build)
+ *   - Credential resolution mirrors gsc.mjs (the same service account already
+ *     plumbed for the GSC signals): $GSC_KEY_FILE → $GSC_SERVICE_ACCOUNT_JSON_B64
+ *     (base64 of the JSON, decoded to a 0600 temp file, unlinked on exit) →
+ *     ~/.credentials/gsc-ethernal.json. So Phase 5 needs no new secret.
+ *
+ * The service account `ethernal@ethernal-493613.iam.gserviceaccount.com` must
+ * be an OWNER of the GSC property — the Sitemaps.submit (PUT) endpoint is
+ * Owner-only (read access is enough for the GSC signals, but not for submit).
+ * If the SA only has full-user access, the PUT returns 403 and the script exits
+ * non-zero; promote it to Owner in the GSC UI.
+ *
+ * Failure model: best-effort. The post-merge GH Action treats a non-zero exit
+ * as "GSC ping flaked, Google still crawls naturally" — never block on it.
+ *
+ * Why no `googleapis` SDK: a JWT mint + PUT + GET is ~100 lines of plain fetch
+ * with zero transitive deps. The SDK would pull ~30 MB for three requests.
+ *
+ * Exit codes:
+ *   0 — all submissions succeeded (or status-only read succeeded)
+ *   1 — one or more submissions failed (details on stderr)
+ *   2 — bad CLI args / no readable credential
+ *   3 — token mint failed (key revoked, clock skew, network)
+ *
+ * Usage:
+ *   node submit-sitemap.mjs                              # default set (both)
+ *   node submit-sitemap.mjs --sitemap https://tryethernal.com/sitemap.xml
+ *   node submit-sitemap.mjs --site sc-domain:tryethernal.com
+ *   node submit-sitemap.mjs --status-only                # GET only, no PUT
+ *   node submit-sitemap.mjs --key /path/to/key.json
+ */
+
+import { readFile, access, writeFile, chmod, unlink, constants } from 'node:fs/promises';
+import { unlinkSync } from 'node:fs';
+import { createSign } from 'node:crypto';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Buffer } from 'node:buffer';
+
+// ---------- constants ----------
+
+const DEFAULT_KEY_PATH = join(homedir(), '.credentials', 'gsc-ethernal.json');
+const DEFAULT_SITE = 'sc-domain:tryethernal.com';
+const DEFAULT_SITEMAPS = [
+  'https://tryethernal.com/sitemap.xml',
+  'https://tryethernal.com/blog/sitemap-index.xml',
+];
+// Sitemaps.submit (PUT) is Owner-only and needs the read-WRITE webmasters
+// scope, not the readonly scope gsc.mjs uses for Search Analytics.
+const SCOPE = 'https://www.googleapis.com/auth/webmasters';
+const TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const SC_BASE = 'https://www.googleapis.com/webmasters/v3';
+const REQUEST_TIMEOUT_MS = 20_000;
+
+// ---------- CLI parsing ----------
+
+/** Parse `--flag value` and repeatable `--sitemap <url>` args. No deps. */
+function parseArgs(argv) {
+  const out = { sitemaps: [], statusOnly: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!arg.startsWith('--')) continue;
+    const key = arg.slice(2);
+    if (key === 'status-only') {
+      out.statusOnly = true;
+      continue;
+    }
+    const value = argv[i + 1];
+    if (value === undefined || value.startsWith('--')) {
+      fail(2, `Missing value for --${key}`);
+    }
+    if (key === 'sitemap') {
+      out.sitemaps.push(value);
+    } else {
+      out[key] = value;
+    }
+    i++;
+  }
+  return out;
+}
+
+function fail(code, msg) {
+  console.error(`submit-sitemap: ${msg}`);
+  process.exit(code);
+}
+
+function log(msg) {
+  console.log(`submit-sitemap: ${msg}`);
+}
+
+// Temp credential files materialized from base64. A process `exit` handler
+// unlinks them synchronously — guarantees cleanup even when fail() calls
+// process.exit() (which bypasses the async finally in main()). Mirrors gsc.mjs.
+const TEMP_KEY_FILES = new Set();
+let exitHandlerInstalled = false;
+function installExitHandlerOnce() {
+  if (exitHandlerInstalled) return;
+  exitHandlerInstalled = true;
+  const unlinkAll = () => {
+    for (const p of TEMP_KEY_FILES) {
+      try { unlinkSync(p); } catch { /* best-effort */ }
+    }
+    TEMP_KEY_FILES.clear();
+  };
+  process.on('exit', unlinkAll);
+  process.on('SIGINT', () => { unlinkAll(); process.exit(130); });
+  process.on('SIGTERM', () => { unlinkAll(); process.exit(143); });
+}
+
+// ---------- credential resolution (mirrors gsc.mjs) ----------
+
+/**
+ * Resolve the service-account JSON. Returns { json, cleanup } where cleanup is
+ * an async no-op for file paths and an unlink for a temp file materialized from
+ * base64. Resolution order matches gsc.mjs so Phase 5 reuses the same secret:
+ *   1. --key / $GSC_KEY_FILE      (explicit path)
+ *   2. $GSC_SERVICE_ACCOUNT_JSON_B64 (base64 JSON → 0600 temp file)
+ *   3. ~/.credentials/gsc-ethernal.json
+ * On failure, calls fail(2, ...) (never returns).
+ * @param {string|undefined} explicitKey
+ * @returns {Promise<{path: string, cleanup: () => Promise<void>}>}
+ */
+async function resolveKeyFile(explicitKey) {
+  const fromFlag = explicitKey || process.env.GSC_KEY_FILE || process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  if (fromFlag) {
+    const canRead = await access(fromFlag, constants.R_OK).then(() => true, () => false);
+    if (!canRead) fail(2, `Service-account key not readable at ${fromFlag}`);
+    return { path: fromFlag, cleanup: async () => {} };
+  }
+
+  const b64 = process.env.GSC_SERVICE_ACCOUNT_JSON_B64;
+  if (b64) {
+    let json;
+    try {
+      json = Buffer.from(b64, 'base64').toString('utf8');
+      JSON.parse(json); // validate; throws if malformed
+    } catch (err) {
+      fail(2, `GSC_SERVICE_ACCOUNT_JSON_B64 malformed: ${err.message}`);
+    }
+    const tmp = join(tmpdir(), `gsc-ethernal-sitemap-${process.pid}-${Date.now()}.json`);
+    await writeFile(tmp, json, { mode: 0o600 });
+    await chmod(tmp, 0o600);
+    TEMP_KEY_FILES.add(tmp);
+    installExitHandlerOnce();
+    const cleanup = async () => {
+      TEMP_KEY_FILES.delete(tmp);
+      try { await unlink(tmp); } catch { /* best-effort */ }
+    };
+    return { path: tmp, cleanup };
+  }
+
+  const canRead = await access(DEFAULT_KEY_PATH, constants.R_OK).then(() => true, () => false);
+  if (!canRead) {
+    fail(2, `no credentials (set --key / GSC_KEY_FILE or GSC_SERVICE_ACCOUNT_JSON_B64, or place key at ${DEFAULT_KEY_PATH})`);
+  }
+  return { path: DEFAULT_KEY_PATH, cleanup: async () => {} };
+}
+
+// ---------- service-account JWT auth ----------
+
+/** Base64url-encode a Buffer or string with no padding. */
+function b64url(input) {
+  const buf = Buffer.isBuffer(input) ? input : Buffer.from(input);
+  return buf.toString('base64').replace(/=+$/, '').replace(/\+/g, '-').replace(/\//g, '_');
+}
+
+/**
+ * Mint a short-lived (1h) access token from a service-account JWT.
+ * Uses node:crypto directly — no `jose` / `google-auth-library` dep.
+ * @param {object} sa - Parsed service-account JSON.
+ * @returns {Promise<string>}
+ */
+async function mintAccessToken(sa) {
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: 'RS256', typ: 'JWT', kid: sa.private_key_id };
+  const claims = { iss: sa.client_email, scope: SCOPE, aud: TOKEN_URL, iat: now, exp: now + 3600 };
+  const signingInput = `${b64url(JSON.stringify(header))}.${b64url(JSON.stringify(claims))}`;
+  const signer = createSign('RSA-SHA256');
+  signer.update(signingInput);
+  signer.end();
+  const sig = signer.sign(sa.private_key);
+  const jwt = `${signingInput}.${b64url(sig)}`;
+
+  const body = new URLSearchParams({
+    grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+    assertion: jwt,
+  });
+
+  const res = await fetchWithTimeout(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    fail(3, `token mint failed: HTTP ${res.status}: ${text.slice(0, 400)}`);
+  }
+  const data = await res.json();
+  return data.access_token;
+}
+
+// ---------- HTTP helper ----------
+
+async function fetchWithTimeout(url, init = {}) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+// ---------- Search Console operations ----------
+
+/** PUT (submit/re-submit) a sitemap. 204 No Content on success. */
+async function submitSitemap(token, site, sitemapUrl) {
+  const url = `${SC_BASE}/sites/${encodeURIComponent(site)}/sitemaps/${encodeURIComponent(sitemapUrl)}`;
+  const res = await fetchWithTimeout(url, {
+    method: 'PUT',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    return { ok: false, reason: `HTTP ${res.status}: ${text.slice(0, 400)}` };
+  }
+  return { ok: true };
+}
+
+/** GET the current sitemap status. Returns the parsed entry or an error. */
+async function getSitemapStatus(token, site, sitemapUrl) {
+  const url = `${SC_BASE}/sites/${encodeURIComponent(site)}/sitemaps/${encodeURIComponent(sitemapUrl)}`;
+  const res = await fetchWithTimeout(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    return { ok: false, reason: `HTTP ${res.status}: ${text.slice(0, 400)}` };
+  }
+  return { ok: true, data: await res.json() };
+}
+
+// ---------- main ----------
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  const site = args.site || DEFAULT_SITE;
+  const sitemaps = args.sitemaps.length > 0 ? args.sitemaps : DEFAULT_SITEMAPS;
+
+  // Validate sitemap URLs eagerly — better than a cryptic GSC 400.
+  for (const url of sitemaps) {
+    if (!/^https:\/\/[^/]+\/.+/.test(url)) {
+      fail(2, `Invalid sitemap URL: ${url} (must be a full https:// URL)`);
+    }
+  }
+
+  const cred = await resolveKeyFile(args.key);
+  let sa;
+  try {
+    sa = JSON.parse(await readFile(cred.path, 'utf8'));
+  } catch (err) {
+    await cred.cleanup();
+    fail(2, `Failed to parse credential at ${cred.path}: ${err.message}`);
+  }
+  if (!sa?.client_email || !sa?.private_key) {
+    await cred.cleanup();
+    fail(2, `credential is not a valid service-account JSON (missing client_email or private_key)`);
+  }
+
+  log(`site=${site}`);
+  log(`service-account=${sa.client_email}`);
+  log(`sitemaps=${sitemaps.length} (${sitemaps.join(', ')})`);
+  if (args.statusOnly) log('mode=status-only (no PUT)');
+
+  let anyFailed = false;
+  try {
+    const token = await mintAccessToken(sa);
+    log('token minted (1h validity)');
+
+    for (const sitemap of sitemaps) {
+      if (!args.statusOnly) {
+        const put = await submitSitemap(token, site, sitemap);
+        if (put.ok) {
+          log(`PUT ${sitemap} → 204 submitted`);
+        } else {
+          console.error(`submit-sitemap: PUT ${sitemap} FAILED — ${put.reason}`);
+          anyFailed = true;
+          continue;
+        }
+      }
+
+      const status = await getSitemapStatus(token, site, sitemap);
+      if (!status.ok) {
+        console.error(`submit-sitemap: GET ${sitemap} FAILED — ${status.reason}`);
+        anyFailed = true;
+        continue;
+      }
+      const d = status.data;
+      log(
+        `GET  ${sitemap} → lastSubmitted=${d.lastSubmitted || '(none)'} ` +
+          `pending=${d.isPending} warnings=${d.warnings} errors=${d.errors} ` +
+          `index=${d.isSitemapsIndex}`,
+      );
+    }
+  } finally {
+    await cred.cleanup();
+  }
+
+  if (anyFailed) {
+    console.error('submit-sitemap: one or more sitemaps failed (see above)');
+    process.exit(1);
+  }
+  log('done');
+}
+
+main().catch((err) => {
+  console.error('submit-sitemap: unexpected error:', err);
+  process.exit(1);
+});

--- a/blog/pipeline/submit-sitemap.mjs
+++ b/blog/pipeline/submit-sitemap.mjs
@@ -42,7 +42,7 @@
  *   node submit-sitemap.mjs --key /path/to/key.json
  */
 
-import { readFile, access, writeFile, chmod, unlink, constants } from 'node:fs/promises';
+import { readFile, access, writeFile, unlink, constants } from 'node:fs/promises';
 import { unlinkSync } from 'node:fs';
 import { createSign } from 'node:crypto';
 import { homedir, tmpdir } from 'node:os';
@@ -150,8 +150,9 @@ async function resolveKeyFile(explicitKey) {
       fail(2, `GSC_SERVICE_ACCOUNT_JSON_B64 malformed: ${err.message}`);
     }
     const tmp = join(tmpdir(), `gsc-ethernal-sitemap-${process.pid}-${Date.now()}.json`);
+    // mode:0o600 is sufficient — umask can only strip bits already absent from
+    // 0o600 (group/world), never widen them, so an explicit chmod adds nothing.
     await writeFile(tmp, json, { mode: 0o600 });
-    await chmod(tmp, 0o600);
     TEMP_KEY_FILES.add(tmp);
     installExitHandlerOnce();
     const cleanup = async () => {


### PR DESCRIPTION
## Phase 5 — sitemap re-ping to Google Search Console

Final infra phase of the search-feedback layer (plan: `.claude/references/SERP-INTEGRATION-PLAN.md`). After blog content lands on `develop` (the branch that auto-deploys the blog), re-ping GSC so it re-crawls the updated sitemaps promptly instead of waiting for its natural crawl cadence.

### Changes
- **`blog/pipeline/submit-sitemap.mjs`** — ported from ronda, adapted to ethernal:
  - Default site `sc-domain:tryethernal.com`; default sitemaps are the two prod exposes: landing `https://tryethernal.com/sitemap.xml` + blog `https://tryethernal.com/blog/sitemap-index.xml`.
  - Dependency-free: JWT mint + PUT + GET via `node:crypto`/`fetch` (no `googleapis` SDK — three requests don't justify ~30 MB).
  - **Reuses the `gsc.mjs` credential chain** (`GSC_KEY_FILE` → `GSC_SERVICE_ACCOUNT_JSON_B64` → `~/.credentials/gsc-ethernal.json`) — no new secret needed.
  - Process `exit` handler unlinks the base64 temp key even when `fail()` calls `process.exit()` (closes a cleanup gap the inline-finally couldn't cover).
- **`.github/workflows/blog-submit-sitemap.yml`** — GH Action on push-to-develop touching `blog/src/content/blog/**`; best-effort (`|| true`) so a GSC flake never fails the run; serialized via concurrency group.
- **`blog-trend-scan.yml`** — refresh the now-stale "GSC not yet read" comment (Phase 4 is merged; GSC drives `--pick` refresh-mode).

### Validation
- `node --check` clean; both workflow YAMLs parse.
- Error paths tested: no creds → exit 2; bad sitemap URL → exit 2.
- Happy path tested with a throwaway valid-structure SA: cred parse + RS256 JWT signing + Google token exchange all work (correctly rejected as "account not found", exit 3).
- Temp-file cleanup verified: base64 path leaves **no** temp key after `process.exit(3)`.

### Ops note (blocking for live submit, not for merge)
`Sitemaps.submit` (PUT) is **Owner-only**. The SA `ethernal@ethernal-493613.iam.gserviceaccount.com` must be promoted to **Owner** of `sc-domain:tryethernal.com` (read access — already confirmed — is enough for the GSC signals but not for submit). Until then the PUT returns 403 and the workflow logs it without failing.

Completes Phases 0–5. Phase 6 (optional quality gates) is the only remaining item.
