### PR TITLE
fix(ci): run migrations over a Fly tunnel instead of the retired database

### DIFF
--- a/.github/workflows/sentry-auto-fix.yml
+++ b/.github/workflows/sentry-auto-fix.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Install frontend deps
         run: yarn install
 
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # v1.6
 
       - name: Setup SSH
         uses: webfactory/ssh-agent@v0.9.0
@@ -595,7 +595,7 @@ jobs:
         if: steps.check_sentry.outputs.is_sentry == 'true'
         run: yarn install
 
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # v1.6
         if: steps.check_sentry.outputs.is_sentry == 'true'
 
       - name: Setup SSH

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -125,7 +125,10 @@ jobs:
       - name: Install deps
         run: cd run && npm install
 
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      # Pinned to a SHA, not @master: FLY_API_TOKEN is set at workflow level, so
+      # every job here hands the production Fly credential to whatever that
+      # branch happens to point at today. This SHA is what v1/1.6 resolve to.
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # v1.6
 
       # The database has no public address. Since the move to Fly it is reachable
       # only on Fly's private IPv6 network, so a runner cannot dial it by any
@@ -172,7 +175,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      # Pinned to a SHA, not @master: FLY_API_TOKEN is set at workflow level, so
+      # every job here hands the production Fly credential to whatever that
+      # branch happens to point at today. This SHA is what v1/1.6 resolve to.
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # v1.6
 
       - name: Deploy Caddy
         run: |
@@ -201,7 +207,10 @@ jobs:
         env:
           GCLOUD_CREDENTIALS: ${{ secrets.GCLOUD_CREDENTIALS }}
 
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      # Pinned to a SHA, not @master: FLY_API_TOKEN is set at workflow level, so
+      # every job here hands the production Fly credential to whatever that
+      # branch happens to point at today. This SHA is what v1/1.6 resolve to.
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # v1.6
 
       - name: Setup Docker Buildx
         run: |
@@ -226,7 +235,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      # Pinned to a SHA, not @master: FLY_API_TOKEN is set at workflow level, so
+      # every job here hands the production Fly credential to whatever that
+      # branch happens to point at today. This SHA is what v1/1.6 resolve to.
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # v1.6
 
       - name: Setup Docker Buildx
         run: |
@@ -251,7 +263,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      # Pinned to a SHA, not @master: FLY_API_TOKEN is set at workflow level, so
+      # every job here hands the production Fly credential to whatever that
+      # branch happens to point at today. This SHA is what v1/1.6 resolve to.
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # v1.6
 
       - name: Update version
         run: |

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -125,11 +125,42 @@ jobs:
       - name: Install deps
         run: cd run && npm install
 
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      # The database has no public address. Since the move to Fly it is reachable
+      # only on Fly's private IPv6 network, so a runner cannot dial it by any
+      # hostname — it has to come in over WireGuard. The tunnel and the migration
+      # share one step so the proxy's lifetime is unambiguous.
+      #
+      # Connects to the pgbouncer flycast address rather than a database machine
+      # directly: pgbouncer already tracks whichever machine is primary, so this
+      # keeps working across a failover or a rebuilt machine, neither of which
+      # keeps its address.
       - name: Run migrations
-        run: cd run && npx sequelize db:migrate
+        run: |
+          nohup flyctl proxy 15432:5432 ethernal-pgbouncer.flycast \
+            -a ethernal-pgbouncer > /tmp/flyproxy.log 2>&1 &
+
+          for i in $(seq 1 30); do
+            (echo > /dev/tcp/127.0.0.1/15432) >/dev/null 2>&1 && break
+            if [ "$i" = "30" ]; then
+              echo "::error::Tunnel to ethernal-pgbouncer never came up"
+              cat /tmp/flyproxy.log
+              exit 1
+            fi
+            sleep 1
+          done
+
+          cd run && npx sequelize db:migrate --env migration
         env:
-          DB_HOST: ${{ secrets.DB_HOST }}
-          DB_PORT: ${{ secrets.DB_PORT }}
+          # Not secrets: the tunnel endpoint is local to the runner. The
+          # `ethernal_migrations` database is the same database as `ethernal`,
+          # pooled per session instead of per transaction — migrations hold
+          # session state, and CONCURRENT index builds cannot run in a
+          # transaction at all.
+          DB_HOST: 127.0.0.1
+          DB_PORT: 15432
+          DB_NAME: ethernal_migrations
           DB_USER: ${{ secrets.DB_USER }}
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
 

