### PR TITLE
fix(retention): paginate workspaceReset by indexed id, drop 30s timeout

### DIFF
--- a/run/jobs/workspaceReset.js
+++ b/run/jobs/workspaceReset.js
@@ -7,9 +7,99 @@
 const Sequelize = require('sequelize');
 const { Workspace } = require('../models');
 const { bulkEnqueue } = require('../lib/queue');
-const { getMaxBlockForSyncReset, getMaxContractForReset } = require('../lib/env');
+const { getMaxBlockForSyncReset, getMaxContractForReset, getWorkspaceResetPageSize } = require('../lib/env');
 const Op = Sequelize.Op;
 
+/**
+ * Enqueues batch-delete jobs for a set of ids, chunked by the given size.
+ *
+ * @param {string} queueName - Target queue ('batchBlockDelete' or 'batchContractDelete')
+ * @param {number} workspaceId - Workspace whose records are being deleted
+ * @param {number[]} ids - Record ids to schedule for deletion
+ * @param {number} chunkSize - Maximum number of ids per enqueued job
+ * @param {function(number, number): string} nameFn - Builds a job name from (startOffset, endOffset)
+ * @param {number} baseOffset - Running offset used to keep job names unique across pages
+ * @returns {Promise<void>}
+ */
+const enqueueBatchDeletes = async (queueName, workspaceId, ids, chunkSize, nameFn, baseOffset) => {
+    const jobs = [];
+    for (let i = 0; i < ids.length; i += chunkSize)
+        jobs.push({
+            name: nameFn(baseOffset + i, baseOffset + i + chunkSize),
+            data: {
+                workspaceId,
+                ids: ids.slice(i, i + chunkSize)
+            }
+        });
+
+    if (jobs.length)
+        await bulkEnqueue(queueName, jobs);
+};
+
+/**
+ * Walks a workspace association in keyset-paginated pages ordered by indexed
+ * primary key, enqueuing batch-delete jobs for records whose createdAt falls
+ * within [from, to]. Avoids the unindexed createdAt full scan (and the tight
+ * job timeout it triggered) by keeping each query indexed and bounded.
+ *
+ * @param {Object} getter - Sequelize association getter (e.g. workspace.getBlocks)
+ * @param {number} workspaceId - Workspace being reset
+ * @param {Date|string|number} from - Inclusive start of the retention window
+ * @param {Date|string|number} to - Inclusive end of the retention window
+ * @param {string} queueName - Target delete queue name
+ * @param {number} chunkSize - Ids per enqueued delete job
+ * @param {function(number, number): string} nameFn - Builds a job name from (startOffset, endOffset)
+ * @returns {Promise<void>}
+ */
+const paginateAndEnqueue = async (getter, workspaceId, from, to, queueName, chunkSize, nameFn) => {
+    const pageSize = getWorkspaceResetPageSize();
+    const fromTime = new Date(from).getTime();
+    const toTime = new Date(to).getTime();
+    let lastId = 0;
+    let offset = 0;
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+        const page = await getter({
+            where: { id: { [Op.gt]: lastId } },
+            attributes: ['id', 'createdAt'],
+            order: [['id', 'ASC']],
+            limit: pageSize
+        });
+
+        if (!page.length)
+            break;
+
+        lastId = page[page.length - 1].id;
+
+        const matchingIds = page
+            .filter(r => {
+                const t = new Date(r.createdAt).getTime();
+                return t >= fromTime && t <= toTime;
+            })
+            .map(r => r.id);
+
+        if (matchingIds.length) {
+            await enqueueBatchDeletes(queueName, workspaceId, matchingIds, chunkSize, nameFn, offset);
+            offset += matchingIds.length;
+        }
+
+        if (page.length < pageSize)
+            break;
+    }
+};
+
+/**
+ * Resets a workspace by scheduling deletion of its blocks and contracts within
+ * a date range and destroying associated orbit data, integrity checks and
+ * accounts. Only acts on the workspaceId it is handed; plan/retention selection
+ * lives in enforceDataRetentionForWorkspace.js.
+ *
+ * @param {Object} job - BullMQ job
+ * @param {Object} job.data - { workspaceId, from, to }
+ * @returns {Promise<string|void>} 'Invalid date range' on a bad window, otherwise void
+ * @throws {Error} If a required parameter is missing or the workspace cannot be found
+ */
 module.exports = async (job) => {
     console.log('workspaceReset');
     const data = job.data;
@@ -20,8 +110,6 @@ module.exports = async (job) => {
     if (new Date(data.from).getTime() < 0 || new Date(data.to).getTime() < 0 || new Date(data.from) > new Date(data.to))
         return 'Invalid date range';
 
-    const where = { createdAt: { [Op.between]: [data.from, data.to] }};
-
     const workspace = await Workspace.findByPk(data.workspaceId);
     if (!workspace)
         throw new Error('Cannot find workspace');
@@ -29,32 +117,28 @@ module.exports = async (job) => {
     console.log('destroying orbit data for workspace', data.workspaceId);
     await workspace.safeDestroyOrbitData();
 
-    const blocks = await workspace.getBlocks({ where, attributes: ['id'] });
-    const blockIds = blocks.map(b => b.id);
+    const fromTime = new Date(data.from).getTime();
+    const toTime = new Date(data.to).getTime();
 
-    const blockDeleteJobs = [];
-    for (let i = 0; i < blockIds.length; i += getMaxBlockForSyncReset())
-        blockDeleteJobs.push({
-            name: `batchBlockDelete-${data.workspaceId}-${i}-${i + getMaxBlockForSyncReset()}-${new Date(data.from).getTime()}-${new Date(data.to).getTime()}`,
-            data: {
-                workspaceId: data.workspaceId,
-                ids: blockIds.slice(i, i + getMaxBlockForSyncReset())
-            }
-        });
-    await bulkEnqueue('batchBlockDelete', blockDeleteJobs);
+    await paginateAndEnqueue(
+        workspace.getBlocks.bind(workspace),
+        data.workspaceId,
+        data.from,
+        data.to,
+        'batchBlockDelete',
+        getMaxBlockForSyncReset(),
+        (start, end) => `batchBlockDelete-${data.workspaceId}-${start}-${end}-${fromTime}-${toTime}`
+    );
 
-    const contracts = await workspace.getContracts({ where, attributes: ['id'] });
-    const contractIds = contracts.map(b => b.id);
-    const contractDeleteJobs =[];
-    for (let i = 0; i < contractIds.length; i += getMaxContractForReset())
-        contractDeleteJobs.push({
-            name: `batchContractDelete-${data.workspaceId}-${i}-${i + getMaxContractForReset()}`,
-            data: {
-                workspaceId: data.workspaceId,
-                ids: contractIds.slice(i, i + getMaxContractForReset())
-            }
-        });
-    await bulkEnqueue('batchContractDelete', contractDeleteJobs);
+    await paginateAndEnqueue(
+        workspace.getContracts.bind(workspace),
+        data.workspaceId,
+        data.from,
+        data.to,
+        'batchContractDelete',
+        getMaxContractForReset(),
+        (start, end) => `batchContractDelete-${data.workspaceId}-${start}-${end}`
+    );
 
     await workspace.safeDestroyIntegrityCheck();
     await workspace.safeDestroyAccounts();

--- a/run/lib/env.js
+++ b/run/lib/env.js
@@ -25,6 +25,7 @@ module.exports = {
     getPostHogApiHost: () => process.env.POST_HOG_API_HOST,
     getMaxBlockForSyncReset: () => parseInt(process.env.MAX_BLOCK_FOR_SYNC_RESET) || 10,
     getMaxContractForReset: () => parseInt(process.env.MAX_CONTRACT_FOR_RESET) || 5,
+    getWorkspaceResetPageSize: () => parseInt(process.env.WORKSPACE_RESET_PAGE_SIZE) || 10000,
     getFreeTierDefaultRetentionDays: () => parseInt(process.env.FREE_TIER_DEFAULT_RETENTION_DAYS) || 7,
     getEncryptionKey: () => process.env.ENCRYPTION_KEY,
     getEncryptionJwtSecret: () => process.env.ENCRYPTION_JWT_SECRET,

--- a/run/queues.js
+++ b/run/queues.js
@@ -46,6 +46,11 @@ priorities['medium'].forEach(jobName => {
 });
 
 priorities['low'].forEach(jobName => {
+    // workspaceReset is registered separately below without the shared 30s
+    // timeout; skip it here so we don't create an orphaned Queue instance.
+    if (jobName === 'workspaceReset')
+        return;
+
     queues[jobName] = new Queue(jobName, {
         defaultJobOptions: {
             attempts: 10,
@@ -65,7 +70,7 @@ priorities['low'].forEach(jobName => {
 // workspaceReset paginates through a workspace's blocks/contracts (millions of
 // rows for large free/demo explorers) to enqueue batchBlockDelete jobs. The
 // shared low-tier 30s timeout stalled it before it enumerated anything, so
-// large workspaces never got pruned. Re-register it without a per-job timeout;
+// large workspaces never got pruned. Register it without a per-job timeout;
 // the bounded, indexed keyset queries are the only work it does (the actual
 // deletes happen in batchBlockDelete).
 queues['workspaceReset'] = new Queue('workspaceReset', {

--- a/run/queues.js
+++ b/run/queues.js
@@ -62,6 +62,26 @@ priorities['low'].forEach(jobName => {
     });
 });
 
+// workspaceReset paginates through a workspace's blocks/contracts (millions of
+// rows for large free/demo explorers) to enqueue batchBlockDelete jobs. The
+// shared low-tier 30s timeout stalled it before it enumerated anything, so
+// large workspaces never got pruned. Re-register it without a per-job timeout;
+// the bounded, indexed keyset queries are the only work it does (the actual
+// deletes happen in batchBlockDelete).
+queues['workspaceReset'] = new Queue('workspaceReset', {
+    defaultJobOptions: {
+        attempts: 10,
+        stackTraceLimit: 3,
+        removeOnComplete: 10,
+        removeOnFail: 10,
+        backoff: {
+            type: 'exponential',
+            delay: 1000
+        }
+    },
+    connection
+});
+
 queues['processHistoricalBlocks'] = new Queue('processHistoricalBlocks', {
     defaultJobOptions: {
         attempts: 5,

--- a/run/tests/jobs/workspaceReset.test.js
+++ b/run/tests/jobs/workspaceReset.test.js
@@ -1,6 +1,7 @@
 jest.mock('sequelize', () => ({
     Op: {
-        between: 'between'
+        between: 'between',
+        gt: 'gt'
     }
 }));
 require('../mocks/lib/firebase');
@@ -15,6 +16,22 @@ const workspaceReset = require('../../jobs/workspaceReset');
 beforeEach(() => jest.clearAllMocks());
 
 describe('workspaceReset', () => {
+    it('should throw if a parameter is missing', (done) => {
+        workspaceReset({ data: { workspaceId: 1, from: new Date(0) }})
+            .catch(error => {
+                expect(error.message).toEqual('Missing parameter');
+                done();
+            });
+    });
+
+    it('should return an error string on an invalid date range', (done) => {
+        workspaceReset({ data: { workspaceId: 1, from: new Date(1000), to: new Date(0) }})
+            .then(res => {
+                expect(res).toEqual('Invalid date range');
+                done();
+            });
+    });
+
     it('return an error if cannot find workspace', (done) => {
         jest.spyOn(Workspace, 'findByPk').mockResolvedValueOnce(null);
         workspaceReset({ data: { workspaceId: 1, from: new Date(0), to: new Date(1000) }})
@@ -24,9 +41,23 @@ describe('workspaceReset', () => {
             });
     });
 
-    it('Should enqueue block/contract deletion and delete integrity checks & accounts', (done) => {
-        const getBlocks = jest.fn().mockResolvedValueOnce([{ id: 0 }, { id: 1 }]);
-        const getContracts = jest.fn().mockResolvedValueOnce([{ id: 0 }, { id: 1 }]);
+    it('Should only enqueue deletion for records within the retention window', (done) => {
+        // from=0, to=1000. Block id 2 (createdAt 5000) is outside the window
+        // and must not be enqueued for deletion. Contract id 1 (createdAt 2000)
+        // is likewise excluded.
+        const getBlocks = jest.fn()
+            .mockResolvedValueOnce([
+                { id: 0, createdAt: new Date(100) },
+                { id: 1, createdAt: new Date(500) },
+                { id: 2, createdAt: new Date(5000) }
+            ])
+            .mockResolvedValueOnce([]);
+        const getContracts = jest.fn()
+            .mockResolvedValueOnce([
+                { id: 0, createdAt: new Date(200) },
+                { id: 1, createdAt: new Date(2000) }
+            ])
+            .mockResolvedValueOnce([]);
         const safeDestroyIntegrityCheck = jest.fn();
         const safeDestroyAccounts = jest.fn();
         const safeDestroyOrbitData = jest.fn();
@@ -40,11 +71,46 @@ describe('workspaceReset', () => {
                     { name: 'batchBlockDelete-1-1-2-0-1000', data: { workspaceId: 1, ids: [1] }}
                 ]);
                 expect(bulkEnqueue).toHaveBeenCalledWith('batchContractDelete', [
-                    { name: 'batchContractDelete-1-0-1', data: { workspaceId: 1, ids: [0] }},
-                    { name: 'batchContractDelete-1-1-2', data: { workspaceId: 1, ids: [1] }}
+                    { name: 'batchContractDelete-1-0-1', data: { workspaceId: 1, ids: [0] }}
                 ]);
                 expect(safeDestroyAccounts).toHaveBeenCalled();
                 expect(safeDestroyIntegrityCheck).toHaveBeenCalled();
+                done();
+            });
+    });
+
+    it('Should paginate blocks by id across multiple pages', (done) => {
+        // Page size is mocked to 2 (see mocks/lib/env). A full page (length ===
+        // pageSize) triggers another fetch; a short page stops the walk.
+        const getBlocks = jest.fn()
+            .mockResolvedValueOnce([
+                { id: 0, createdAt: new Date(100) },
+                { id: 1, createdAt: new Date(200) }
+            ])
+            .mockResolvedValueOnce([
+                { id: 2, createdAt: new Date(300) }
+            ]);
+        const getContracts = jest.fn().mockResolvedValueOnce([]);
+        const safeDestroyIntegrityCheck = jest.fn();
+        const safeDestroyAccounts = jest.fn();
+        const safeDestroyOrbitData = jest.fn();
+
+        jest.spyOn(Workspace, 'findByPk').mockResolvedValueOnce({ id: 1, getBlocks, getContracts, safeDestroyIntegrityCheck, safeDestroyAccounts, safeDestroyOrbitData });
+
+        workspaceReset({ data: { workspaceId: 1, from: new Date(0), to: new Date(1000) }})
+            .then(() => {
+                // Two full-length probes + the short page.
+                expect(getBlocks).toHaveBeenCalledTimes(2);
+                // Second call keysets past the last id of the first page (1).
+                expect(getBlocks.mock.calls[1][0].where).toEqual({ id: { gt: 1 }});
+                expect(bulkEnqueue).toHaveBeenCalledWith('batchBlockDelete', [
+                    { name: 'batchBlockDelete-1-0-1-0-1000', data: { workspaceId: 1, ids: [0] }},
+                    { name: 'batchBlockDelete-1-1-2-0-1000', data: { workspaceId: 1, ids: [1] }}
+                ]);
+                // Offset continues across pages so page-2 job names stay unique.
+                expect(bulkEnqueue).toHaveBeenCalledWith('batchBlockDelete', [
+                    { name: 'batchBlockDelete-1-2-3-0-1000', data: { workspaceId: 1, ids: [2] }}
+                ]);
                 done();
             });
     });

--- a/run/tests/jobs/workspaceReset.test.js
+++ b/run/tests/jobs/workspaceReset.test.js
@@ -99,7 +99,8 @@ describe('workspaceReset', () => {
 
         workspaceReset({ data: { workspaceId: 1, from: new Date(0), to: new Date(1000) }})
             .then(() => {
-                // Two full-length probes + the short page.
+                // One full page (length === pageSize triggers another fetch) +
+                // one short page (stops the walk) = 2 calls.
                 expect(getBlocks).toHaveBeenCalledTimes(2);
                 // Second call keysets past the last id of the first page (1).
                 expect(getBlocks.mock.calls[1][0].where).toEqual({ id: { gt: 1 }});

--- a/run/tests/mocks/lib/env.js
+++ b/run/tests/mocks/lib/env.js
@@ -15,6 +15,7 @@ jest.mock('../../../lib/env', () => ({
     getPostHogApiHost: jest.fn(() => 'x'),
     getMaxBlockForSyncReset: jest.fn(() => 1),
     getMaxContractForReset: jest.fn(() => 1),
+    getWorkspaceResetPageSize: jest.fn(() => 2),
     getEncryptionKey: jest.fn(() => '382A5C31A96D38E3DF430E5101E8D07D'),
     getEncryptionJwtSecret: jest.fn(() => '26F95488BA7D7E545B1B8669990739BB21A0A6D3EFB4910C0460B068BDDD3E1C'),
     getQuicknodeCredentials: jest.fn(() => 'qn'),


### PR DESCRIPTION
The free/demo 7-day data cap never pruned large explorers. workspaceReset enumerated blocks via getBlocks({ where: { createdAt between } }) — a scan on blocks.createdAt, which has no index. For a workspace with millions of blocks this took ~2min but the low-tier queue enforces a 30s job timeout, so the job stalled before listing any blocks and never enqueued batchBlockDelete. Small workspaces worked; large old ones (e.g. the biggest free explorer, ~26 GB of blocks) were never reclaimed.

- Rewrite workspaceReset to walk blocks/contracts with keyset pagination by primary key id (indexed), filtering the createdAt window in memory per page, and enqueue batch-delete jobs as it goes so memory stays bounded.
- Re-register the workspaceReset queue without the shared 30s timeout; it now only runs bounded indexed queries (the heavy deletes stay in batchBlockDelete).
- Add optional WORKSPACE_RESET_PAGE_SIZE knob (default 10000).
- Preserve all guards and side effects; no change to plan/slug selection.
- Tests cover window exclusion, multi-page keyset pagination, and guards.