### PR TITLE
fix(sentry): sample traces against the span quota instead of blowing …

### DIFF
--- a/.claude/references/SENTRY.md
+++ b/.claude/references/SENTRY.md
@@ -1,10 +1,15 @@
 # Sentry Error & Performance Monitoring
 
-Self-hosted Sentry (v26.2.1) at `sentry.tryethernal.com`. Server details and credentials in `.credentials.local`.
+Hosted Sentry (`sentry.io`, org `antoine-0l`, Developer plan) with projects `ethernal-backend` and `ethernal-frontend`. Migrated off the self-hosted instance 2026-07-28. Credentials in `.credentials.local`.
+
+## Quota
+
+The Developer plan allows **5M spans and 5k errors per month**, with on-demand spend set to 0 — once a quota is hit, data is dropped rather than billed. Sampling is therefore a correctness concern, not a cost one: over-sampling means going blind for the rest of the billing period.
 
 ## Integration Points
 
-- **Backend**: `instrument.js` initializes `@sentry/node` using `SENTRY_DSN` env var (Fly.io secret). Uses a custom `tracesSampler` that samples 100% of API requests (`GET/POST/PUT/DELETE /api*`) and 10% of everything else — ensures slow user-facing queries always appear in performance monitoring. Workers wrap jobs in `Sentry.startSpan()` with `op: 'queue.process'` for Queue Monitoring.
+- **Backend**: `instrument.js` initializes `@sentry/node` using `SENTRY_DSN` env var (Fly.io secret). A custom `tracesSampler` applies, in order: infrastructure noise (`/api/caddy/validDomain`, `/bull`) is dropped entirely; an upstream sampling decision is honoured to keep distributed traces whole; background queue jobs (identified by the `messaging.destination.name` attribute) sample at 0.1%; user-facing `/api*` routes sample at 5%; everything else at 1%. All three rates are overridable via `SENTRY_API_SAMPLE_RATE`, `SENTRY_QUEUE_SAMPLE_RATE` and `SENTRY_DEFAULT_SAMPLE_RATE` so the budget can be corrected without a release. Workers wrap jobs in `Sentry.startSpan()` with `op: 'queue.process'` for Queue Monitoring.
+- **Profiling is deliberately off.** The plan's profile duration quota is 0, so every profile sent was rate-limited and discarded. `@sentry/profiling-node` remains in `package.json` but is no longer initialized.
 - **Frontend**: `@sentry/vue` initialized in `main.js` using `VITE_SENTRY_*` env vars. These are passed as build args to `Dockerfile.caddyfile` from GitHub secrets in CI.
 - **Queue monitoring**: `enqueue()` in `run/lib/queue.js` wraps with `op: 'queue.publish'` spans. All 4 workers use `op: 'queue.process'` spans with `messaging.destination.name` and `messaging.message.id` attributes.
 - **Proxy**: Caddy on Fly.io proxies `/api/2/*` to `sentry.tryethernal.com` so frontend events route through the explorer's own domain.

--- a/run/instrument.js
+++ b/run/instrument.js
@@ -1,16 +1,82 @@
-const { getNodeEnv, getSentryDsn, getVersion } = require('./lib/env');
+/**
+ * @fileoverview Sentry instrumentation. Must be required before anything else
+ * so the SDK can patch modules as they load.
+ *
+ * Sampling is deliberately aggressive. On 2026-07-29 the org was ingesting
+ * ~3M spans/day against a 5M/month quota — the whole month's allowance in
+ * under two days, after which everything is dropped (on-demand spend is 0).
+ * The three drivers were: every /api route sampled at 100%, Caddy's on-demand
+ * TLS check and the bull-monitor UI counting as "API" traffic, and background
+ * queue jobs sampled at 10% while running millions of jobs a day.
+ *
+ * @module instrument
+ */
+
+const {
+    getNodeEnv,
+    getSentryDsn,
+    getVersion,
+    getSentryApiSampleRate,
+    getSentryQueueSampleRate,
+    getSentryDefaultSampleRate
+} = require('./lib/env');
 const logger = require('./lib/logger');
