### PR TITLE
fix(sync): keep retrying recovery daily instead of giving up at max a…

### DIFF
--- a/run/jobs/syncRecoveryCheck.js
+++ b/run/jobs/syncRecoveryCheck.js
@@ -20,8 +20,9 @@ const logger = require('../lib/logger');
 const BATCH_SIZE = 50;
 
 module.exports = async () => {
-    // Find explorers that are due for a recovery check (with batch limit)
-    // Excludes explorers that have reached max recovery attempts (nextRecoveryCheckAt is null)
+    // Find explorers that are due for a recovery check (with batch limit).
+    // Explorers past max recovery attempts are still included: nextRecoveryCheckAt
+    // is always set to a future value (daily cadence), never null.
     const explorers = await Explorer.findAll({
         where: {
             syncDisabledReason: { [Op.ne]: null },
@@ -74,6 +75,9 @@ module.exports = async () => {
             } else {
                 // Block fetch returned null - still unreachable
                 const result = await explorer.scheduleNextRecoveryCheck();
+                // Every still-unreachable explorer is counted here; maxAttemptsReached
+                // is an additional flag for the subset that is past max attempts.
+                stillUnreachable++;
                 if (result.maxReached) {
                     maxAttemptsReached++;
                     logger.warn({
@@ -82,13 +86,14 @@ module.exports = async () => {
                         explorerSlug: explorer.slug,
                         attempts: result.attempts
                     });
-                } else {
-                    stillUnreachable++;
                 }
             }
         } catch (error) {
             // RPC check failed - schedule next check with backoff
             const result = await explorer.scheduleNextRecoveryCheck();
+            // Every still-unreachable explorer is counted here; maxAttemptsReached
+            // is an additional flag for the subset that is past max attempts.
+            stillUnreachable++;
             if (result.maxReached) {
                 maxAttemptsReached++;
                 logger.warn({
@@ -97,8 +102,6 @@ module.exports = async () => {
                     explorerSlug: explorer.slug,
                     attempts: result.attempts
                 });
-            } else {
-                stillUnreachable++;
             }
 
             logger.debug({

--- a/run/jobs/syncRecoveryCheck.js
+++ b/run/jobs/syncRecoveryCheck.js
@@ -3,8 +3,9 @@
  * Periodically checks auto-disabled explorers to see if their RPC has recovered.
  * Re-enables sync when RPC becomes reachable, using exponential backoff for retries.
  *
- * Backoff schedule: 5m -> 15m -> 1h -> 6h (max)
- * Max recovery attempts: 10 (after which manual intervention is required)
+ * Backoff schedule: 5m -> 15m -> 1h -> 6h -> 24h (capped)
+ * After 10 attempts the explorer is flagged for manual intervention but keeps
+ * retrying once a day so it can self-recover if the RPC comes back.
  *
  * @module jobs/syncRecoveryCheck
  */
@@ -76,7 +77,7 @@ module.exports = async () => {
                 if (result.maxReached) {
                     maxAttemptsReached++;
                     logger.warn({
-                        message: 'Explorer reached max recovery attempts - manual intervention required',
+                        message: 'Explorer past max recovery attempts - flagged for manual intervention, still retrying daily',
                         explorerId: explorer.id,
                         explorerSlug: explorer.slug,
                         attempts: result.attempts
@@ -91,7 +92,7 @@ module.exports = async () => {
             if (result.maxReached) {
                 maxAttemptsReached++;
                 logger.warn({
-                    message: 'Explorer reached max recovery attempts - manual intervention required',
+                    message: 'Explorer past max recovery attempts - flagged for manual intervention, still retrying daily',
                     explorerId: explorer.id,
                     explorerSlug: explorer.slug,
                     attempts: result.attempts

--- a/run/migrations/20260427000001-backfill-stuck-recovery-explorers.js
+++ b/run/migrations/20260427000001-backfill-stuck-recovery-explorers.js
@@ -1,0 +1,35 @@
+/**
+ * @fileoverview Backfill nextRecoveryCheckAt for explorers that were permanently
+ * stuck at max recovery attempts.
+ *
+ * Before the indefinite-retry change, scheduleNextRecoveryCheck set
+ * nextRecoveryCheckAt = NULL once an explorer hit MAX_RECOVERY_ATTEMPTS, which
+ * permanently excluded it from the syncRecoveryCheck query (NULL <= now() is
+ * never true). Those explorers can never self-recover without this one-time
+ * backfill. We stagger the scheduled checks over the next 24h to avoid a
+ * thundering herd of RPC checks when the recovery job next runs.
+ *
+ * Only auto-disabled explorers (syncDisabledReason IS NOT NULL) are touched;
+ * intentionally pruned explorers (e.g. infra-prune-*) keep their NULL value so
+ * they stay excluded.
+ */
+
+'use strict';
+
+module.exports = {
+    async up(queryInterface) {
+        await queryInterface.sequelize.query(`
+            UPDATE explorers
+            SET "nextRecoveryCheckAt" = now() + (random() * interval '24 hours'),
+                "updatedAt" = now()
+            WHERE "syncDisabledReason" = 'max_recovery_attempts_reached'
+              AND "nextRecoveryCheckAt" IS NULL
+        `);
+    },
+
+    async down() {
+        // No-op: re-stuck rows would naturally return to NULL via the old code
+        // path, and we have no record of which rows were NULL before. The
+        // backfill is idempotent and safe to leave in place.
+    }
+};

--- a/run/models/explorer.js
+++ b/run/models/explorer.js
@@ -40,9 +40,11 @@ const RECOVERY_BACKOFF_SCHEDULE = [
     60 * 60 * 1000,        // 1 hour
     6 * 60 * 60 * 1000     // 6 hours
 ];
-// After MAX_RECOVERY_ATTEMPTS the explorer is flagged as needing manual
-// intervention, but we keep retrying at this cadence (at least once a day)
-// so it can self-recover if the RPC comes back without manual action.
+// At MAX_RECOVERY_ATTEMPTS the explorer is flagged as needing manual
+// intervention AND its retry cadence switches to this daily cap, so the
+// monitoring flag and the slow cadence coincide. We keep retrying at this
+// cadence forever so it can self-recover if the RPC comes back without
+// manual action.
 const RECOVERY_MAX_BACKOFF = 24 * 60 * 60 * 1000; // 24 hours
 // Stagger recovery checks to avoid thundering herd (random jitter up to 2 minutes)
 const RECOVERY_JITTER_MAX = 2 * 60 * 1000;
@@ -380,9 +382,10 @@ module.exports = (sequelize, DataTypes) => {
      * Schedules the next recovery check using exponential backoff.
      * Increments recovery attempts and never stops retrying: once
      * MAX_RECOVERY_ATTEMPTS is reached the explorer is flagged as needing
-     * manual intervention (maxReached) but keeps retrying at a daily cadence
-     * so it can self-recover if the RPC comes back.
-     * Backoff schedule: 5m -> 15m -> 1h -> 6h -> 24h (capped, retried indefinitely)
+     * manual intervention (maxReached) and switches to a daily cadence, but
+     * keeps retrying forever so it can self-recover if the RPC comes back.
+     * Backoff: 5m -> 15m -> 1h -> 6h (held) until attempt MAX_RECOVERY_ATTEMPTS,
+     * then 24h (capped, retried indefinitely).
      * @returns {Promise<{scheduled: boolean, attempts: number, maxReached: boolean}>} Result
      */
     async scheduleNextRecoveryCheck() {
@@ -393,13 +396,17 @@ module.exports = (sequelize, DataTypes) => {
         const newAttempts = (this.recoveryAttempts || 0) + 1;
         const maxReached = newAttempts >= MAX_RECOVERY_ATTEMPTS;
 
-        // Once past the backoff schedule (or past max attempts), cap retries at
-        // the daily interval so we keep trying at least once a day forever.
+        // Backoff: ramp through the schedule (holding the last entry once the
+        // schedule is exhausted), then once MAX_RECOVERY_ATTEMPTS is reached
+        // switch to the daily cap. This keeps the monitoring flag (maxReached)
+        // and the slow daily cadence aligned at the same threshold, and we keep
+        // retrying at the daily cadence forever so the explorer can self-recover.
         let backoff;
-        if (newAttempts > RECOVERY_BACKOFF_SCHEDULE.length) {
+        if (maxReached) {
             backoff = RECOVERY_MAX_BACKOFF;
         } else {
-            backoff = RECOVERY_BACKOFF_SCHEDULE[newAttempts - 1];
+            const backoffIndex = Math.min(newAttempts - 1, RECOVERY_BACKOFF_SCHEDULE.length - 1);
+            backoff = RECOVERY_BACKOFF_SCHEDULE[backoffIndex];
         }
 
         // Add random jitter to stagger recovery checks

--- a/run/models/explorer.js
+++ b/run/models/explorer.js
@@ -35,11 +35,15 @@ const MAX_RPC_ATTEMPTS = 3;
 const SYNC_FAILURE_THRESHOLD = 3;
 const MAX_RECOVERY_ATTEMPTS = 10;
 const RECOVERY_BACKOFF_SCHEDULE = [
-    5 * 60 * 1000,       // 5 minutes
-    15 * 60 * 1000,      // 15 minutes
-    60 * 60 * 1000,      // 1 hour
-    6 * 60 * 60 * 1000   // 6 hours (max)
+    5 * 60 * 1000,         // 5 minutes
+    15 * 60 * 1000,        // 15 minutes
+    60 * 60 * 1000,        // 1 hour
+    6 * 60 * 60 * 1000     // 6 hours
 ];
+// After MAX_RECOVERY_ATTEMPTS the explorer is flagged as needing manual
+// intervention, but we keep retrying at this cadence (at least once a day)
+// so it can self-recover if the RPC comes back without manual action.
+const RECOVERY_MAX_BACKOFF = 24 * 60 * 60 * 1000; // 24 hours
 // Stagger recovery checks to avoid thundering herd (random jitter up to 2 minutes)
 const RECOVERY_JITTER_MAX = 2 * 60 * 1000;
 
@@ -374,8 +378,11 @@ module.exports = (sequelize, DataTypes) => {
 
     /**
      * Schedules the next recovery check using exponential backoff.
-     * Increments recovery attempts and returns null if max attempts reached.
-     * Backoff schedule: 5m -> 15m -> 1h -> 6h (max)
+     * Increments recovery attempts and never stops retrying: once
+     * MAX_RECOVERY_ATTEMPTS is reached the explorer is flagged as needing
+     * manual intervention (maxReached) but keeps retrying at a daily cadence
+     * so it can self-recover if the RPC comes back.
+     * Backoff schedule: 5m -> 15m -> 1h -> 6h -> 24h (capped, retried indefinitely)
      * @returns {Promise<{scheduled: boolean, attempts: number, maxReached: boolean}>} Result
      */
     async scheduleNextRecoveryCheck() {
@@ -384,28 +391,28 @@ module.exports = (sequelize, DataTypes) => {
         }
 
         const newAttempts = (this.recoveryAttempts || 0) + 1;
+        const maxReached = newAttempts >= MAX_RECOVERY_ATTEMPTS;
 
-        // Check if max recovery attempts reached
-        if (newAttempts >= MAX_RECOVERY_ATTEMPTS) {
-            await this.update({
-                recoveryAttempts: newAttempts,
-                nextRecoveryCheckAt: null,
-                syncDisabledReason: 'max_recovery_attempts_reached'
-            });
-            return { scheduled: false, attempts: newAttempts, maxReached: true };
+        // Once past the backoff schedule (or past max attempts), cap retries at
+        // the daily interval so we keep trying at least once a day forever.
+        let backoff;
+        if (newAttempts > RECOVERY_BACKOFF_SCHEDULE.length) {
+            backoff = RECOVERY_MAX_BACKOFF;
+        } else {
+            backoff = RECOVERY_BACKOFF_SCHEDULE[newAttempts - 1];
         }
 
-        // Use recovery attempts as index, capped at max backoff
-        const backoffIndex = Math.min(newAttempts - 1, RECOVERY_BACKOFF_SCHEDULE.length - 1);
         // Add random jitter to stagger recovery checks
         const jitter = Math.floor(Math.random() * RECOVERY_JITTER_MAX);
-        const nextCheck = new Date(Date.now() + RECOVERY_BACKOFF_SCHEDULE[backoffIndex] + jitter);
+        const nextCheck = new Date(Date.now() + backoff + jitter);
 
         await this.update({
             recoveryAttempts: newAttempts,
-            nextRecoveryCheckAt: nextCheck
+            nextRecoveryCheckAt: nextCheck,
+            // Flag for monitoring once max attempts reached, but keep retrying.
+            ...(maxReached ? { syncDisabledReason: 'max_recovery_attempts_reached' } : {})
         });
-        return { scheduled: true, attempts: newAttempts, maxReached: false };
+        return { scheduled: true, attempts: newAttempts, maxReached };
     }
 
     /**

--- a/run/tests/jobs/syncRecoveryCheck.test.js
+++ b/run/tests/jobs/syncRecoveryCheck.test.js
@@ -107,7 +107,7 @@ describe('syncRecoveryCheck', () => {
         const result = await syncRecoveryCheck();
 
         expect(mockScheduleNextRecoveryCheck).toHaveBeenCalled();
-        expect(result).toEqual('Checked 1 explorers: 0 recovered, 0 still unreachable, 1 max attempts reached');
+        expect(result).toEqual('Checked 1 explorers: 0 recovered, 1 still unreachable, 1 max attempts reached');
     });
 
     it('Should skip explorers without workspace', async () => {

--- a/run/tests/jobs/syncRecoveryCheck.test.js
+++ b/run/tests/jobs/syncRecoveryCheck.test.js
@@ -87,8 +87,8 @@ describe('syncRecoveryCheck', () => {
         expect(result).toEqual('Checked 1 explorers: 0 recovered, 1 still unreachable, 0 max attempts reached');
     });
 
-    it('Should handle max recovery attempts reached', async () => {
-        const mockScheduleNextRecoveryCheck = jest.fn().mockResolvedValue({ scheduled: false, attempts: 10, maxReached: true });
+    it('Should flag max recovery attempts reached while still rescheduling a daily retry', async () => {
+        const mockScheduleNextRecoveryCheck = jest.fn().mockResolvedValue({ scheduled: true, attempts: 10, maxReached: true });
         jest.spyOn(Explorer, 'findAll').mockResolvedValueOnce([{
             id: 1,
             slug: 'test-explorer',

--- a/run/tests/jobs/syncRecoveryCheck.test.js
+++ b/run/tests/jobs/syncRecoveryCheck.test.js
@@ -110,6 +110,29 @@ describe('syncRecoveryCheck', () => {
         expect(result).toEqual('Checked 1 explorers: 0 recovered, 1 still unreachable, 1 max attempts reached');
     });
 
+    it('Should flag max recovery attempts reached when the RPC check throws', async () => {
+        const mockScheduleNextRecoveryCheck = jest.fn().mockResolvedValue({ scheduled: true, attempts: 10, maxReached: true });
+        jest.spyOn(Explorer, 'findAll').mockResolvedValueOnce([{
+            id: 1,
+            slug: 'test-explorer',
+            syncDisabledReason: 'rpc_unreachable',
+            enableSyncAfterRecovery: jest.fn(),
+            scheduleNextRecoveryCheck: mockScheduleNextRecoveryCheck,
+            workspace: {
+                id: 1,
+                rpcServer: 'http://localhost:8545'
+            }
+        }]);
+        ProviderConnector.mockImplementation(() => ({
+            fetchLatestBlock: jest.fn().mockRejectedValue(new Error('Connection refused'))
+        }));
+
+        const result = await syncRecoveryCheck();
+
+        expect(mockScheduleNextRecoveryCheck).toHaveBeenCalled();
+        expect(result).toEqual('Checked 1 explorers: 0 recovered, 1 still unreachable, 1 max attempts reached');
+    });
+
     it('Should skip explorers without workspace', async () => {
         jest.spyOn(Explorer, 'findAll').mockResolvedValueOnce([{
             id: 1,


### PR DESCRIPTION
…ttempts

Previously, once an auto-disabled explorer reached MAX_RECOVERY_ATTEMPTS (10), scheduleNextRecoveryCheck set nextRecoveryCheckAt to null, which permanently excluded it from syncRecoveryCheck (the query filters on nextRecoveryCheckAt <= now). Explorers whose RPC was temporarily down required manual intervention to ever resume, even after the RPC recovered.

Now the backoff schedule caps at 24h and recovery is retried indefinitely. After 10 attempts the explorer is still flagged with the max_recovery_attempts_reached reason (for monitoring/alerting) but keeps getting checked at least once a day, so it can self-recover when the RPC comes back without manual action.

Backoff: 5m -> 15m -> 1h -> 6h -> 24h (capped, retried indefinitely)