### PR TITLE
feat(blog): enable the blog draft schedule now the Hetzner timer is off

### DIFF
--- a/.github/workflows/blog-draft.yml
+++ b/.github/workflows/blog-draft.yml
@@ -10,26 +10,25 @@ name: Blog Draft Pipeline
 # needs preserving. (The tweet pipeline was not portable for exactly that
 # reason — its queue was 34 MB of files on the box.)
 
-# ⚠️ MANUAL-ONLY UNTIL THE HETZNER TIMER IS OFF.
+# blog-draft.timer on the Hetzner box was disabled 2026-07-29 and this is now the
+# only scheduler. Do not re-enable that timer without disabling this, or both will
+# pick a topic before the other marks it taken and publish twice.
 #
-# The schedule below is deliberately commented out. blog-draft.timer on the
-# Hetzner box is still enabled and fires at 08:00 UTC on the same days. Two
-# schedulers would each pick a topic before the other marked it taken, then
-# generate and push two posts and race on develop.
+# This workflow existed before and was deleted in March as a duplicate of the box.
+# The reasons given then no longer hold: Actions minutes are free on a public repo,
+# and the objection about needing "the Claude CLI with full auth" is met by
+# installing the CLI and running draft.sh unchanged — rather than reimplementing
+# the pipeline inside claude-code-action as the old one did, which is the likeliest
+# reason its scheduled runs kept failing.
 #
-# TO ACTIVATE, in this order:
-#   1. ssh ethernal-blog && sudo systemctl disable --now blog-draft.timer
-#   2. confirm: systemctl list-timers --all | grep blog   (should be empty)
-#   3. uncomment the schedule below
-#
-# Until then, run it by hand from the Actions tab. The box remains the fallback,
-# so nothing is unscheduled in the meantime.
+# Proven end to end on 2026-07-29 (run 30469887209): published
+# "PeerDAS Has Been Live for 8 Months", covers included and correctly sized.
 on:
-  # schedule:
-  #   # 08:00 UTC on odd days of the month, matching the systemd timer it
-  #   # replaces (OnCalendar=*-*-1/2 08:00:00). Both drift by a day across month
-  #   # boundaries; keeping the drift identical means the cadence does not change.
-  #   - cron: '0 8 1-31/2 * *'
+  schedule:
+    # 08:00 UTC on odd days of the month, matching the systemd timer it replaces
+    # (OnCalendar=*-*-1/2 08:00:00). Both drift by a day across month boundaries;
+    # keeping the drift identical means the publishing cadence does not change.
+    - cron: '0 8 1-31/2 * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Follow-up to #1356, which shipped the workflow deliberately manual-only while the Hetzner timer was still live.

That timer was disabled today, so **until this merges nothing is scheduled at all** — the guard that was correct an hour ago is now the gap.

## Proven before enabling

Rather than trusting an unattended cron to work first time, I ran the pipeline end to end on Actions via a temporary push trigger (run `30469887209`). It published **"PeerDAS Has Been Live for 8 Months. Here's How Ethereum Verifies It's Actually Working."** — research, draft, humanize, cover generation, Astro validation, commit and push to develop.

Both covers came out at the correct dimensions (1424x752 and 1200x630). That was the important one to verify: `draft.sh` treats a failed cover as a *warning*, so a broken ImageMagick shim would have published imageless posts indefinitely without failing anything.

## On the earlier removal

This workflow existed before and was deleted in March as a duplicate of the box. Both reasons given then are now moot:

- *"no Actions minutes burned on long sessions"* — the repo is public, so minutes are free and unlimited.
- *"Claude CLI with full auth"* — the old workflow used `claude-code-action`, i.e. a reimplementation of the pipeline. This one installs the real CLI and runs `draft.sh` unchanged, which is the likeliest reason the old scheduled runs kept failing where this one passed.

Temporary push trigger and test branch are not included here.