+
+/**
+ * Transactions with no diagnostic value that are hit constantly.
+ *
+ * - `/api/caddy/validDomain` is Caddy's on-demand TLS lookup, fired on every
+ *   handshake for a custom explorer domain (~490k spans/day).
+ * - `/bull` is the bull-monitor dashboard polling itself (~50k spans/day).
+ *
+ * Matched by prefix so sub-paths are covered too.
+ */
+const UNTRACED_PREFIXES = [
+    'GET /api/caddy/validDomain',
+    'GET /bull'
+];
+
+const API_TRANSACTION = /^(GET|POST|PUT|PATCH|DELETE) \/api/;
+
+/**
+ * Decides what fraction of traces to keep.
+ *
+ * Order matters: noise is dropped before the parent decision is honoured, so a
+ * sampled browser trace cannot drag an infrastructure endpoint back in.
+ *
+ * @param {Object} ctx - Sentry sampling context.
+ * @param {string} ctx.name - Transaction name.
+ * @param {Object} [ctx.attributes] - Attributes the span was created with.
+ * @param {boolean} [ctx.parentSampled] - Upstream sampling decision, if any.
+ * @returns {number|boolean} Sample rate, or the inherited decision.
+ */
+const tracesSampler = ({ name, attributes, parentSampled }) => {
+    if (UNTRACED_PREFIXES.some(prefix => name.startsWith(prefix)))
+        return 0;
+
+    // Keep distributed traces whole rather than truncating them mid-flight.
+    if (parentSampled !== undefined)
+        return parentSampled;
+
+    // Background queue work. Every job span carries this attribute (see
+    // lib/queue.js and workers/*.js), so job names never need hardcoding here.
+    if (attributes && attributes['messaging.destination.name'])
+        return getSentryQueueSampleRate();
+
+    if (API_TRANSACTION.test(name))
+        return getSentryApiSampleRate();
+
+    return getSentryDefaultSampleRate();
+};
 
 if (getSentryDsn()) {
     const Sentry = require('@sentry/node');
-    const { nodeProfilingIntegration } = require('@sentry/profiling-node');
 
     Sentry.init({
         dsn: getSentryDsn(),
         environment: getNodeEnv() || 'development',
         release: `ethernal@${getVersion()}`,
         integrations: [
-            nodeProfilingIntegration(),
             Sentry.postgresIntegration
         ],
         beforeSend(event, hint) {
@@ -18,16 +84,13 @@ if (getSentryDsn()) {
             if (err && err.sentryIgnore) return null;
             return event;
         },
-        tracesSampler: ({ name, parentSampled }) => {
-            if (name.startsWith('GET /api') || name.startsWith('POST /api') ||
-                name.startsWith('PUT /api') || name.startsWith('DELETE /api'))
-                return 1.0;
-            if (parentSampled !== undefined)
-                return parentSampled;
-            return 0.1;
-        },
-        profilesSampleRate: 0.1
+        tracesSampler
+        // No profiling: the plan's profile duration quota is 0, so every
+        // profile ever sent was rate-limited and discarded. It cost CPU and
+        // bandwidth for data that never arrived.
     });
-    
+
     logger.info('Started Sentry instrumentation');
 }
+
+module.exports = { tracesSampler };

--- a/run/lib/env.js
+++ b/run/lib/env.js
@@ -40,6 +40,21 @@ module.exports = {
     getDiscordFeedbackChannelWebhook: () => process.env.DISCORD_FEEDBACK_CHANNEL_WEBHOOK,
     getMaxV2DexPairsForTrial: () => process.env.MAX_V2_DEX_PAIRS_FOR_TRIAL || 20,
     getSentryDsn: () => process.env.SENTRY_DSN,
+    /**
+     * Trace sample rates, tunable without a release so the span budget can be
+     * corrected from `fly secrets set` when traffic shifts.
+     *
+     * Defaults are sized against a 5M spans/month quota at roughly 3.8M queue
+     * jobs and 40k user-facing API requests a day, which lands near 1.9M
+     * spans/month. Raise the API rate first — it is the one worth paying for.
+     *
+     * @returns {number} Fraction of traces to keep, 0 to 1.
+     */
+    getSentryApiSampleRate: () => parseFloat(process.env.SENTRY_API_SAMPLE_RATE || '0.05'),
+    /** @returns {number} Sample rate for background queue jobs, 0 to 1. */
+    getSentryQueueSampleRate: () => parseFloat(process.env.SENTRY_QUEUE_SAMPLE_RATE || '0.001'),
+    /** @returns {number} Sample rate for everything else, 0 to 1. */
+    getSentryDefaultSampleRate: () => parseFloat(process.env.SENTRY_DEFAULT_SAMPLE_RATE || '0.01'),
     getVersion: () => process.env.VERSION,
     getRedisUrl: () => process.env.REDIS_URL,
     /**

--- a/run/tests/instrument.test.js
+++ b/run/tests/instrument.test.js
@@ -1,0 +1,69 @@
+/**
+ * @fileoverview Tests for the Sentry trace sampler.
+ *
+ * These rates are a quota guard, not a preference: the org ingests against a
+ * fixed monthly span allowance with no on-demand spend, so a regression here
+ * means production goes blind partway through the billing period. The exact
+ * numbers are asserted deliberately.
+ */
+
+jest.mock('../lib/logger', () => ({ info: jest.fn() }));
+
+const { tracesSampler } = require('../instrument');
+
+const sample = (name, { attributes = {}, parentSampled } = {}) =>
+    tracesSampler({ name, attributes, parentSampled });
+
+describe('tracesSampler', () => {
+    describe('infrastructure noise', () => {
+        it('drops the Caddy on-demand TLS check', () => {
+            expect(sample('GET /api/caddy/validDomain')).toBe(0);
+        });
+
+        it('drops the bull-monitor dashboard and its sub-paths', () => {
+            expect(sample('GET /bull')).toBe(0);
+            expect(sample('GET /bull/queues/blockSync')).toBe(0);
+        });
+
+        it('drops noise even when an upstream trace was sampled', () => {
+            // Ordering matters: a sampled browser trace must not be able to
+            // drag a high-frequency infrastructure endpoint back in.
+            expect(sample('GET /api/caddy/validDomain', { parentSampled: true })).toBe(0);
+        });
+    });
+
+    describe('distributed traces', () => {
+        it('honours an upstream sampling decision', () => {
+            expect(sample('GET /api/blocks', { parentSampled: true })).toBe(true);
+            expect(sample('GET /api/blocks', { parentSampled: false })).toBe(false);
+        });
+    });
+
+    describe('background queue jobs', () => {
+        it('samples anything carrying a messaging destination at 0.1%', () => {
+            expect(sample('blockSync', {
+                attributes: { 'messaging.destination.name': 'blockSync' }
+            })).toBe(0.001);
+        });
+
+        it('identifies jobs by attribute, not by name', () => {
+            // Job names must never need hardcoding in the sampler.
+            expect(sample('someFutureJob', {
+                attributes: { 'messaging.destination.name': 'someFutureJob' }
+            })).toBe(0.001);
+        });
+    });
+
+    describe('user-facing API', () => {
+        it.each(['GET', 'POST', 'PUT', 'PATCH', 'DELETE'])('samples %s /api at 5%%', method => {
+            expect(sample(`${method} /api/blocks`)).toBe(0.05);
+        });
+    });
+
+    describe('everything else', () => {
+        it('falls back to 1%', () => {
+            expect(sample('GET /')).toBe(0.01);
+            expect(sample('some random transaction')).toBe(0.01);
+        });
+    });
+});

--- a/src/main.js
+++ b/src/main.js
@@ -44,10 +44,15 @@ const createVueApp = (rootComponent, options) => {
             dsn: `${window.location.protocol}//${import.meta.env.VITE_SENTRY_DSN_SECRET}@${window.location.host}/${import.meta.env.VITE_SENTRY_DSN_PROJECT_ID}`,
             integrations: [
                 Sentry.browserTracingIntegration({ router }),
-                Sentry.browserProfilingIntegration(),
             ],
-            tracesSampleRate: 0.1,
-            tracePropagationTargets: [/.*/],
+            // Shares a 5M spans/month org quota with the backend, which is the
+            // heavy consumer. 2% of page loads is enough to see real user
+            // latency without competing for the same budget.
+            tracesSampleRate: 0.02,
+            // Only attach trace headers to our own API. The previous `/.*/`
+            // sent sentry-trace and baggage to every third party the app talks
+            // to, and forced the backend to sample whatever it touched.
+            tracePropagationTargets: [/\/api\//],
             enabled: !!import.meta.env.VITE_SENTRY_ENABLED
         });
     }


### PR DESCRIPTION
…through it

The org was ingesting ~3M spans/day against a 5M/month allowance, with on-demand spend set to 0 — so the entire month's budget was gone in under two days and everything after that was silently dropped. Errors were at 92% of quota with two weeks left in the period.

Three things drove it:

- Every /api route sampled at 100%. That included `/api/caddy/validDomain`, which Caddy calls on every on-demand TLS handshake (~490k spans/day), and the bull-monitor dashboard polling itself (~50k spans/day). Neither has any diagnostic value.
- Background queue jobs sampled at 10% while the workers run millions of jobs a day. queue.process and queue.publish together were ~1.7M spans/day.
- Profiling ran at 10% even though the plan's profile duration quota is 0, so every profile was rate-limited and discarded. It cost CPU and bandwidth to send data that never arrived.

The sampler now drops infrastructure noise outright, honours an upstream sampling decision so distributed traces stay whole, samples queue jobs at 0.1% and user-facing /api routes at 5%. Queue work is identified by the `messaging.destination.name` attribute rather than a hardcoded job list, so new jobs are covered automatically. Projected ~1.9M spans/month, which leaves real headroom.

All three rates are overridable via env so the budget can be corrected with `fly secrets set` rather than waiting for a release.

On the frontend, profiling was configured without a `profilesSampleRate` and so never ran at all — removed. `tracePropagationTargets` was `/.*/`, which attached sentry-trace and baggage headers to every third party the app talks to and let the browser force backend sampling; it is now scoped to our API.