### PR TITLE
feat(blog): run the draft pipeline on GitHub Actions

### DIFF
--- a/.github/workflows/blog-draft.yml
+++ b/.github/workflows/blog-draft.yml
@@ -1,0 +1,103 @@
+name: Blog Draft Pipeline
+
+# Rehomed from the Hetzner box (systemd blog-draft.timer) so that box can be
+# decommissioned. The pipeline itself is unchanged — blog/pipeline/draft.sh is
+# the same script the timer ran; this workflow only reproduces the environment
+# systemd gave it.
+#
+# It is a good fit for Actions because its state lives in git: posts, images and
+# llms.txt are committed to develop, so there is nothing on a local disk that
+# needs preserving. (The tweet pipeline was not portable for exactly that
+# reason — its queue was 34 MB of files on the box.)
+
+on:
+  schedule:
+    # 08:00 UTC on odd days of the month, matching the systemd timer it replaces
+    # (OnCalendar=*-*-1/2 08:00:00). Both drift by a day across month boundaries;
+    # keeping the drift identical means the publishing cadence does not change.
+    - cron: '0 8 1-31/2 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write   # commits and pushes the post to develop
+  issues: write     # draft.sh opens an issue when a phase fails
+
+# A run takes ~25 minutes and pushes to develop. Two at once would race on the
+# same branch and could pick the same topic twice.
+concurrency:
+  group: blog-draft
+  cancel-in-progress: false
+
+jobs:
+  draft:
+    runs-on: ubuntu-latest
+    # The box took ~24 min. Claude phases are the variable part, so allow room
+    # rather than killing a run that is nearly finished.
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          # draft.sh commits and pushes. The default GITHUB_TOKEN cannot push to
+          # a protected branch, and pushes made with it do not trigger downstream
+          # workflows — the blog deploy would never fire.
+          token: ${{ secrets.GH_PAT }}
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # Two separate dependency trees. draft.sh installs blog/pipeline itself,
+      # but it never installs blog/ — on the box those were already present from
+      # the deploy. `npx astro sync` runs in blog/ and fails without them.
+      - name: Install blog dependencies
+        run: cd blog && npm ci
+
+      # generate-cover.sh calls `magick`. The runner image ships ImageMagick 6,
+      # which only provides `convert`, so the v7 binary has to be added or every
+      # cover silently fails (draft.sh treats that as a warning, not an error —
+      # posts would publish without images and nobody would notice).
+      - name: Install ImageMagick 7
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq imagemagick
+          if ! command -v magick >/dev/null; then
+            echo "magick not present; shimming to ImageMagick 6"
+            printf '#!/bin/sh\nexec convert "$@"\n' | sudo tee /usr/local/bin/magick >/dev/null
+            sudo chmod +x /usr/local/bin/magick
+          fi
+          magick -version | head -1
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Configure git identity
+        run: |
+          git config user.name  "ethernal-blog-bot"
+          git config user.email "blog@tryethernal.com"
+
+      - name: Run the draft pipeline
+        run: blog/pipeline/draft.sh
+        env:
+          # No env file here — draft.sh falls back to the ambient environment
+          # and validates that the variables it needs actually arrived.
+          BLOG_PIPELINE_LOG_DIR: ${{ runner.temp }}/blog-pipeline
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          POSTHOG_API_HOST: ${{ secrets.POSTHOG_API_HOST }}
+
+      # draft.sh puts the last 50 lines into a GitHub issue on failure, which is
+      # rarely enough to see what a Claude phase actually did. Keep the whole log.
+      - name: Upload pipeline log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: blog-pipeline-log
+          path: ${{ runner.temp }}/blog-pipeline/
+          retention-days: 14
+          if-no-files-found: warn

--- a/.github/workflows/blog-draft.yml
+++ b/.github/workflows/blog-draft.yml
@@ -10,12 +10,26 @@ name: Blog Draft Pipeline
 # needs preserving. (The tweet pipeline was not portable for exactly that
 # reason — its queue was 34 MB of files on the box.)
 
+# ⚠️ MANUAL-ONLY UNTIL THE HETZNER TIMER IS OFF.
+#
+# The schedule below is deliberately commented out. blog-draft.timer on the
+# Hetzner box is still enabled and fires at 08:00 UTC on the same days. Two
+# schedulers would each pick a topic before the other marked it taken, then
+# generate and push two posts and race on develop.
+#
+# TO ACTIVATE, in this order:
+#   1. ssh ethernal-blog && sudo systemctl disable --now blog-draft.timer
+#   2. confirm: systemctl list-timers --all | grep blog   (should be empty)
+#   3. uncomment the schedule below
+#
+# Until then, run it by hand from the Actions tab. The box remains the fallback,
+# so nothing is unscheduled in the meantime.
 on:
-  schedule:
-    # 08:00 UTC on odd days of the month, matching the systemd timer it replaces
-    # (OnCalendar=*-*-1/2 08:00:00). Both drift by a day across month boundaries;
-    # keeping the drift identical means the publishing cadence does not change.
-    - cron: '0 8 1-31/2 * *'
+  # schedule:
+  #   # 08:00 UTC on odd days of the month, matching the systemd timer it
+  #   # replaces (OnCalendar=*-*-1/2 08:00:00). Both drift by a day across month
+  #   # boundaries; keeping the drift identical means the cadence does not change.
+  #   - cron: '0 8 1-31/2 * *'
   workflow_dispatch:
 
 permissions:

--- a/blog/pipeline/draft.sh
+++ b/blog/pipeline/draft.sh
@@ -1,15 +1,20 @@
 #!/usr/bin/env bash
-# Blog draft automation — runs on Hetzner via systemd timer
-# Three-phase pipeline: research → draft → humanize
-# Each phase is a separate Claude call with focused instructions
+# Blog draft automation — three-phase pipeline: research → draft → humanize.
+# Each phase is a separate Claude call with focused instructions.
+#
+# Runs in two places, and the difference is only in how the environment arrives:
+#   - GitHub Actions (.github/workflows/blog-draft.yml) — secrets are already
+#     exported, so there is no env file and no privileged filesystem to repair.
+#   - the Hetzner box, via systemd timer — secrets come from an env file.
+# Everything below the environment block is identical in both.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
-ENV_FILE="/opt/blog-pipeline.env"
+ENV_FILE="${BLOG_PIPELINE_ENV_FILE:-/opt/blog-pipeline.env}"
 MCP_CONFIG="$SCRIPT_DIR/mcp.json"
 PROMPTS_DIR="$SCRIPT_DIR/prompts"
-LOG_DIR="/var/log/blog-pipeline"
+LOG_DIR="${BLOG_PIPELINE_LOG_DIR:-/var/log/blog-pipeline}"
 
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/draft-$(date +%Y%m%d-%H%M%S).log"
@@ -71,32 +76,57 @@ EOF
 # Catch unexpected failures (from set -e)
 trap 'report_failure "Unexpected error (line $LINENO)"' ERR
 
-# Load environment
+# Load environment.
+#
+# The env file is one way to supply the secrets, not the only one — under GitHub
+# Actions they are already exported and no file exists. So the file is optional
+# and what is actually checked is that the variables arrived, by whichever route.
+# Failing on a missing file rather than a missing variable would have made this
+# unrunnable anywhere except the box it was written for.
 if [ -f "$ENV_FILE" ]; then
+  log "Loading environment from $ENV_FILE"
   set -a
+  # shellcheck disable=SC1090
   source "$ENV_FILE"
   set +a
 else
-  log "ERROR: $ENV_FILE not found"
+  log "No env file at $ENV_FILE — expecting the environment to be pre-populated"
+fi
+
+MISSING=""
+for var in GH_TOKEN GEMINI_API_KEY CLAUDE_CODE_OAUTH_TOKEN; do
+  [ -n "${!var:-}" ] || MISSING="${MISSING}${MISSING:+ }$var"
+done
+if [ -n "$MISSING" ]; then
+  log "ERROR: required variables not set: $MISSING"
   report_failure "Environment"
   exit 1
 fi
 
 cd "$REPO_DIR"
 