--- a/run/config/database.js
+++ b/run/config/database.js
@@ -38,6 +38,35 @@ module.exports = {
             evict: 5000
         }
     },
+    /**
+     * Schema migrations, run from CI through a Fly WireGuard tunnel.
+     *
+     * Separate from `production` on purpose. That config sets
+     * synchronous_commit=off, which is a sensible latency trade for application
+     * writes and a bad one for DDL — a crash in the seconds after a migration
+     * commits could lose the schema change while leaving it recorded as applied.
+     *
+     * Points at the `ethernal_migrations` entry on PgBouncer, which is the same
+     * database as `ethernal` but pooled per session rather than per transaction.
+     * Migrations hold session state, and indexes built CONCURRENTLY cannot run
+     * inside a transaction at all.
+     */
+    migration: {
+        "username": process.env.DB_USER,
+        "password": process.env.DB_PASSWORD,
+        "database": process.env.DB_NAME,
+        "host": process.env.DB_HOST,
+        "port": process.env.DB_PORT,
+        "dialect": "postgres",
+        "dialectOptions": {
+            "family": getDbFamily()
+        },
+        "logging": console.log,
+        "pool": {
+            max: 1,
+            min: 0
+        }
+    },
     production: {
         "username": process.env.DB_USER,
         "password": process.env.DB_PASSWORD,


### PR DESCRIPTION
Fixes the failed `run_migrations` job on **v5.17.254**, which blocked every deploy behind it — so the release created a GitHub release and shipped nothing. Production was never affected; it is still serving 5.17.252.

## What was wrong

The pipeline was still dialling the **Hetzner** database. `DB_HOST` and friends were last set on **9 March**, four months before the cutover on 28 July.

The error was misleading:

```
ERROR: server login has been failing, try again later (server_login_retry)
```

Those ports were deliberately left open for the bake week, so the old address still accepts connections — but the cluster behind it is hibernated. The pooler answered, failed to log in to a database that no longer exists, and reported that *its own* logins keep failing. It reads as an auth problem. It was an empty building.

## Why repointing the secret could not have fixed it

The database on Fly has **no public address**. `ethernal-pgbouncer` has only a private `fdaa:` address, so there is no hostname a GitHub runner could dial. This needed a different route, not a corrected value.

The migration step now opens a WireGuard tunnel for its own duration and connects over localhost. The tunnel and the migration share a **single step**, so the proxy's lifetime isn't left to chance between steps.

It tunnels to the **pgbouncer flycast address**, not a database machine, because pgbouncer already tracks whichever machine is primary. Hardcoding a machine address would break on the next failover or rebuilt machine — neither keeps its address. Worth noting the roles are currently inverted, so the machine *named* `pg-primary` is the standby; pointing CI at a name would have been a slow-burning trap.

## Two more faults, either of which would have bitten next

**No environment was set**, so sequelize silently used the `development` config — which forces IPv4. Fly's private network is IPv6-only, so it would have failed even from inside the network. There is now an explicit `migration` environment.

**That environment is deliberately not `production`.** Production sets `synchronous_commit=off` — a sensible latency trade for application writes, a bad one for DDL. A crash in the seconds after a migration commits could lose the schema change while leaving it recorded as applied.

## Pooling

Migrations now use a **session-pooled** entry (`ethernal_migrations`) rather than the transaction-pooled one the application uses. Same database, different pooling. Transaction pooling cannot carry session state, and the project's own convention of building large indexes `CONCURRENTLY` cannot run inside a transaction at all.

That entry was added to the pooler config in `ethernal-fly-infra` and is already deployed — rolling, one machine at a time, both healthy throughout, app serving 200 the whole way.

## Verified

Ran the exact command path from a tunnel against the live primary:

- reaches the true primary (`pg_is_in_recovery() = false`)
- 207 migrations applied, **0 pending** — this release had no schema changes at all, and still blocked the deploy

`DB_USER` and `DB_PASSWORD` have been reset to values verified against that primary.

## Follow-ups

- **`DB_HOST` / `DB_PORT` are now referenced by nothing** and still point at the retired host. They should be deleted rather than left as a trap for whoever wires up the next job.
- **`bin/render.sh pgbouncer` in the infra repo is broken and dangerous.** It reads a template path that no longer exists, writes to a config path the container no longer uses, and resolves the upstream to `pg-primary` — which is now the **standby**. Running it as documented would point production at a read-only replica. Raised separately.