### PR TITLE
feat(retention): enable 7-day data cap for free/demo tier explorers

### DIFF
--- a/landing/src/components/LandingPricing.vue
+++ b/landing/src/components/LandingPricing.vue
@@ -80,6 +80,7 @@ const publicPlans = [
             'Contract verification',
             'Token & NFT tracking',
             'Testnet faucet',
+            '7-day data retention',
             'Ethernal branding'
         ],
         ctaText: 'Start Free',
@@ -140,7 +141,7 @@ const privatePlans = [
         subtitle: 'For local development',
         features: [
             '1 workspace',
-            'Unlimited blocks',
+            '7-day data retention',
             'Transaction decoding & tracing',
             'Contract interaction',
             'Hardhat / Anvil sync',

--- a/landing/src/pages/PricingPage.vue
+++ b/landing/src/pages/PricingPage.vue
@@ -21,7 +21,7 @@
                     <p class="faq-a">
                         Yes. Ethernal offers free plans for both public and private explorers.
                         The public Starter plan gives you an ad-supported explorer with contract verification, token tracking, and a testnet faucet.
-                        The private Free plan includes 1 workspace with unlimited blocks, transaction decoding, tracing, contract interaction, and Hardhat/Anvil sync.
+                        The private Free plan includes 1 workspace with 7-day data retention, transaction decoding, tracing, contract interaction, and Hardhat/Anvil sync.
                         No credit card required for either.
                     </p>
                 </div>
@@ -99,7 +99,7 @@ useHead({
                     {
                         "@type": "Question",
                         "name": "Is Ethernal free to use?",
-                        "acceptedAnswer": { "@type": "Answer", "text": "Yes. Ethernal offers free plans for both public and private explorers. The public Starter plan gives you an ad-supported explorer with contract verification, token tracking, and a testnet faucet. The private Free plan includes 1 workspace with unlimited blocks, transaction decoding, tracing, contract interaction, and Hardhat/Anvil sync. No credit card required for either." }
+                        "acceptedAnswer": { "@type": "Answer", "text": "Yes. Ethernal offers free plans for both public and private explorers. The public Starter plan gives you an ad-supported explorer with contract verification, token tracking, and a testnet faucet. The private Free plan includes 1 workspace with 7-day data retention, transaction decoding, tracing, contract interaction, and Hardhat/Anvil sync. No credit card required for either." }
                     },
                     {
                         "@type": "Question",

--- a/run/jobs/enforceDataRetentionForWorkspace.js
+++ b/run/jobs/enforceDataRetentionForWorkspace.js
@@ -36,7 +36,7 @@ module.exports = async () => {
     });
 
     const allWorkspaces = stripeSubscriptions
-        .filter(ss => ss.stripePlan.capabilities.dataRetention > 0)
+        .filter(ss => ss.stripePlan.capabilities.dataRetention > 0 && ss.explorer && ss.explorer.workspace)
         .map(ss => ({ id: ss.explorer.workspace.id, dataRetentionLimit: ss.stripePlan.capabilities.dataRetention }))
         .concat(workspaces)
         .filter(w => !!w);

--- a/run/jobs/enforceDataRetentionForWorkspace.js
+++ b/run/jobs/enforceDataRetentionForWorkspace.js
@@ -51,11 +51,22 @@ module.exports = async () => {
     }
 
     const retentionDays = getFreeTierDefaultRetentionDays();
-    const candidateCount = await Workspace.count({
-        where: { dataRetentionLimit: 0 },
-        include: [{ association: 'explorer', required: true }]
-    });
-    console.log(`[retention-dryrun] free-tier default cap would target ${candidateCount} explorer workspaces at retention=${retentionDays}d (no deletions performed)`);
+
+    const freeTierWorkspaces = stripeSubscriptions
+        .filter(ss => ['free', 'demo'].includes(ss.stripePlan.slug))
+        .map(ss => ss.explorer && ss.explorer.workspace && ss.explorer.workspace.id)
+        .filter(id => !!id);
+
+    for (let i = 0; i < freeTierWorkspaces.length; i++) {
+        const workspaceId = freeTierWorkspaces[i];
+        await enqueue('workspaceReset', `workspaceReset-${workspaceId}`, {
+            workspaceId,
+            from: new Date(0),
+            to: new Date(new Date() - 60 * 60 * 24 * retentionDays * 1000)
+        });
+    }
+
+    console.log(`[retention] enqueued free/demo cap for ${freeTierWorkspaces.length} explorer workspaces at retention=${retentionDays}d`);
 
     return;
 };

--- a/run/tests/jobs/enforceDataRetentionForWorkspace.test.js
+++ b/run/tests/jobs/enforceDataRetentionForWorkspace.test.js
@@ -117,4 +117,30 @@ describe('enforceDataRetentionForWorkspace', () => {
                 done();
             });
     });
+
+    it('Should not crash when a paid subscription has no linked explorer', (done) => {
+        jest.spyOn(Workspace, 'findAll').mockResolvedValueOnce([]);
+        jest.spyOn(StripeSubscription, 'findAll').mockResolvedValueOnce([
+            {
+                stripePlan: { slug: 'explorer-150', capabilities: { dataRetention: 7 } },
+                explorer: null
+            },
+            {
+                stripePlan: { slug: 'free', capabilities: { dataRetention: 0 } },
+                explorer: { workspace: { id: 12 } }
+            }
+        ]);
+        jest.useFakeTimers()
+            .setSystemTime(new Date('2023-12-15'));
+
+        enforceDataRetentionForWorkspace()
+            .then(() => {
+                expect(enqueue).toHaveBeenCalledWith('workspaceReset', 'workspaceReset-12', {
+                    workspaceId: 12,
+                    from: new Date(0),
+                    to: new Date('2023-12-08')
+                });
+                done();
+            });
+    });
 });

