### PR TITLE
feat(blog-pipeline): scored GEO quality gate + source verification (Phase 6)

### DIFF
--- a/.claude/references/SERP-INTEGRATION-PLAN.md
+++ b/.claude/references/SERP-INTEGRATION-PLAN.md
@@ -3,16 +3,21 @@
 Plan to port ronda's search-feedback blog pipeline (GSC signals, DataForSEO keyword
 enrichment, SERP coverage hints, refresh-mode) into ethernal-marketing's pipeline.
 
-**Status:** Phases 0–5 implemented and merged to develop (Phase 3+4 via #1332).
-Phase 6 (optional quality gates) remains. Phase 4 (GSC-driven pick + refresh-mode):
-`refresh.mjs`, `findRefreshCandidate`/`slugFromPageUrl`/`postExists` in `project.js`,
-the `--pick` refresh branch in `index.js`, the `draft.sh` refresh-mode branch, and
-`updatedDate` in `content.config.ts` + `PostLayout.astro`. Phase 5 (sitemap re-ping):
-`submit-sitemap.mjs` (reuses the gsc.mjs credential chain) + the
-`blog-submit-sitemap.yml` GH Action on push-to-develop touching blog content.
-**Outstanding ops:** the GSC service account must be promoted to **Owner** of
-`sc-domain:tryethernal.com` for `Sitemaps.submit` (PUT) to succeed — read access
-(already confirmed) is enough for signals but not for submit.
+**Status:** Phases 0–6 implemented and merged to develop (Phase 3+4 via #1332,
+Phase 5 via #1333). The full search-feedback loop is complete. Phase 4 (GSC-driven
+pick + refresh-mode): `refresh.mjs`, `findRefreshCandidate`/`slugFromPageUrl`/
+`postExists` in `project.js`, the `--pick` refresh branch in `index.js`, the
+`draft.sh` refresh-mode branch, and `updatedDate` in `content.config.ts` +
+`PostLayout.astro`. Phase 5 (sitemap re-ping): `submit-sitemap.mjs` (reuses the
+gsc.mjs credential chain) + the `blog-submit-sitemap.yml` GH Action. Phase 6
+(quality gates): `prompts/5-geo-score.md` (6-dimension scored GEO rubric, 7.5
+soft-gate) + `prompts/3b-verify-sources.md` (source-claim verification subagent),
+wired as a Phase 3b fix loop in `draft.sh` (soft gate: raises quality via a
+2-iteration fix loop but publishes as-is below threshold, since Ethernal
+auto-publishes without review). Funnel-position bias was deliberately NOT ported
+(low value for a technical dev-tooling blog, per §6).
+**Ops:** the GSC service account is now an Owner of `sc-domain:tryethernal.com`,
+so `Sitemaps.submit` (PUT) is unblocked.
 **Source of truth studied:** `~/projects/ronda/blog/pipeline/` + ronda design docs
 (`docs/superpowers/specs/2026-05-25-blog-keyword-enrichment-design.md`,
 `docs/superpowers/handoffs/2026-05-27-blog-pipeline-sensai-integration.md`) +
@@ -244,10 +249,20 @@ degrades to exactly today's behavior).
 - Wire a GH Action on push-to-develop touching `blog/src/content/blog/**` (ethernal already
   auto-deploys blog changes on develop — add the ping step there).
 
-### Phase 6 (optional, defer) — quality gates
-- Scored GEO rubric (`5-geo-score.md`) + parallel verify subagents (`3b-verify-sources.md`).
-- Funnel-position tagging + 80/20 TOFU/MOFU bias (`stats.mjs`). Lower priority for a
-  technical dev-tooling blog than for ronda's PM/designer funnel.
+### Phase 6 — quality gates [DONE]
+- Scored GEO rubric (`prompts/5-geo-score.md`) + source-claim verification subagent
+  (`prompts/3b-verify-sources.md`). Both adapted to Ethernal's conventions: numbered-
+  footnote References (not ronda's markdown table), Ethernal's banned-word list
+  (`3-humanize.md`), and Ethernal's content-type vocabulary.
+- Wired into `draft.sh` as **Phase 3b**, after humanize and before the build validate.
+  SOFT gate: a 2-iteration fix loop raises quality (verify → score → fix → re-score),
+  but a post below 7.5 after the cap still ships, with the score + remaining fixes
+  logged. This matches Ethernal's direct-publish philosophy (a hard gate would
+  silently drop posts with no human to re-queue them). Fully best-effort: malformed
+  subagent JSON or a Claude flake degrades to "publish as-is".
+- Funnel-position tagging + TOFU/MOFU bias: **NOT ported** (deliberate). Low value for
+  a technical dev-tooling blog vs ronda's PM/designer funnel (§6). Revisit only if the
+  content mix ever needs funnel balancing.
 
 ---
 

--- a/blog/pipeline/.gitignore
+++ b/blog/pipeline/.gitignore
@@ -1,6 +1,9 @@
 # Temp files created during pipeline runs
 .card-body.md
 .research-notes.md
+.refresh-plan.json
+.geo-score.json
+.verify-sources.json
 test-covers-out/
 
 # Host-local keyword / SERP caches (rebuild themselves, 30d / 7d TTL)

--- a/blog/pipeline/draft.sh
+++ b/blog/pipeline/draft.sh
@@ -353,6 +353,92 @@ fi
 log "Phase 3 complete."
 
 # ============================================================
+# PHASE 3b: GEO quality gate (Phase 6 — soft gate)
+# Source-claim verification + scored GEO rubric. Ethernal publishes directly
+# to develop with no human review, so this is a SOFT gate: it runs a fix loop
+# to raise quality, but a post that still scores below threshold after the cap
+# ships anyway (the score + remaining fixes are logged for follow-up). Wholly
+# best-effort: any malformed JSON or Claude flake degrades to "publish as-is".
+# ============================================================
+GEO_GATE_MAX_ITERATIONS=2
+GEO_PASS=false
+rm -f blog/pipeline/.geo-score.json blog/pipeline/.verify-sources.json
+
+for GEO_ITER in $(seq 1 "$GEO_GATE_MAX_ITERATIONS"); do
+  log "Phase 3b: GEO quality gate (iteration $GEO_ITER/$GEO_GATE_MAX_ITERATIONS)..."
+
+  # Source-claim verification subagent (WebFetches every cited number).
+  claude -p "Verify the sources in the blog post at $ARTICLE_PATH. $(cat "$PROMPTS_DIR/3b-verify-sources.md")
+
+The post file is: $ARTICLE_PATH
+Write your JSON report to blog/pipeline/.verify-sources.json (and nothing else)." \
+    --dangerously-skip-permissions \
+    --mcp-config "$MCP_CONFIG" \
+    --max-turns 20 \
+    2>&1 | tee -a "$LOG_FILE" || log "WARNING: source-verification subagent flaked (non-fatal)"
+
+  # GEO score subagent (scores the file as-is, no WebFetch).
+  claude -p "Score the blog post at $ARTICLE_PATH against the rubric. $(cat "$PROMPTS_DIR/5-geo-score.md")
+
+The post file is: $ARTICLE_PATH
+Write your JSON score to blog/pipeline/.geo-score.json (and nothing else)." \
+    --dangerously-skip-permissions \
+    --max-turns 10 \
+    2>&1 | tee -a "$LOG_FILE" || log "WARNING: GEO-score subagent flaked (non-fatal)"
+
+  # Parse the verdict. Missing/malformed file -> treat as a non-blocking skip.
+  if [ ! -f blog/pipeline/.geo-score.json ]; then
+    log "Phase 3b: no GEO score produced — skipping gate (publishing as-is)"
+    break
+  fi
+  GEO_VERDICT=$(jq -r '.verdict // "unknown"' blog/pipeline/.geo-score.json 2>/dev/null || echo unknown)
+  GEO_SCORE=$(jq -r '.totalScore // "?"' blog/pipeline/.geo-score.json 2>/dev/null || echo "?")
+  log "Phase 3b: GEO verdict=$GEO_VERDICT score=$GEO_SCORE"
+
+  if [ "$GEO_VERDICT" = "pass" ]; then
+    GEO_PASS=true
+    break
+  fi
+
+  # Last iteration: don't fix again, just publish with the score logged.
+  if [ "$GEO_ITER" -eq "$GEO_GATE_MAX_ITERATIONS" ]; then
+    log "Phase 3b: still below threshold after $GEO_GATE_MAX_ITERATIONS iterations — publishing as-is (soft gate)"
+    log "Phase 3b: remaining fixes: $(jq -c '.iterationsNeeded // []' blog/pipeline/.geo-score.json 2>/dev/null || echo '[]')"
+    break
+  fi
+
+  # Build the fix brief from both reports (auto-zeros + dimension fixes + source fixes).
+  GEO_AUTOZEROS=$(jq -r '(.autoZeros // []) | join("; ")' blog/pipeline/.geo-score.json 2>/dev/null || echo "")
+  GEO_FIXES=$(jq -r '(.iterationsNeeded // []) | join("\n- ")' blog/pipeline/.geo-score.json 2>/dev/null || echo "")
+  SRC_FIXES=$(jq -r '(.fixesNeeded // []) | join("\n- ")' blog/pipeline/.verify-sources.json 2>/dev/null || echo "")
+
+  log "Phase 3b: applying GEO fixes (iteration $GEO_ITER)..."
+  claude -p "The blog post at $ARTICLE_PATH scored below the GEO quality threshold ($GEO_SCORE/10). Apply the following targeted fixes. Do NOT rewrite the whole post; make surgical edits only.
+
+Auto-zero conditions to clear (must fix all): $GEO_AUTOZEROS
+
+GEO dimension fixes (highest-impact first):
+- $GEO_FIXES
+
+Source-claim fixes (from verification — drop/reattribute as noted):
+- $SRC_FIXES
+
+Rules: no em-dashes; description must stay <= 160 chars; keep every numbered footnote in sync with its inline <sup>[N](#fn-N)</sup> marker; edit only $ARTICLE_PATH." \
+    --dangerously-skip-permissions \
+    --mcp-config "$MCP_CONFIG" \
+    --max-turns 15 \
+    2>&1 | tee -a "$LOG_FILE" || log "WARNING: GEO fix pass flaked (non-fatal)"
+
+  # Em-dash safety net after the fix pass (the fixer can reintroduce them).
+  if grep -q '—' "$ARTICLE_PATH"; then
+    log "WARNING: Em dashes present after GEO fix — stripping with sed"
+    sed -i 's/—/,/g' "$ARTICLE_PATH"
+  fi
+done
+
+log "Phase 3b complete (GEO gate passed: $GEO_PASS)."
+
+# ============================================================
 # Validate: Astro build must pass before committing
 # Auto-fix loop: if validation fails, Claude fixes errors and retries (max 2 attempts)
 # ============================================================
@@ -490,6 +576,7 @@ CARD_ID="$CARD_ID" ARTICLE_PATH="$ARTICLE_PATH" node --input-type=module -e "
 " 2>&1 | tee -a "$LOG_FILE"
 
 # Clean up temp files
-rm -f blog/pipeline/.research-notes.md blog/pipeline/.card-body.md
+rm -f blog/pipeline/.research-notes.md blog/pipeline/.card-body.md \
+      blog/pipeline/.geo-score.json blog/pipeline/.verify-sources.json
 
 log "Done. Article deployed as draft: $ARTICLE_URL"

--- a/blog/pipeline/draft.sh
+++ b/blog/pipeline/draft.sh
@@ -362,10 +362,13 @@ log "Phase 3 complete."
 # ============================================================
 GEO_GATE_MAX_ITERATIONS=2
 GEO_PASS=false
-rm -f blog/pipeline/.geo-score.json blog/pipeline/.verify-sources.json
 
 for GEO_ITER in $(seq 1 "$GEO_GATE_MAX_ITERATIONS"); do
   log "Phase 3b: GEO quality gate (iteration $GEO_ITER/$GEO_GATE_MAX_ITERATIONS)..."
+  # Clear stale artifacts at the TOP of each iteration so a scorer flake on a
+  # later pass is always detected as "no score produced" rather than silently
+  # reusing the previous iteration's score in the verdict/log.
+  rm -f blog/pipeline/.geo-score.json blog/pipeline/.verify-sources.json
 
   # Source-claim verification subagent (WebFetches every cited number).
   claude -p "Verify the sources in the blog post at $ARTICLE_PATH. $(cat "$PROMPTS_DIR/3b-verify-sources.md")

--- a/blog/pipeline/prompts/3b-verify-sources.md
+++ b/blog/pipeline/prompts/3b-verify-sources.md
@@ -12,7 +12,7 @@ Phase 3 in this pipeline:
   - **GEO score** — `prompts/5-geo-score.md`. Scores the file content as-is (no WebFetch).
 - **3c (Apply fixes)** — main agent reads both reports, applies edits, re-scores (2-iteration cap).
 
-Your output goes to stdout as JSON only. No prose preamble, no closing remarks.
+Your output is JSON only — no prose preamble, no closing remarks. The caller decides where it lands: if the invoking prompt asks you to write it to a file, write exactly that JSON to the file and nothing else; otherwise print it to stdout.
 
 ## What to verify
 
@@ -97,7 +97,7 @@ When the post paraphrases a study's or spec's conclusion, the paraphrase sometim
 - `verdict` = `'pass'` if every entry in `claims[]` is `verified` AND `unfetchable[]` is empty. Otherwise `'fail'`.
 - `fixesNeeded[]` = ordered list of concrete edits. Each entry: `"<claim quote (truncated)>: <action>"`. Empty on pass.
 
-Output the JSON only. No prose framing. Start with `{`.
+Emit the JSON only, no prose framing (it starts with `{`). Write it to the file the invoking prompt names, or to stdout if none is given.
 
 ## When to escalate (not return a verdict)
 

--- a/blog/pipeline/prompts/3b-verify-sources.md
+++ b/blog/pipeline/prompts/3b-verify-sources.md
@@ -1,0 +1,124 @@
+# 3b-verify-sources: source-claim verification subagent
+
+## Purpose
+
+You are a source-verification pass in Phase 3b of the Ethernal blog pipeline. You read a draft post and check every cited number / named study / specific stat against its source URL. You **do not edit the post.** You return a structured report; the main agent applies fixes afterward.
+
+Phase 3 in this pipeline:
+
+- **3a (Voice humanize)** — main agent edits the post in place: em-dash sweep, banned phrases, AI tells (`prompts/3-humanize.md`).
+- **3b (Verify + score)**:
+  - **Source-claim verification** — this prompt. WebFetches sources, checks every cited number.
+  - **GEO score** — `prompts/5-geo-score.md`. Scores the file content as-is (no WebFetch).
+- **3c (Apply fixes)** — main agent reads both reports, applies edits, re-scores (2-iteration cap).
+
+Your output goes to stdout as JSON only. No prose preamble, no closing remarks.
+
+## What to verify
+
+For every number, percentage, statistic, gas figure, dollar amount, or named-study finding in the body:
+
+1. Identify which source the claim is attributed to. Ethernal posts cite with inline `<sup>[N](#fn-N)</sup>` footnotes pointing at a numbered entry in the `## References` footer (`<span id="fn-N">N.</span> Author. "Title." _Source_, Date. [url](url)`). Attribution can be:
+   - **Explicit** — "per the EIP-4844 spec", "Vitalik's post argues", "a 2025 paper found".
+   - **Footnote** — the claim carries a `<sup>[N](#fn-N)</sup>` marker; resolve N to its References URL.
+   - **Implicit** — claim immediately precedes/follows a cited link with no other source nearby.
+2. WebFetch that source URL.
+3. Search the fetched content for the specific number. Look for the digit string itself, paraphrased forms ("thirty percent" ↔ "30%"), and contextual matches (the source may cite a slightly different figure the post rounded).
+4. Decide the verification status (see below).
+
+## Skip rule
+
+If a number is a rough order-of-magnitude framing the drafter invented for illustration ("most rollups post batches every few minutes" with no source attached), skip it. **The rule is: if it's attributed to a source, it has to be in the source.** A bare "most chains" with no citation is voice, not a claim.
+
+## Status options
+
+For each numerical claim you find, return one of:
+
+- **`verified`** — the number (or its paraphrase) appears in the cited source, and the source's framing matches the post's. No action needed.
+- **`reattribute`** — the number appears in *some* cited source in References, but not the one the body credits. The main agent should swap the footnote.
+- **`drop`** — the number doesn't appear in any cited source. The main agent should remove the number, drop the surrounding claim, or research a new source.
+- **`unfetchable`** — the source URL failed to WebFetch (404, paywall, timeout). Report it; the main agent decides whether to find an alternative or drop the claim.
+
+## Failure modes to watch for
+
+### Cross-source contamination
+
+When the drafter had multiple sources with similar-shaped findings, they sometimes attribute Source A's numbers to Source B because both fit the paragraph's argument. The numbers are real, the source is wrong. **How to catch it:** if you find a number in a DIFFERENT cited source than the one credited, status = `reattribute` (don't mark `verified` just because the number exists somewhere in References).
+
+### Confabulated precision
+
+When a claim's qualitative direction is true but the cited source lacks the precise stat, the drafter sometimes invents a plausible number. Example: "exactly 1,287,433 transactions" when the source only gives "over 1.2M". **How to catch it:** when a number is suspiciously precise (six significant figures on a count, three decimals on a percentage) and you can't find it in the source, default to `drop`. Real on-chain data is usually round or carries explicit provenance; over-precise numbers without provenance are usually inventions.
+
+### Quote drift
+
+When the post paraphrases a study's or spec's conclusion, the paraphrase sometimes shifts it in a way the source wouldn't endorse. Example: spec says "blob fees *can* dominate under load"; post says "blob fees dominate 40% of the time." **How to catch it:** if the source's framing is hedged ("can", "in some cases", "under certain conditions") but the post's is absolute, status = `drop` or `reattribute` to a source that supports the absolute claim.
+
+## Output schema (strict)
+
+```json
+{
+  "post": "blog/src/content/blog/<slug>.md",
+  "checkedCount": 12,
+  "claims": [
+    {
+      "quote": "<the exact sentence or phrase from the body containing the claim>",
+      "number": "30%",
+      "attributedSource": "https://...",
+      "status": "verified",
+      "notes": "Number appears verbatim in the source's abstract."
+    },
+    {
+      "quote": "...",
+      "number": "1,287,433",
+      "attributedSource": "https://...",
+      "status": "drop",
+      "notes": "Source gives 'over 1.2M' but no 1,287,433 figure. Likely confabulated precision."
+    },
+    {
+      "quote": "...",
+      "number": "12.5 gwei",
+      "attributedSource": "https://eips.ethereum.org/EIPS/eip-1559",
+      "alternativeSource": "https://etherscan.io/gastracker",
+      "status": "reattribute",
+      "notes": "12.5 gwei is a live-tracker figure, not in the EIP-1559 spec. Reattribute."
+    }
+  ],
+  "unfetchable": [
+    { "source": "https://...", "reason": "404 Not Found" }
+  ],
+  "verdict": "pass",
+  "fixesNeeded": []
+}
+```
+
+- `checkedCount` = total numerical/study claims examined.
+- `claims[]` = one entry per claim, including `verified` ones (the main agent uses the full list for the run log).
+- `unfetchable[]` = sources that couldn't be checked. Separate from `claims[]` so the agent can decide source-level vs claim-level action.
+- `verdict` = `'pass'` if every entry in `claims[]` is `verified` AND `unfetchable[]` is empty. Otherwise `'fail'`.
+- `fixesNeeded[]` = ordered list of concrete edits. Each entry: `"<claim quote (truncated)>: <action>"`. Empty on pass.
+
+Output the JSON only. No prose framing. Start with `{`.
+
+## When to escalate (not return a verdict)
+
+If you can't WebFetch ANY cited source (tools broken / no network), return:
+
+```json
+{
+  "post": "...",
+  "checkedCount": 0,
+  "claims": [],
+  "unfetchable": [],
+  "verdict": "error",
+  "error": "<reason>"
+}
+```
+
+The main agent surfaces this as "Source verification: blocked" and skips source-fix application. GEO-score fixes can still proceed.
+
+## Performance hints
+
+- Run WebFetches in parallel where possible. Source URLs are independent.
+- Cache fetched content in your context; multiple claims often map to the same source.
+- Don't fetch the same URL twice in a run.
+- For arXiv URLs, prefer the `/abs/` page over `/pdf/` (faster, contains the cited numbers). For EIPs/ERCs, `eips.ethereum.org/EIPS/eip-N` is canonical.

--- a/blog/pipeline/prompts/5-geo-score.md
+++ b/blog/pipeline/prompts/5-geo-score.md
@@ -162,7 +162,7 @@ The smallest weight because the build step + earlier prompts enforce most of thi
 4. **Compute `totalScore`** as the weighted sum. Round to one decimal.
 5. **Verdict.** Pass if `totalScore >= 7.5` AND `autoZeros` is empty.
 6. **`iterationsNeeded`** — ordered list, highest-impact fix first. Empty on pass.
-7. **Output the JSON only.** No prose framing, no "Here is the score:", start with `{`.
+7. **Emit the JSON only** — it must be your sole output, with no prose framing or "Here is the score:" preamble (it starts with `{`). The caller decides where it lands: if the invoking prompt asks you to write it to a file, write exactly that JSON to the file and nothing else; otherwise print it to stdout.
 
 ## Threshold ratchet roadmap
 

--- a/blog/pipeline/prompts/5-geo-score.md
+++ b/blog/pipeline/prompts/5-geo-score.md
@@ -1,0 +1,172 @@
+# 5-geo-score: scored GEO (Generative Engine Optimization) rubric
+
+## Purpose
+
+Quantitative pass/fail gate for new blog posts, run after Phase 3 humanize. Replaces a "vibes-based" exit with a numeric score against 6 weighted dimensions. Below the threshold = the main agent re-runs targeted fixes with the dimension-specific feedback, then re-scores (2-iteration cap).
+
+This prompt is consumed by a scoring subagent in Phase 3b of the Ethernal blog pipeline. It is paired with `prompts/3b-verify-sources.md` (source-claim verification), which runs alongside it.
+
+## Why "GEO" not just "SEO"
+
+Generative Engine Optimization. Ranks for what answer-engine LLMs (Perplexity, ChatGPT browse mode, Google AI overviews, Claude with browsing) cite when synthesizing answers. The dimensions below are what those engines reward: verified sources, extractable answer-first passages, direct quotations, concrete statistics, named entities, structural clarity. Pure-SEO heuristics (keyword density, internal-linking) are necessary but not sufficient for GEO, and keyword stuffing is *measurably counterproductive* (-10% citation visibility on Perplexity in the Princeton GEO study, arXiv:2311.09735).
+
+**The measured top-3 GEO techniques** (Princeton GEO study, validated on Perplexity) are: adding direct **quotations** from credible named sources (approximately +27%, the single best lever), adding concrete **statistics** in place of vague claims (+25-37%), and **citing sources** inline (+25%, compounding to +30-40% combined). The rubric below weights toward these: Extractability (answer-first) and Specificity-and-GEO-levers (quotes + stats) carry more weight, because they are what the evidence shows engines actually cite.
+
+## How the subagent uses this prompt
+
+You are scoring ONE post (the file path will be given to you). Read it end-to-end including the `## References` footer. For each of the 6 dimensions below, assign a score from 1 to 10 according to the dimension's own rubric. Compute the weighted total. Check the auto-zero conditions. Output JSON only, no prose preamble, no closing remarks.
+
+**Output schema** (strict, the main agent parses this):
+
+```json
+{
+  "totalScore": 8.2,
+  "dimensions": [
+    {
+      "name": "Source verification",
+      "score": 10,
+      "weight": 0.25,
+      "notes": "All 7 cited numbers have a matching numbered footnote in ## References. No misattributions."
+    },
+    { "name": "Voice distinctiveness", "score": 8, "weight": 0.18, "notes": "..." },
+    { "name": "Extractability", "score": 7, "weight": 0.20, "notes": "..." },
+    { "name": "Citation depth", "score": 9, "weight": 0.12, "notes": "..." },
+    { "name": "Specificity & GEO levers", "score": 8, "weight": 0.17, "notes": "..." },
+    { "name": "Structure compliance", "score": 10, "weight": 0.08, "notes": "..." }
+  ],
+  "autoZeros": [],
+  "verdict": "pass",
+  "iterationsNeeded": []
+}
+```
+
+- `totalScore` = sum of (score × weight) per dimension. Range 1-10.
+- `dimensions[].notes` = 1-3 sentences. Specific. Quote the offending phrase when relevant.
+- `autoZeros` = array of strings, one per triggered auto-zero condition (see below). Non-empty = `verdict: 'fail'` regardless of `totalScore`.
+- `verdict` = `'pass'` if `totalScore >= 7.5` AND `autoZeros` is empty. Otherwise `'fail'`.
+- `iterationsNeeded` = ordered list of concrete fixes the main agent should apply on re-run. Each entry: `"<dimension>: <specific change>"`. Empty on pass.
+
+## Threshold
+
+**`totalScore >= 7.5` = pass.** Below 7.5 OR any auto-zero = fail.
+
+This is a soft gate: the Ethernal pipeline publishes directly to develop with no human review, so a post that can't reach 7.5 after the iteration cap still ships, but the failing score and `iterationsNeeded` are recorded in the run log for follow-up. The gate's job is to *raise* quality via the fix loop, not to silently drop posts. Ratchet the threshold up only after 5-10 calibration posts of data.
+
+## Auto-zero conditions (any one = immediate fail)
+
+Each ships the post with a critical defect no other dimension can compensate for.
+
+1. **Unverified factual claim.** A specific numerical or named-source claim in the body that the source-verification pass (`3b-verify-sources.md`) flagged `drop` or `reattribute` and that wasn't fixed. The humanize phase + verify subagent require every cited number to appear in its source.
+2. **Em-dash present in final file.** The blog voice is em-dash-free. The offender is `—` (U+2014); hyphen `-` and en-dash `–` are fine. Run `grep -c "—" <file>` mentally; a non-zero count auto-zeros.
+3. **Description >160 chars.** The Zod schema in `blog/src/content.config.ts` hard-fails the build at this length; catch it here so iteration is faster.
+4. **`## References` footer missing.** Every Ethernal post must end with a `## References` H2 followed by numbered footnotes in the locked format (`<span id="fn-N">N.</span> Author. "Title." _Source_, Date. [url](url)`), with `<sup>[N](#fn-N)</sup>` inline citations in the body. A post without it auto-zeros.
+
+`autoZeros` array MUST be exhaustive. If multiple conditions fire, list all of them.
+
+## Dimensions
+
+### 1. Source verification — 25%
+
+The single highest-leverage thing to get right. AI-generated copy fails most often on fabricated or misattributed statistics; this dimension is the strongest defense.
+
+| Score | Description |
+|---|---|
+| 10 | Every cited number / named study / specific stat in the body has a matching numbered footnote in `## References`. The footnote's source supports the body's framing. Zero misattributions. |
+| 8 | All numbers cited; 1-2 borderline cases where a number is in the source but the framing is paraphrased slightly. No outright misattributions. |
+| 6 | One number can't be located in its cited source on a re-fetch. Either reattribute or remove. |
+| 4 | Multiple unverifiable claims OR one named study confabulated. |
+| 1 | Numbers throughout the body have no anchor in References, or References lists URLs not actually cited in the body. |
+
+**Score 6 or below on this dimension = treat as if an auto-zero fired** (it's the most consequential failure for GEO; engines cite us based on whether our facts check out).
+
+### 2. Voice distinctiveness — 18%
+
+Does the post sound like Ethernal (em-dash-free, opinionated, concrete, technically precise) or like generic AI-shaped copy? The full banned-word and banned-phrase lists live in `prompts/3-humanize.md` — score against those.
+
+| Score | Description |
+|---|---|
+| 10 | Zero banned words/phrases from `3-humanize.md` (delve, leverage, robust/seamless/comprehensive as praise, "it's worth noting", "in today's digital landscape", etc.). Zero AI scaffolding tells. No synonym cycling on technical terms (same EIP/protocol/concept name used every time, never rotated through "the proposal"/"the standard"/"the specification"). No promotional adjectives, no forced triads. Sentence-opener distribution healthy. Reads opinionated and specific. |
+| 8 | 1-2 minor tells (a single spelled-out percentage, one slightly-flat opener sequence) that don't disrupt voice. |
+| 6 | 3-5 detectable tells. A human reader would notice the cumulative effect even if no single one is glaring. |
+| 4 | Recurring tells. Voice slides toward generic. |
+| 1 | Reads as obviously AI-written. Banned phrases present. Synonym cycling. Promotional adjectives. |
+
+**Specific tells to watch for** (non-exhaustive, read `3-humanize.md` for the full list):
+
+- Conjunctive-adverb openers beyond 1 per 500 words (Additionally, Consequently, Furthermore, Moreover, Notably, However)
+- Synonym cycling on a technical term (rotating "the proposal" / "the standard" / "the specification" for the same EIP/ERC)
+- Percentages spelled out as words ("forty percent" instead of "40%")
+- "X, not Y" constructions where Y is a strawman; "Not only... but..."
+- Triadic lists ("clearer, faster, more reliable")
+- Significance inflation ("marks a pivotal moment", "stands as a testament")
+- Superficial -ing tails ("highlighting/underscoring/emphasizing ...")
+- Sentence-opener flatness: 3+ consecutive sentences starting with The/A/An/This/It
+
+### 3. Extractability — 20%
+
+How easy is it for an answer-engine to extract a quotable answer? This is the answer-first dimension, weighted high because position-decay (the engine lifts the *first* clear sentence of a passage) makes it one of the highest-leverage GEO properties.
+
+Check three things: (a) the post-level answer surfaces in the **first 40-60 words**, (b) **each H2 section opens with a self-contained 40-80 word direct answer** before expanding, and (c) at least one explicit `<Term> is <definition>` sentence near the top of the relevant section.
+
+| Score | Description |
+|---|---|
+| 10 | First 40-60 words contain a tight declarative answer (central claim/verdict, or top pick named). EVERY H2 opens answer-first, takeaway in the opening sentence, not buried below framing. At least one explicit "X is …" definition. Passages self-contained (no "as mentioned above"; key passages name the entity, not a pronoun). For comparison-listicle: up-front verdict in the hook and the item-claim in the H2 + first sentence. |
+| 8 | Post-level answer-first present; most sections open answer-first; 1-2 sections bury the takeaway below framing. Definition sentence present. |
+| 6 | Hook is curious but doesn't surface the answer until approximately 300 words in, OR several sections open with framing/anecdote before the point. No clear definition sentence. |
+| 4 | Buried lede: reader (and extractor) has to skim past anecdote/framing to find the point. |
+| 1 | Reads like a continuous essay with no scannable answer-first structure. |
+
+### 4. Citation depth — 12%
+
+| Score | Description |
+|---|---|
+| 10 | At least 4 primary sources cited (EIPs/ERCs, papers, primary product/protocol docs, named experts). References footer complete. Body cites the source explicitly where contested ("per the EIP-4844 spec", "Vitalik's post argues"). Sources authoritative, not aggregator recaps. URLs stable / archive-friendly. |
+| 8 | 3 primary sources, well-cited. 1 borderline aggregator-tier source that's still defensible. |
+| 6 | 2-3 sources only, or sources skew aggregator-tier. Body cites inconsistently. |
+| 4 | Sources thin (<=2) or one is broken / paywalled / login-gated. |
+| 1 | Body lacks specific source attributions, or References contradicts body citations. |
+
+### 5. Specificity & GEO levers — 17%
+
+Combines concrete specificity with the two measured top-3 GEO techniques not covered elsewhere: **direct quotations** and **statistics**.
+
+Score on three things: (a) concrete numbers and named entities throughout, (b) at least one verbatim attributed **quote** from a named primary source, (c) statistics in place of vague adjectives.
+
+| Score | Description |
+|---|---|
+| 10 | Body uses concrete numbers (gas costs, block sizes, dollar amounts, chain counts), named tools/protocols/people, named EIPs/papers. At least one verbatim quote (<=2 sentences) from a named credible source (core dev, auditor, protocol author, Vitalik), attributed inline. Statistics replace adjectives wherever a number exists. Zero filler quantifiers ("many", "various", "some", "often"). |
+| 8 | Mostly specific; has either a strong quote OR strong stats but not both at full strength; 1-3 mild filler quantifiers where a number would be awkward. |
+| 6 | Recurring vague quantifiers. Numbers present but mixed with "studies have shown" framing. No verbatim quote from a named source. |
+| 4 | Sparse on specifics. No quotes. Body could be about any chain in any ecosystem. |
+| 1 | Generic throughout. Adjectives where numbers belong. |
+
+**Don't reward fabricated specifics.** A "specific" number that's actually unverifiable hits auto-zero on dimension 1, not a boost here. A fabricated quote is an auto-zero (unverified claim), never a boost.
+
+### 6. Structure compliance — 8%
+
+The smallest weight because the build step + earlier prompts enforce most of this. This dimension catches what slips past Zod (which only validates frontmatter).
+
+| Score | Description |
+|---|---|
+| 10 | Content-type structure matches the declared Content Type (see `2-draft.md`). For Comparison Listicle: per-item H2 sections, a comparison table near the top, a decision framework, and "Last updated: <Month Year>" under the title. For explainer/deep-dive types: clear H2 sectioning, answer-first leads, code blocks where relevant. All: `## References` footer immediately before file ends with the locked footnote format. |
+| 8 | Structure correct; minor variance on 1 section (e.g. one section thinner than the rest). |
+| 6 | Section count borderline, or a comparison-listicle missing its comparison table. |
+| 4 | Wrong structure for the declared contentType. |
+| 1 | No discernible structural pattern. |
+
+## How to score (quick checklist for the subagent)
+
+1. **Read the file end-to-end.** Including the References footer.
+2. **Auto-zero pass first.** Run the 4 checks in order. If any fires, note it in `autoZeros[]` and still score the 6 dimensions (so the main agent can fix the auto-zero AND raise scores in one re-run).
+3. **Score each dimension 1-10** against its rubric. Quote specific phrases in `notes` where relevant.
+4. **Compute `totalScore`** as the weighted sum. Round to one decimal.
+5. **Verdict.** Pass if `totalScore >= 7.5` AND `autoZeros` is empty.
+6. **`iterationsNeeded`** — ordered list, highest-impact fix first. Empty on pass.
+7. **Output the JSON only.** No prose framing, no "Here is the score:", start with `{`.
+
+## Threshold ratchet roadmap
+
+- **First ratchet** (after 5 posts scored): if median post score >= 8.0, raise threshold to 7.8.
+- **Second ratchet** (after 10 total posts): if median >= 8.3, raise to 8.0.
+
+Don't ratchet preemptively. A handful of posts isn't enough to distinguish "we got better" from "we got lucky."


### PR DESCRIPTION
## Phase 6 — scored GEO quality gate + source verification

Final phase of the search-feedback layer (plan: `.claude/references/SERP-INTEGRATION-PLAN.md`). Adds a quality gate after Phase 3 humanize, ported from ronda and adapted to Ethernal.

### Changes
- **`prompts/5-geo-score.md`** — scored 6-dimension GEO rubric (source verification 25%, voice 18%, extractability 20%, citation depth 12%, specificity+GEO levers 17%, structure 8%), 7.5 pass threshold, 4 auto-zero conditions. Grounded in the Princeton GEO study (quotes ~+27%, stats +25-37%, citations +25% are the measured top levers). Adapted to Ethernal: numbered-footnote `## References` (not ronda's markdown table), Ethernal's banned-word list (`3-humanize.md`), Ethernal's content-type vocabulary.
- **`prompts/3b-verify-sources.md`** — source-claim verification subagent: WebFetches every cited number and returns `verified`/`reattribute`/`drop`/`unfetchable` per claim, with EVM/blog domain examples (EIP specs, gas figures, on-chain counts).
- **`draft.sh` Phase 3b** — **soft gate**. A 2-iteration loop (verify → score → fix → re-score) raises quality, but a post still below 7.5 after the cap **ships anyway** with the score + remaining fixes logged. This is deliberate: Ethernal auto-publishes to develop with no human review, so a hard gate would silently drop posts with no one to re-queue them. Fully best-effort — malformed subagent JSON or a Claude flake degrades to "publish as-is". Refreshes skip the gate (they exit the script earlier; `refresh.mjs` has its own per-strategy checks).
- **`.gitignore`** — ignore `.geo-score.json`, `.verify-sources.json`, and (closing a Phase 4 gap) `.refresh-plan.json`. All are `rm`-cleaned at end of run; ignoring them guards against a mid-run failure leaving an artifact.

### Design note: why soft, not hard
ronda's gate blocks publish on a sub-threshold score because ronda ships every post as a hidden draft for human review. Ethernal publishes directly. A hard block here would drop a post with no review queue to catch it. The soft gate keeps the quality-raising fix loop (the valuable part) while preserving Ethernal's direct-publish model. The threshold can ratchet up after 5-10 calibration posts (roadmap in the prompt).

### Not ported (deliberate)
Funnel-position tagging + TOFU/MOFU bias — low value for a technical dev-tooling blog vs ronda's PM/designer funnel (plan §6).

### Validation
- `bash -n draft.sh` clean; the Phase 3b block is fully `jq`-guarded (no malformed JSON can abort publish).
- Em-dash usage in the new prompts/comments is consistent with existing pipeline prompts (the em-dash ban applies to published post *content*, not internal prompts — existing `2-draft.md` has 9, the prior `draft.sh` 24).

Completes Phases 0-6. The search-feedback loop is fully shipped.
