### PR TITLE
fix(db): address two unbounded DB-growth leaks

### DIFF
--- a/run/jobs/enforceDataRetentionForWorkspace.js
+++ b/run/jobs/enforceDataRetentionForWorkspace.js
@@ -6,6 +6,7 @@
 
 const { Op } = require('sequelize');
 const { enqueue } = require('../lib/queue');
+const { getFreeTierDefaultRetentionDays } = require('../lib/env');
 const { Workspace, Explorer, StripeSubscription } = require('../models');
 
 module.exports = async () => {
@@ -48,6 +49,13 @@ module.exports = async () => {
             to: new Date(new Date() - 60 * 60 * 24 * workspace.dataRetentionLimit * 1000)
         });
     }
+
+    const retentionDays = getFreeTierDefaultRetentionDays();
+    const candidateCount = await Workspace.count({
+        where: { dataRetentionLimit: 0 },
+        include: [{ association: 'explorer', required: true }]
+    });
+    console.log(`[retention-dryrun] free-tier default cap would target ${candidateCount} explorer workspaces at retention=${retentionDays}d (no deletions performed)`);
 
     return;
 };

--- a/run/lib/env.js
+++ b/run/lib/env.js
@@ -25,6 +25,7 @@ module.exports = {
     getPostHogApiHost: () => process.env.POST_HOG_API_HOST,
     getMaxBlockForSyncReset: () => parseInt(process.env.MAX_BLOCK_FOR_SYNC_RESET) || 10,
     getMaxContractForReset: () => parseInt(process.env.MAX_CONTRACT_FOR_RESET) || 5,
+    getFreeTierDefaultRetentionDays: () => parseInt(process.env.FREE_TIER_DEFAULT_RETENTION_DAYS) || 7,
     getEncryptionKey: () => process.env.ENCRYPTION_KEY,
     getEncryptionJwtSecret: () => process.env.ENCRYPTION_JWT_SECRET,
     getQuicknodeCredentials: () => process.env.QUICKNODE_CREDENTIALS,

--- a/run/migrations/20260713000001-add-event-hypertable-retention.js
+++ b/run/migrations/20260713000001-add-event-hypertable-retention.js
@@ -14,7 +14,7 @@ module.exports = {
       }
       await transaction.commit();
     } catch(error) {
-        console.log(error);
+        console.error(error);
         await transaction.rollback();
         throw error;
     }
@@ -32,7 +32,7 @@ module.exports = {
       }
       await transaction.commit();
     } catch(error) {
-        console.log(error);
+        console.error(error);
         await transaction.rollback();
         throw error;
     }

--- a/run/migrations/20260713000001-add-event-hypertable-retention.js
+++ b/run/migrations/20260713000001-add-event-hypertable-retention.js
@@ -1,0 +1,40 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    const tables = ['transaction_events', 'token_transfer_events', 'block_events', 'token_balance_change_events'];
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      for (const table of tables) {
+        await queryInterface.sequelize.query(
+          `SELECT add_retention_policy('${table}', INTERVAL '90 days', if_not_exists => TRUE);`,
+          { transaction }
+        );
+      }
+      await transaction.commit();
+    } catch(error) {
+        console.log(error);
+        await transaction.rollback();
+        throw error;
+    }
+  },
+
+  async down (queryInterface, Sequelize) {
+    const tables = ['transaction_events', 'token_transfer_events', 'block_events', 'token_balance_change_events'];
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      for (const table of tables) {
+        await queryInterface.sequelize.query(
+          `SELECT remove_retention_policy('${table}', if_exists => TRUE);`,
+          { transaction }
+        );
+      }
+      await transaction.commit();
+    } catch(error) {
+        console.log(error);
+        await transaction.rollback();
+        throw error;
+    }
+  }
+};

--- a/run/tests/jobs/enforceDataRetentionForWorkspace.test.js
+++ b/run/tests/jobs/enforceDataRetentionForWorkspace.test.js
@@ -79,6 +79,7 @@ describe('enforceDataRetentionForWorkspace', () => {
             .then(() => {
                 expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[retention-dryrun]'));
                 expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('42'));
+                consoleSpy.mockRestore();
                 done();
             });
     });

--- a/run/tests/jobs/enforceDataRetentionForWorkspace.test.js
+++ b/run/tests/jobs/enforceDataRetentionForWorkspace.test.js
@@ -24,6 +24,7 @@ describe('enforceDataRetentionForWorkspace', () => {
                 }
             }
         ]);
+        jest.spyOn(Workspace, 'count').mockResolvedValue(0);
         jest.useFakeTimers()
             .setSystemTime(new Date('2023-12-15'));
 
@@ -59,10 +60,25 @@ describe('enforceDataRetentionForWorkspace', () => {
                 }
             }
         ]);
-        
+        jest.spyOn(Workspace, 'count').mockResolvedValue(0);
+
         enforceDataRetentionForWorkspace({ data: { workspaceId: 123 }})
             .then(() => {
                 expect(enqueue).not.toHaveBeenCalled();
+                done();
+            });
+    });
+
+    it('Should log the dry-run candidate count', (done) => {
+        jest.spyOn(Workspace, 'findAll').mockResolvedValueOnce([]);
+        jest.spyOn(StripeSubscription, 'findAll').mockResolvedValueOnce([]);
+        jest.spyOn(Workspace, 'count').mockResolvedValueOnce(42);
+        const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+        enforceDataRetentionForWorkspace()
+            .then(() => {
+                expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[retention-dryrun]'));
+                expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('42'));
                 done();
             });
     });

--- a/run/tests/mocks/models/Workspace.js
+++ b/run/tests/mocks/models/Workspace.js
@@ -119,6 +119,7 @@ const Workspace = {
     findByPk: jest.fn().mockResolvedValue(workspace),
     findAll: jest.fn(),
     findOne: jest.fn(),
+    count: jest.fn(),
     getAvailableL1Parents: jest.fn().mockResolvedValue({ publicParents: [], customParents: [] }),
     createCustomL1Parent: jest.fn(),
     getAvailableTopOrbitParent: jest.fn().mockResolvedValue([]),


### PR DESCRIPTION
Leak A (observation-only): free-tier explorer workspaces with dataRetentionLimit=0 never get their block/contract data pruned, so they grow unbounded. Add read-only dry-run instrumentation to enforceDataRetentionForWorkspace that logs how many explorer workspaces a future free-tier default cap (FREE_TIER_DEFAULT_RETENTION_DAYS, default 7) would target. No enqueue/delete behavior changed.

Leak B: the *_events hypertables (transaction/token_transfer/block/ token_balance_change) had NO retention policy (the only 1-month job is Timescale's internal error-log cleanup, not data retention), so ~123 GB of event data grows without bound. Add a migration that installs native TimescaleDB retention policies (90 days) on all four hypertables. Chunk drops run as a non-blocking background job; reversible via down().

Refs: docs/plans/fly-db-migration.md