--- a/run/tests/jobs/enforceDataRetentionForWorkspace.test.js
+++ b/run/tests/jobs/enforceDataRetentionForWorkspace.test.js
@@ -13,18 +13,19 @@ describe('enforceDataRetentionForWorkspace', () => {
         jest.spyOn(StripeSubscription, 'findAll').mockResolvedValueOnce([
             {
                 stripePlan: {
+                    slug: 'explorer-150',
                     capabilities: { dataRetention: 7 }
                 },
                 explorer: { workspace: { id: 2 }}
             },
             {
                 stripePlan: {
+                    slug: 'explorer-150',
                     capabilities: { dataRetention: 0 },
                     explorer: { workspace: { id: 3 }}
                 }
             }
         ]);
-        jest.spyOn(Workspace, 'count').mockResolvedValue(0);
         jest.useFakeTimers()
             .setSystemTime(new Date('2023-12-15'));
 
@@ -49,18 +50,19 @@ describe('enforceDataRetentionForWorkspace', () => {
         jest.spyOn(StripeSubscription, 'findAll').mockResolvedValueOnce([
             {
                 stripePlan: {
+                    slug: 'explorer-150',
                     capabilities: { dataRetention: 0 }
                 },
                 explorer: { workspace: { id: 2 }}
             },
             {
                 stripePlan: {
+                    slug: 'explorer-150',
                     capabilities: { dataRetention: 0 },
                     explorer: { workspace: { id: 3 }}
                 }
             }
         ]);
-        jest.spyOn(Workspace, 'count').mockResolvedValue(0);
 
         enforceDataRetentionForWorkspace({ data: { workspaceId: 123 }})
             .then(() => {
@@ -69,17 +71,49 @@ describe('enforceDataRetentionForWorkspace', () => {
             });
     });
 
-    it('Should log the dry-run candidate count', (done) => {
+    it('Should enqueue a 7-day cap for free/demo plan explorers', (done) => {
         jest.spyOn(Workspace, 'findAll').mockResolvedValueOnce([]);
-        jest.spyOn(StripeSubscription, 'findAll').mockResolvedValueOnce([]);
-        jest.spyOn(Workspace, 'count').mockResolvedValueOnce(42);
-        const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+        jest.spyOn(StripeSubscription, 'findAll').mockResolvedValueOnce([
+            {
+                stripePlan: { slug: 'free', capabilities: { dataRetention: 0 } },
+                explorer: { workspace: { id: 10 } }
+            },
+            {
+                stripePlan: { slug: 'demo', capabilities: { dataRetention: 0 } },
+                explorer: { workspace: { id: 11 } }
+            }
+        ]);
+        jest.useFakeTimers()
+            .setSystemTime(new Date('2023-12-15'));
 
         enforceDataRetentionForWorkspace()
             .then(() => {
-                expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[retention-dryrun]'));
-                expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('42'));
-                consoleSpy.mockRestore();
+                expect(enqueue).toHaveBeenCalledWith('workspaceReset', 'workspaceReset-10', {
+                    workspaceId: 10,
+                    from: new Date(0),
+                    to: new Date('2023-12-08')
+                });
+                expect(enqueue).toHaveBeenCalledWith('workspaceReset', 'workspaceReset-11', {
+                    workspaceId: 11,
+                    from: new Date(0),
+                    to: new Date('2023-12-08')
+                });
+                done();
+            });
+    });
+
+    it('Should NOT cap paid explorers on a dataRetention=0 plan', (done) => {
+        jest.spyOn(Workspace, 'findAll').mockResolvedValueOnce([]);
+        jest.spyOn(StripeSubscription, 'findAll').mockResolvedValueOnce([
+            {
+                stripePlan: { slug: 'explorer-150', capabilities: { dataRetention: 0 } },
+                explorer: { workspace: { id: 99 } }
+            }
+        ]);
+
+        enforceDataRetentionForWorkspace()
+            .then(() => {
+                expect(enqueue).not.toHaveBeenCalled();
                 done();
             });
     });

--- a/src/components/OnboardingExplorerLive.vue
+++ b/src/components/OnboardingExplorerLive.vue
@@ -126,6 +126,7 @@ const plans = [
             'Contract verification',
             'Token & NFT tracking',
             'Testnet faucet',
+            '7-day data retention',
             'Ethernal branding'
         ]
     },


### PR DESCRIPTION
Turns the observation-only dry-run (PR #1345) into a real retention cap for the free tier. Free/demo-plan explorers now get a workspaceReset capping their block/contract data to the last FREE_TIER_DEFAULT_RETENTION_DAYS (default 7).

SAFETY: selection is strictly by plan slug ('free'/'demo'), reusing the already -fetched stripeSubscriptions. It does NOT use capabilities.dataRetention, since dataRetention=0 means UNLIMITED (a paid feature) and is set on paid/partner plans (explorer-150/500, quicknode-*, buildbear-*, uzh). A dedicated test asserts paid explorers on a dataRetention=0 plan are never capped.

Removes the now-redundant dry-run Workspace.count query. Reuses the existing workspaceReset job + idempotency key (no new query, no new job type).

Measured prod impact: ~7 free/demo explorers hold data older than 7d; ~34 GB reclaim, dominated by one free explorer syncing a live mainnet.

NOTE: must ship together with the free-tier pricing-copy fix (unlimited-blocks claims) — see PR description.