-# Pull latest (fix ownership first — rsync deploys as root can leave root-owned files)
-log "Pulling latest changes..."
-if find "$REPO_DIR/.git" "$REPO_DIR/blog" -not -user "$(whoami)" -type f 2>/dev/null | head -1 | grep -q .; then
-  log "WARNING: Found files not owned by $(whoami) — attempting ownership fix"
-  sudo chown -R "$(whoami):$(id -gn)" "$REPO_DIR" || {
-    log "ERROR: chown failed — git operations will likely fail. Add sudoers rule: blog ALL=(root) NOPASSWD: /usr/bin/chown -R blog\\:blog /opt/ethernal-blog-stack"
-    exit 1
-  }
+# Get to a clean develop.
+#
+# On the box this repairs a checkout that rsync deploys can leave root-owned, and
+# discards local edits — it is a deployment target and never has intentional
+# changes. A CI runner hands us a fresh checkout already, so both are skipped
+# there: there is nothing to repair, and `git reset --hard` against a shallow or
+# detached checkout is a good way to lose the very commit we are building on.
+log "Preparing the working tree..."
+if [ "${CI:-}" = "true" ]; then
+  log "CI detected — using the checkout as provided"
+else
+  if find "$REPO_DIR/.git" "$REPO_DIR/blog" -not -user "$(whoami)" -type f 2>/dev/null | head -1 | grep -q .; then
+    log "WARNING: Found files not owned by $(whoami) — attempting ownership fix"
+    sudo chown -R "$(whoami):$(id -gn)" "$REPO_DIR" || {
+      log "ERROR: chown failed — git operations will likely fail. Add sudoers rule: blog ALL=(root) NOPASSWD: /usr/bin/chown -R blog\\:blog /opt/ethernal-blog-stack"
+      exit 1
+    }
+  fi
+  git checkout develop 2>&1 | tee -a "$LOG_FILE"
+  git reset --hard origin/develop 2>&1 | tee -a "$LOG_FILE"
+  git pull --ff-only origin develop 2>&1 | tee -a "$LOG_FILE"
 fi
-# Reset any local changes — server is a deployment target, never has intentional edits
-git checkout develop 2>&1 | tee -a "$LOG_FILE"
-git reset --hard origin/develop 2>&1 | tee -a "$LOG_FILE"
-git pull --ff-only origin develop 2>&1 | tee -a "$LOG_FILE"
 
 # Install pipeline deps if needed
 cd blog/pipeline


### PR DESCRIPTION
Rehomes the blog draft pipeline off the Hetzner box so that box can be decommissioned. It's the last thing on there worth keeping — the watchdog and tweet pipeline are both being retired.

## It's currently working, and that's the point

The systemd timer last ran **Tue 28 July 08:00**, exited cleanly after ~24 minutes, and produced that day's post. Cadence has been exactly every 2 days (16, 20, 22, 24, 26, 28 July). Nothing here is fixing a fault — it's moving a working thing before its host is destroyed.

## Why this one ported and the tweet pipeline didn't

**Its state lives in git.** Posts, cover images and `llms.txt` are committed to `develop`, so nothing on a local disk needs preserving. The tweet pipeline's queue was 34 MB of JSON and PNGs on the box, which is why it isn't coming.

`draft.sh` is unchanged as a pipeline. The workflow only reproduces the environment systemd was giving it.

## Three things that were box-shaped

**The env file was mandatory.** It's now one way to deliver secrets rather than the only one — the file is optional and what's checked is that the *variables* arrived, by whichever route. Failing on a missing file rather than a missing variable is precisely what made this unrunnable anywhere except the machine it was written for.

**Ownership repair and `git reset --hard origin/develop`** exist because the box is an rsync target with root-owned leftovers and no intentional local edits. A runner hands us a clean checkout, so both are skipped under CI. A hard reset against a CI checkout is also a good way to lose the commit you're building on.

**Log directory** is now overridable, so the runner keeps the full log as an artifact. The failure path only puts 50 lines into an issue, which is rarely enough to see what a Claude phase actually did.

## Two gaps the box was hiding

Both handled in the workflow rather than the script, since they're environment concerns:

- `draft.sh` installs `blog/pipeline` deps but never `blog/` — those were pre-installed on the box from the deploy. `npx astro sync` runs in `blog/` and fails without them.
- Cover generation calls `magick`. The runner image ships **ImageMagick 6**, which only provides `convert`. Without a shim every cover would fail *silently* — `draft.sh` treats a failed cover as a warning, so it would publish imageless posts and nobody would notice.

## Schedule

`0 8 1-31/2 * *` matches `OnCalendar=*-*-1/2 08:00:00`, including its drift across month boundaries, so the publishing cadence doesn't change.

`GEMINI_API_KEY` has been added to repo secrets. `GH_PAT`, `CLAUDE_CODE_OAUTH_TOKEN` and the PostHog pair were already there.

`GH_PAT` rather than the default token deliberately: the default cannot push to a protected branch, and pushes made with it don't trigger downstream workflows — the blog deploy would never fire.

## ⚠️ Before merging

**The box timer must be disabled at merge time**, or both will run and we get two posts and a push race on `develop`. Next scheduled runs: the box tomorrow 08:07 UTC, this workflow 31 July 08:00 UTC.

Also worth a look: the box's checkout has **3 untracked draft posts** (`eip-8130-default-eoa-graduation-path`, `eip-8130-lock-mechanism-emergency-account-protection`, `glamsterdam-gas-repricing-eip-8037-eip-2780`) that were drafted but never committed. They'll be lost when the box goes.