### PR TITLE
fix(config): make DB and Redis IP family configurable for IPv6 networks

### DIFF
--- a/pm2-server/lib/queue.js
+++ b/pm2-server/lib/queue.js
@@ -9,6 +9,19 @@ const { Queue } = require('bullmq');
 
 const redisUrl = process.env.ETHERNAL_REDIS_URL
 
+/**
+ * IP family used to resolve the Redis host.
+ *
+ * ioredis defaults to IPv4. Set ETHERNAL_REDIS_FAMILY=6 when Redis is reached
+ * over an IPv6-only network (e.g. Fly.io private networking, where *.internal
+ * names publish AAAA records only), otherwise the connection never resolves.
+ *
+ * Parsed to a Number on purpose: net.connect() ignores a string `family`.
+ *
+ * @returns {number} 4 or 6
+ */
+const getRedisFamily = () => parseInt(process.env.ETHERNAL_REDIS_FAMILY, 10) || 4;
+
 const defaultJobOptions = {
     attempts: 50,
     removeOnComplete: {
@@ -22,7 +35,7 @@ const defaultJobOptions = {
     }
 };
 
-const connection = new Redis(redisUrl);
+const connection = new Redis(redisUrl, { family: getRedisFamily() });
 
 const enqueue = (queueName, jobName, data, priority = 1) => {
     const queue = new Queue(queueName, { connection, defaultJobOptions });

--- a/run/config/database.js
+++ b/run/config/database.js
@@ -1,4 +1,20 @@
 const logger = require('../lib/logger');
+
+/**
+ * IP family used to resolve DB_HOST.
+ *
+ * Defaults to 4 to preserve existing behaviour. Set DB_FAMILY=6 when the
+ * database is reached over an IPv6-only network (e.g. Fly.io private
+ * networking, where *.internal names publish AAAA records only and an IPv4
+ * lookup fails outright).
+ *
+ * Parsed to a Number on purpose: net.connect() ignores a string `family`,
+ * which would silently fall back to IPv4.
+ *
+ * @returns {number} 4 or 6
+ */
+const getDbFamily = () => parseInt(process.env.DB_FAMILY, 10) || 4;
+
 module.exports = {
     development: {
         "host": process.env.DB_HOST,
@@ -8,7 +24,7 @@ module.exports = {
         "port": process.env.DB_PORT,
         "dialect": "postgres",
         "dialectOptions": {
-            "family": 4
+            "family": getDbFamily()
         },
         "logging": function(sql, sequelizeObject) {
             logger.debug(sql, { instance: sequelizeObject.instance });
@@ -30,7 +46,7 @@ module.exports = {
         "port": process.env.DB_PORT,
         "dialect": "postgres",
         "dialectOptions": {
-            "family": 4,
+            "family": getDbFamily(),
             "keepAlive": true,
             "keepAliveInitialDelayMillis": 10000
         },

--- a/run/lib/env.js
+++ b/run/lib/env.js
@@ -42,7 +42,13 @@ module.exports = {
     getSentryDsn: () => process.env.SENTRY_DSN,
     getVersion: () => process.env.VERSION,
     getRedisUrl: () => process.env.REDIS_URL,
-    getRedisFamily: () => process.env.REDIS_FAMILY,
+    /**
+     * IP family to use when resolving the Redis host.
+     * Returns a Number because net.connect() ignores a string value, which
+     * would silently fall back to IPv4 and fail against an IPv6-only host.
+     * @returns {number|undefined} 4, 6, or undefined when unset
+     */
+    getRedisFamily: () => (process.env.REDIS_FAMILY ? parseInt(process.env.REDIS_FAMILY, 10) : undefined),
     queueMonitoringMaxProcessingTime: () => parseInt(process.env.QUEUE_MONITORING_MAX_PROCESSING_TIME) || 60,
     queueMonitoringHighProcessingTimeThreshold: () => parseInt(process.env.QUEUE_MONITORING_HIGH_PROCESSING_TIME_THRESHOLD) || 20,
     queueMonitoringHighWaitingJobCountThreshold: () => parseInt(process.env.QUEUE_MONITORING_HIGH_WAITING_JOB_COUNT_THRESHOLD) || 50,


### PR DESCRIPTION
Fly.io private networking (6PN) is IPv6-only: *.internal names publish AAAA records exclusively, so an IPv4-only lookup fails outright. Three call sites pinned or defaulted to IPv4 and could not reach a 6PN host.

- run/config/database.js pinned dialectOptions.family = 4 in both the development and production blocks, with no override. Now reads DB_FAMILY, defaulting to 4 so current behaviour is unchanged.
- pm2-server/lib/queue.js constructed ioredis with no family option; ioredis defaults to IPv4. Now reads ETHERNAL_REDIS_FAMILY, also defaulting to 4.
- run/lib/env.js getRedisFamily() returned the raw string. net.connect() ignores a string family, so REDIS_FAMILY=6 would have been silently dropped and fallen back to IPv4. Now parsed to a Number.

All three default to the existing IPv4 behaviour, so this is a no-op until the new variables are set. Groundwork for the Postgres/Redis move onto Fly, where the app reaches both over 6PN.