### PR TITLE
fix(sync): stop a single out-of-range field from losing the whole block

### DIFF
--- a/run/jobs/blockSync.js
+++ b/run/jobs/blockSync.js
@@ -15,6 +15,7 @@ const RateLimiter = require('../lib/rateLimiter');
 const constants = require('../constants/orbit');
 const { isBatchTransaction } = require('../lib/opBatches');
 const { reportRpcFailure } = require('../lib/syncHelpers');
+const { isPermanentDataError, unrecoverableError } = require('../lib/errors');
 
 // Threshold for inline receipt fetching vs job queueing
 const INLINE_RECEIPT_THRESHOLD = 25;
@@ -481,7 +482,26 @@ module.exports = async job => {
             processedBlock.transactionsCount = filteredTransactions.length;
         }
 
-        const syncedBlock = await workspace.safeCreatePartialBlock(processedBlock);
+        let syncedBlock;
+        try {
+            syncedBlock = await workspace.safeCreatePartialBlock(processedBlock);
+        } catch(error) {
+            // A block carrying data the schema cannot represent will fail
+            // identically on every one of its 50 attempts. Fail it now so it
+            // lands in the failed set where it is visible, instead of backing
+            // off into a delayed set nobody watches.
+            if (isPermanentDataError(error)) {
+                logger.error(`Block ${data.blockNumber} cannot be stored: ${error.message}`, {
+                    location: 'jobs.blockSync',
+                    error,
+                    data
+                });
+                throw unrecoverableError(`Block ${data.blockNumber} contains data that cannot be stored: ${error.message}`);
+            }
+
+            throw error;
+        }
+
         if (!syncedBlock)
             return "Couldn't store block";
 

--- a/run/lib/errors.js
+++ b/run/lib/errors.js
@@ -57,4 +57,59 @@ const managedWorkerError = (error, jobName, jobData, worker) => {
     return Sentry.captureException(error, { tags: { job: jobName, worker }});
 };
 
-module.exports = { managedError, unmanagedError, managedWorkerError };
+// PostgreSQL error codes that describe data the database can never accept, no
+// matter how many times we send it. Retrying these is pure waste: the job backs
+// off exponentially, never reaches its final attempt within any useful horizon,
+// and silently accumulates in the queue's delayed set where no alert looks.
+//
+// Deliberately excluded:
+//   23505 unique_violation    - normal under concurrent inserts, retry is correct
+//   23503 foreign_key_violation - can be transient while a parent row is committing
+//   40001 / 40P01            - serialization failures and deadlocks, retry is correct
+const PERMANENT_DATA_ERROR_CODES = [
+    '22001', // string_data_right_truncation
+    '22003', // numeric_value_out_of_range
+    '22007', // invalid_datetime_format
+    '22P02', // invalid_text_representation
+    '23502', // not_null_violation
+    '23514'  // check_violation
+];
+
+/**
+ * Determines whether a database error is caused by data the schema can never
+ * store, as opposed to a transient condition worth retrying.
+ *
+ * Sequelize nests the driver error under `parent`/`original`; we check both, and
+ * the error itself for callers that pass a raw pg error.
+ *
+ * @param {Error} error - The error to classify
+ * @returns {boolean} True if retrying the same payload cannot possibly succeed
+ */
+const isPermanentDataError = error => {
+    if (!error)
+        return false;
+
+    const code = (error.parent && error.parent.code) || (error.original && error.original.code) || error.code;
+
+    return PERMANENT_DATA_ERROR_CODES.includes(code);
+};
+
+/**
+ * Builds an error that tells BullMQ to fail a job immediately, without burning
+ * its remaining attempts.
+ *
+ * BullMQ recognises either its own `UnrecoverableError` class or any error
+ * named `UnrecoverableError` (see `Job.moveToFailed`). We use the name because
+ * `instanceof` is only reliable when every caller resolves the exact same copy
+ * of the bullmq module, which nothing guarantees.
+ *
+ * @param {string} message - Why the job can never succeed
+ * @returns {Error} An error BullMQ will move straight to the failed set
+ */
+const unrecoverableError = message => {
+    const error = new Error(message);
+    error.name = 'UnrecoverableError';
+    return error;
+};
+
+module.exports = { managedError, unmanagedError, managedWorkerError, isPermanentDataError, unrecoverableError };

--- a/run/lib/utils.js
+++ b/run/lib/utils.js
@@ -346,14 +346,19 @@ const UNSTORABLE_INT_FIELDS = ['nonce', 'requestId', 'chainId', 'type', 'transac
  * so they are absent from `raw` by construction, and nulling the column would
  * otherwise discard the chain's value entirely.
  *
+ * Pass the untouched RPC payload as `source`: sanitization turns hex strings
+ * into numbers, which silently rounds anything above 2^53, so the row's own copy
+ * of a very large value is no longer exact. The original hex string is.
+ *
  * @param {Object} row - Row about to be inserted, including its `raw` payload
+ * @param {Object} [source={}] - Untouched RPC payload, preferred as the value to keep
  * @param {string[]} [fields=UNSTORABLE_INT_FIELDS] - Fields to check
  * @returns {Object} The row, with out-of-range values added to `raw`
  * @example
- * _preserveUnstorableInts({ nonce: 1786637106312, raw: {} });
- * // returns { nonce: 1786637106312, raw: { nonce: 1786637106312 } }
+ * _preserveUnstorableInts({ nonce: 1786637106312, raw: {} }, { nonce: '0x19ffbdebc88' });
+ * // returns { nonce: 1786637106312, raw: { nonce: '0x19ffbdebc88' } }
  */
-const _preserveUnstorableInts = (row, fields = UNSTORABLE_INT_FIELDS) => {
+const _preserveUnstorableInts = (row, source = {}, fields = UNSTORABLE_INT_FIELDS) => {
     if (row == null)
         return row;
 
@@ -368,7 +373,9 @@ const _preserveUnstorableInts = (row, fields = UNSTORABLE_INT_FIELDS) => {
         if (_toInt32OrNull(value) !== null)
             return;
 
-        preserved[field] = typeof value === 'object' ? String(value) : value;
+        const original = source && source[field] !== undefined && source[field] !== null ? source[field] : value;
+
+        preserved[field] = typeof original === 'object' ? String(original) : original;
     });
 
     if (Object.keys(preserved).length === 0)

--- a/run/lib/utils.js
+++ b/run/lib/utils.js
@@ -285,6 +285,55 @@ const _isJson = function(obj) {
     }
 };
 
+// Bounds of the PostgreSQL `integer` (int4) type. Values outside this range are
+// rejected by the database with "integer out of range", which aborts the whole
+// insert statement they are part of.
+const PG_INT4_MIN = -2147483648;
+const PG_INT4_MAX = 2147483647;
+
+/**
+ * Coerces a chain-supplied value to a PostgreSQL `integer`, or null when it
+ * cannot be represented as one.
+ *
+ * Several transaction fields are typed as int4 in our schema because that is
+ * what they are on every mainstream chain, but nothing in the JSON-RPC spec
+ * bounds them. Chains do exist that put, say, a millisecond timestamp in the
+ * nonce, or a 32-byte hash in requestId. Passing such a value straight to
+ * Postgres fails the entire multi-row insert, so the whole block is lost rather
+ * than the single field we cannot represent.
+ *
+ * Storing null instead keeps the block syncable; the untruncated original value
+ * is still available in the transaction's `raw` payload.
+ *
+ * @param {string|number|bigint|Object|null|undefined} value - Value from the RPC payload
+ * @returns {number|null} The value as an integer, or null if it is absent or out of int4 range
+ * @example
+ * _toInt32OrNull('0x2a');            // returns 42
+ * _toInt32OrNull('0x19ffbdebc88');   // returns null (exceeds int4)
+ */
+const _toInt32OrNull = value => {
+    if (value === null || value === undefined || value === '')
+        return null;
+
+    let parsed;
+
+    if (typeof value === 'number')
+        parsed = value;
+    else if (typeof value === 'bigint')
+        parsed = Number(value);
+    else if (typeof value === 'string')
+        parsed = /^0x/i.test(value) ? Number.parseInt(value, 16) : Number(value);
+    else if (ethers.BigNumber.isBigNumber(value))
+        parsed = Number(ethers.BigNumber.from(value).toString());
+    else
+        return null;
+
+    if (!Number.isInteger(parsed))
+        return null;
+
+    return parsed >= PG_INT4_MIN && parsed <= PG_INT4_MAX ? parsed : null;
+};
+
 /**
  * Sanitizes an object from RPC responses.
  * - Removes null/undefined values
@@ -411,6 +460,7 @@ const sanitizePagination = (page, itemsPerPage, order, options = {}) => {
 
 module.exports = {
     sanitize: _sanitize,
+    toInt32OrNull: _toInt32OrNull,
     stringifyBns: _stringifyBns,
     isJson: _isJson,
     getEnv: getEnv,

--- a/run/lib/utils.js
+++ b/run/lib/utils.js
@@ -297,13 +297,13 @@ const PG_INT4_MAX = 2147483647;
  *
  * Several transaction fields are typed as int4 in our schema because that is
  * what they are on every mainstream chain, but nothing in the JSON-RPC spec
- * bounds them. Chains do exist that put, say, a millisecond timestamp in the
- * nonce, or a 32-byte hash in requestId. Passing such a value straight to
- * Postgres fails the entire multi-row insert, so the whole block is lost rather
- * than the single field we cannot represent.
+ * bounds them: a chain is free to report, say, a millisecond timestamp as the
+ * nonce. Passing such a value straight to Postgres fails the entire multi-row
+ * insert, so the whole block is lost rather than the single field we cannot
+ * represent.
  *
- * Storing null instead keeps the block syncable; the untruncated original value
- * is still available in the transaction's `raw` payload.
+ * Storing null instead keeps the block syncable. Use `preserveUnstorableInts`
+ * alongside this to keep the original value in the row's `raw` payload.
  *
  * @param {string|number|bigint|Object|null|undefined} value - Value from the RPC payload
  * @returns {number|null} The value as an integer, or null if it is absent or out of int4 range
@@ -332,6 +332,49 @@ const _toInt32OrNull = value => {
         return null;
 
     return parsed >= PG_INT4_MIN && parsed <= PG_INT4_MAX ? parsed : null;
+};
+
+// Transaction columns typed int4 whose value is taken verbatim from the chain.
+const UNSTORABLE_INT_FIELDS = ['nonce', 'requestId', 'chainId', 'type', 'transactionIndex'];
+
+/**
+ * Copies chain-supplied integers that will not fit in their int4 column into the
+ * row's `raw` payload, so nothing is silently lost when the column is nulled.
+ *
+ * This is needed because `processRawRpcObject` builds `raw` from the keys it
+ * does *not* recognise as model attributes. These fields are model attributes,
+ * so they are absent from `raw` by construction, and nulling the column would
+ * otherwise discard the chain's value entirely.
+ *
+ * @param {Object} row - Row about to be inserted, including its `raw` payload
+ * @param {string[]} [fields=UNSTORABLE_INT_FIELDS] - Fields to check
+ * @returns {Object} The row, with out-of-range values added to `raw`
+ * @example
+ * _preserveUnstorableInts({ nonce: 1786637106312, raw: {} });
+ * // returns { nonce: 1786637106312, raw: { nonce: 1786637106312 } }
+ */
+const _preserveUnstorableInts = (row, fields = UNSTORABLE_INT_FIELDS) => {
+    if (row == null)
+        return row;
+
+    const preserved = {};
+
+    fields.forEach(field => {
+        const value = row[field];
+
+        if (value === null || value === undefined || value === '')
+            return;
+
+        if (_toInt32OrNull(value) !== null)
+            return;
+
+        preserved[field] = typeof value === 'object' ? String(value) : value;
+    });
+
+    if (Object.keys(preserved).length === 0)
+        return row;
+
+    return Object.assign({}, row, { raw: Object.assign({}, row.raw, preserved) });
 };
 
 /**
@@ -461,6 +504,7 @@ const sanitizePagination = (page, itemsPerPage, order, options = {}) => {
 module.exports = {
     sanitize: _sanitize,
     toInt32OrNull: _toInt32OrNull,
+    preserveUnstorableInts: _preserveUnstorableInts,
     stringifyBns: _stringifyBns,
     isJson: _isJson,
     getEnv: getEnv,

--- a/run/models/transaction.js
+++ b/run/models/transaction.js
@@ -25,7 +25,7 @@ const {
 } = require('sequelize');
 const ethers = require('ethers');
 const Op = Sequelize.Op
-const { sanitize, stringifyBns, processRawRpcObject, eToNumber } = require('../lib/utils');
+const { sanitize, stringifyBns, processRawRpcObject, eToNumber, toInt32OrNull } = require('../lib/utils');
 const { trigger } = require('../lib/pusher');
 const logger = require('../lib/logger');
 let { getTransactionMethodDetails, getTokenTransfer } = require('../lib/abi');
@@ -1218,7 +1218,17 @@ module.exports = (sequelize, DataTypes) => {
     blockHash: DataTypes.STRING,
     blockNumber: DataTypes.INTEGER,
     blockId: DataTypes.INTEGER,
-    chainId: DataTypes.INTEGER,
+    // chainId, nonce, transactionIndex, type and requestId are all int4 columns
+    // fed directly from the RPC payload, and nothing in the JSON-RPC spec bounds
+    // them to int4. A single out-of-range value used to abort the insert of the
+    // entire block, so the block was never stored and its sync job retried
+    // forever. Store null instead and keep the original in `raw`.
+    chainId: {
+        type: DataTypes.INTEGER,
+        set(value) {
+            this.setDataValue('chainId', toInt32OrNull(value));
+        }
+    },
     creates: DataTypes.STRING,
     data: DataTypes.STRING,
     parsedError: DataTypes.STRING,
@@ -1241,7 +1251,12 @@ module.exports = (sequelize, DataTypes) => {
             return getTransactionMethodDetails(this, this.contract && this.contract.abi);
         }
     },
-    nonce: DataTypes.INTEGER,
+    nonce: {
+        type: DataTypes.INTEGER,
+        set(value) {
+            this.setDataValue('nonce', toInt32OrNull(value));
+        }
+    },
     r: DataTypes.STRING,
     s: DataTypes.STRING,
     timestamp: {
@@ -1262,8 +1277,18 @@ module.exports = (sequelize, DataTypes) => {
             return this.getDataValue('to') ? this.getDataValue('to').toLowerCase() : null;
         }
     },
-    transactionIndex: DataTypes.INTEGER,
-    type: DataTypes.INTEGER,
+    transactionIndex: {
+        type: DataTypes.INTEGER,
+        set(value) {
+            this.setDataValue('transactionIndex', toInt32OrNull(value));
+        }
+    },
+    type: {
+        type: DataTypes.INTEGER,
+        set(value) {
+            this.setDataValue('type', toInt32OrNull(value));
+        }
+    },
     v: DataTypes.INTEGER,
     value: {
         type: DataTypes.STRING,
@@ -1350,7 +1375,12 @@ module.exports = (sequelize, DataTypes) => {
             return this.getDataValue('maxFeePerBlobGas') || this.getDataValue('raw.maxFeePerBlobGas');
         }
     },
-    requestId: DataTypes.INTEGER
+    requestId: {
+        type: DataTypes.INTEGER,
+        set(value) {
+            this.setDataValue('requestId', toInt32OrNull(value));
+        }
+    }
   }, {
     hooks: {
         afterBulkCreate(transactions, options) {

--- a/run/models/transaction.js
+++ b/run/models/transaction.js
@@ -1222,7 +1222,8 @@ module.exports = (sequelize, DataTypes) => {
     // fed directly from the RPC payload, and nothing in the JSON-RPC spec bounds
     // them to int4. A single out-of-range value used to abort the insert of the
     // entire block, so the block was never stored and its sync job retried
-    // forever. Store null instead and keep the original in `raw`.
+    // forever. Null the column instead, whatever the insert path; the block sync
+    // path additionally keeps the original value in `raw` (preserveUnstorableInts).
     chainId: {
         type: DataTypes.INTEGER,
         set(value) {

--- a/run/models/workspace.js
+++ b/run/models/workspace.js
@@ -2891,6 +2891,8 @@ module.exports = (sequelize, DataTypes) => {
                     // hold (a chain reporting a timestamp as the nonce, say) in
                     // `raw`. The model setters null those columns so the insert
                     // cannot fail, and `raw` is where the real value survives.
+                    // The untouched `transaction` is passed as the source because
+                    // sanitization has already turned hex into rounded numbers.
                     return preserveUnstorableInts(sanitize({
                         workspaceId: this.id,
                         blockHash: processed.blockHash,
@@ -2935,7 +2937,7 @@ module.exports = (sequelize, DataTypes) => {
                         withdrawals: processed.withdrawals,
                         requestId: processed.requestId,
                         raw: processed.raw
-                    }));
+                    }), transaction);
                 });
 
                 const [createdBlock] = await sequelize.models.Block.bulkCreate(

--- a/run/models/workspace.js
+++ b/run/models/workspace.js
@@ -22,7 +22,7 @@ const {
 } = require('sequelize');
 const { defineChain, createPublicClient, http, webSocket } = require('viem');
 const moment = require('moment');
-const { sanitize, slugify, processRawRpcObject } = require('../lib/utils');
+const { sanitize, slugify, processRawRpcObject, preserveUnstorableInts } = require('../lib/utils');
 const { getTransactionMethodDetails } = require('../lib/abi');
 const { ProviderConnector } = require('../lib/rpc');
 const logger = require('../lib/logger');
@@ -2887,7 +2887,11 @@ module.exports = (sequelize, DataTypes) => {
                         ['input', 'index']
                     );
 
-                    return sanitize({
+                    // preserveUnstorableInts keeps values the int4 columns cannot
+                    // hold (a chain reporting a timestamp as the nonce, say) in
+                    // `raw`. The model setters null those columns so the insert
+                    // cannot fail, and `raw` is where the real value survives.
+                    return preserveUnstorableInts(sanitize({
                         workspaceId: this.id,
                         blockHash: processed.blockHash,
                         blockNumber: processed.blockNumber,
@@ -2931,7 +2935,7 @@ module.exports = (sequelize, DataTypes) => {
                         withdrawals: processed.withdrawals,
                         requestId: processed.requestId,
                         raw: processed.raw
-                    });
+                    }));
                 });
 
                 const [createdBlock] = await sequelize.models.Block.bulkCreate(

--- a/run/tests/jobs/blockSync.test.js
+++ b/run/tests/jobs/blockSync.test.js
@@ -680,4 +680,55 @@ describe('blockSync', () => {
             done();
         });
     });
+
+    describe('when the block cannot be stored', () => {
+        const storageError = code => {
+            const error = new Error('integer out of range');
+            error.name = 'SequelizeDatabaseError';
+            error.parent = { code };
+            return error;
+        };
+
+        const syncBlock42 = () => blockSync({
+            opts: { priority: 1 },
+            data: { workspaceId: 1, userId: '123', workspace: 'My Workspace', blockNumber: 42 }
+        });
+
+        // Earlier tests leave one-shot resolutions queued on the shared mock;
+        // clear them so the rejection below is what the job actually sees.
+        beforeEach(() => mockSafeCreatePartialBlock.mockReset());
+
+        it('Should fail permanently when the data cannot be stored, instead of retrying', async () => {
+            mockSafeCreatePartialBlock.mockRejectedValue(storageError('22003'));
+
+            const error = await syncBlock42().catch(e => e);
+
+            expect(error.name).toEqual('UnrecoverableError');
+        });
+
+        it('Should name the offending block so the failure is actionable', async () => {
+            mockSafeCreatePartialBlock.mockRejectedValue(storageError('22003'));
+
+            await expect(syncBlock42())
+                .rejects.toThrow('Block 42 contains data that cannot be stored: integer out of range');
+        });
+
+        it('Should still retry a transient database failure', async () => {
+            mockSafeCreatePartialBlock.mockRejectedValue(storageError('40001'));
+
+            const error = await syncBlock42().catch(e => e);
+
+            expect(error.message).toEqual('integer out of range');
+            expect(error.name).not.toEqual('UnrecoverableError');
+        });
+
+        it('Should still retry an error with no database code', async () => {
+            mockSafeCreatePartialBlock.mockRejectedValue(new Error('Timed out after 10000ms'));
+
+            const error = await syncBlock42().catch(e => e);
+
+            expect(error.message).toEqual('Timed out after 10000ms');
+            expect(error.name).not.toEqual('UnrecoverableError');
+        });
+    });
 });

--- a/run/tests/jobs/blockSync.test.js
+++ b/run/tests/jobs/blockSync.test.js
@@ -682,6 +682,11 @@ describe('blockSync', () => {
     });
 
     describe('when the block cannot be stored', () => {
+        /**
+         * Builds the database error `safeCreatePartialBlock` would surface.
+         * @param {string} code - The SQLSTATE code the driver would report
+         * @returns {Error} A Sequelize-shaped database error
+         */
         const storageError = code => {
             const error = new Error('integer out of range');
             error.name = 'SequelizeDatabaseError';
@@ -689,6 +694,11 @@ describe('blockSync', () => {
             return error;
         };
 
+        /**
+         * Runs the job against a fixed block so each test differs only by the
+         * failure the storage layer raises.
+         * @returns {Promise} The job's result
+         */
         const syncBlock42 = () => blockSync({
             opts: { priority: 1 },
             data: { workspaceId: 1, userId: '123', workspace: 'My Workspace', blockNumber: 42 }

--- a/run/tests/lib/errors.test.js
+++ b/run/tests/lib/errors.test.js
@@ -10,6 +10,11 @@ require('../mocks/lib/logger');
 
 const { isPermanentDataError } = require('../../lib/errors');
 
+/**
+ * Builds a Sequelize error carrying the given PostgreSQL SQLSTATE code.
+ * @param {string} code - The SQLSTATE code the driver would report
+ * @returns {Error} A Sequelize-shaped database error
+ */
 const sequelizeError = code => {
     const error = new Error('database error');
     error.name = 'SequelizeDatabaseError';

--- a/run/tests/lib/errors.test.js
+++ b/run/tests/lib/errors.test.js
@@ -1,0 +1,64 @@
+/**
+ * @fileoverview Tests for the retryability classifier used by background jobs.
+ *
+ * Misclassifying here is expensive in both directions: calling a transient
+ * error permanent drops work on the floor, while calling a permanent error
+ * transient parks the job in a delayed set for decades where no alert sees it.
+ */
+
+require('../mocks/lib/logger');
+
+const { isPermanentDataError } = require('../../lib/errors');
+
+const sequelizeError = code => {
+    const error = new Error('database error');
+    error.name = 'SequelizeDatabaseError';
+    error.parent = { code };
+    return error;
+};
+
+describe('isPermanentDataError', () => {
+    it('Should flag a value the column cannot hold', () => {
+        expect(isPermanentDataError(sequelizeError('22003'))).toBe(true);
+    });
+
+    it('Should flag the other unstorable-data codes', () => {
+        ['22001', '22007', '22P02', '23502', '23514'].forEach(code => {
+            expect(isPermanentDataError(sequelizeError(code))).toBe(true);
+        });
+    });
+
+    it('Should not flag conditions that succeed on retry', () => {
+        // unique violation, foreign key violation, serialization failure, deadlock
+        ['23505', '23503', '40001', '40P01'].forEach(code => {
+            expect(isPermanentDataError(sequelizeError(code))).toBe(false);
+        });
+    });
+
+    it('Should read the driver code from `original` as well as `parent`', () => {
+        const error = new Error('database error');
+        error.original = { code: '22003' };
+        expect(isPermanentDataError(error)).toBe(true);
+    });
+
+    it('Should read the code off the error itself', () => {
+        const error = new Error('database error');
+        error.code = '22003';
+        expect(isPermanentDataError(error)).toBe(true);
+    });
+
+    it('Should not flag errors carrying no driver code', () => {
+        expect(isPermanentDataError(new Error('Timed out after 10000ms'))).toBe(false);
+    });
+
+    it('Should not flag a missing error', () => {
+        expect(isPermanentDataError(null)).toBe(false);
+        expect(isPermanentDataError(undefined)).toBe(false);
+    });
+
+    it('Should not flag an unrelated connection error code', () => {
+        const error = new Error('connection refused');
+        error.code = 'ECONNREFUSED';
+        expect(isPermanentDataError(error)).toBe(false);
+    });
+});

--- a/run/tests/lib/utils.test.js
+++ b/run/tests/lib/utils.test.js
@@ -1,11 +1,77 @@
+/* global BigInt */
 const ethers = require('ethers');
 const {
     sanitize,
     stringifyBns,
     isJson,
     validateBNString,
-    avg
+    avg,
+    toInt32OrNull
 } = require('../../lib/utils');
+
+describe('toInt32OrNull', () => {
+    it('Should parse hex strings', () => {
+        expect(toInt32OrNull('0x2a')).toEqual(42);
+        expect(toInt32OrNull('0X2A')).toEqual(42);
+    });
+
+    it('Should parse decimal strings and numbers', () => {
+        expect(toInt32OrNull('42')).toEqual(42);
+        expect(toInt32OrNull(42)).toEqual(42);
+    });
+
+    it('Should preserve zero rather than treating it as absent', () => {
+        expect(toInt32OrNull(0)).toEqual(0);
+        expect(toInt32OrNull('0x0')).toEqual(0);
+    });
+
+    it('Should accept the int4 boundaries', () => {
+        expect(toInt32OrNull(2147483647)).toEqual(2147483647);
+        expect(toInt32OrNull(-2147483648)).toEqual(-2147483648);
+    });
+
+    it('Should return null just past the int4 boundaries', () => {
+        expect(toInt32OrNull(2147483648)).toBeNull();
+        expect(toInt32OrNull(-2147483649)).toBeNull();
+    });
+
+    it('Should return null for a timestamp-style nonce', () => {
+        // Observed in production: a chain using epoch milliseconds as the nonce
+        expect(toInt32OrNull('0x19ffbdebc88')).toBeNull();
+        expect(toInt32OrNull(1786637106312)).toBeNull();
+    });
+
+    it('Should return null for a 32 byte requestId', () => {
+        expect(toInt32OrNull(`0x${'ab'.repeat(32)}`)).toBeNull();
+    });
+
+    it('Should return null for absent values', () => {
+        expect(toInt32OrNull(null)).toBeNull();
+        expect(toInt32OrNull(undefined)).toBeNull();
+        expect(toInt32OrNull('')).toBeNull();
+    });
+
+    it('Should return null for values that are not integers', () => {
+        expect(toInt32OrNull('not a number')).toBeNull();
+        expect(toInt32OrNull('0xzz')).toBeNull();
+        expect(toInt32OrNull(1.5)).toBeNull();
+        expect(toInt32OrNull(NaN)).toBeNull();
+        expect(toInt32OrNull(Infinity)).toBeNull();
+        expect(toInt32OrNull({})).toBeNull();
+        expect(toInt32OrNull([])).toBeNull();
+    });
+
+    it('Should handle bigints', () => {
+        // BigInt() rather than a 42n literal: the lint config parses as ES2017
+        expect(toInt32OrNull(BigInt(42))).toEqual(42);
+        expect(toInt32OrNull(BigInt('2147483648'))).toBeNull();
+    });
+
+    it('Should handle BigNumbers', () => {
+        expect(toInt32OrNull(ethers.BigNumber.from(42))).toEqual(42);
+        expect(toInt32OrNull(ethers.BigNumber.from('1786637106312'))).toBeNull();
+    });
+});
 
 describe('avg', () => {
     it('Should return the average of an array', () => {

--- a/run/tests/lib/utils.test.js
+++ b/run/tests/lib/utils.test.js
@@ -130,6 +130,21 @@ describe('preserveUnstorableInts', () => {
         expect(row.raw.nonce).toEqual('1786637106312');
     });
 
+    it('Should prefer the untouched RPC value over the row\'s rounded copy', () => {
+        // sanitize() has already turned the hex string into a number by this
+        // point, which rounds anything above 2^53
+        const hash = `0x${'ab'.repeat(32)}`;
+        const row = preserveUnstorableInts({ requestId: parseInt(hash, 16), raw: {} }, { requestId: hash });
+
+        expect(row.raw.requestId).toEqual(hash);
+    });
+
+    it('Should fall back to the row value when the source has no such field', () => {
+        const row = preserveUnstorableInts({ nonce: 1786637106312, raw: {} }, { hash: '0x1' });
+
+        expect(row.raw.nonce).toEqual(1786637106312);
+    });
+
     it('Should return a nullish row unchanged', () => {
         expect(preserveUnstorableInts(null)).toBeNull();
         expect(preserveUnstorableInts(undefined)).toBeUndefined();

--- a/run/tests/lib/utils.test.js
+++ b/run/tests/lib/utils.test.js
@@ -6,7 +6,8 @@ const {
     isJson,
     validateBNString,
     avg,
-    toInt32OrNull
+    toInt32OrNull,
+    preserveUnstorableInts
 } = require('../../lib/utils');
 
 describe('toInt32OrNull', () => {
@@ -41,7 +42,7 @@ describe('toInt32OrNull', () => {
         expect(toInt32OrNull(1786637106312)).toBeNull();
     });
 
-    it('Should return null for a 32 byte requestId', () => {
+    it('Should return null for a 32 byte value', () => {
         expect(toInt32OrNull(`0x${'ab'.repeat(32)}`)).toBeNull();
     });
 
@@ -70,6 +71,68 @@ describe('toInt32OrNull', () => {
     it('Should handle BigNumbers', () => {
         expect(toInt32OrNull(ethers.BigNumber.from(42))).toEqual(42);
         expect(toInt32OrNull(ethers.BigNumber.from('1786637106312'))).toBeNull();
+    });
+});
+
+describe('preserveUnstorableInts', () => {
+    it('Should copy an out-of-range value into raw', () => {
+        const row = preserveUnstorableInts({ hash: '0x1', nonce: '0x19ffbdebc88', raw: { foo: 'bar' } });
+
+        expect(row.raw).toEqual({ foo: 'bar', nonce: '0x19ffbdebc88' });
+    });
+
+    it('Should leave the row untouched when everything fits', () => {
+        const original = { hash: '0x1', nonce: '0x2a', raw: { foo: 'bar' } };
+
+        expect(preserveUnstorableInts(original)).toBe(original);
+    });
+
+    it('Should cover every chain-supplied int4 field', () => {
+        const row = preserveUnstorableInts({
+            nonce: 1786637106312,
+            requestId: 1786637106312,
+            chainId: 1786637106312,
+            type: 1786637106312,
+            transactionIndex: 1786637106312,
+            raw: {}
+        });
+
+        expect(row.raw).toEqual({
+            nonce: 1786637106312,
+            requestId: 1786637106312,
+            chainId: 1786637106312,
+            type: 1786637106312,
+            transactionIndex: 1786637106312
+        });
+    });
+
+    it('Should not add absent fields to raw', () => {
+        const row = preserveUnstorableInts({ nonce: null, requestId: undefined, type: '', raw: {} });
+
+        expect(row.raw).toEqual({});
+    });
+
+    it('Should not mutate the row it is given', () => {
+        const original = { nonce: 1786637106312, raw: {} };
+
+        preserveUnstorableInts(original);
+
+        expect(original.raw).toEqual({});
+    });
+
+    it('Should cope with a row that has no raw payload yet', () => {
+        expect(preserveUnstorableInts({ nonce: 1786637106312 }).raw).toEqual({ nonce: 1786637106312 });
+    });
+
+    it('Should stringify a BigNumber so it survives JSON storage', () => {
+        const row = preserveUnstorableInts({ nonce: ethers.BigNumber.from('1786637106312'), raw: {} });
+
+        expect(row.raw.nonce).toEqual('1786637106312');
+    });
+
+    it('Should return a nullish row unchanged', () => {
+        expect(preserveUnstorableInts(null)).toBeNull();
+        expect(preserveUnstorableInts(undefined)).toBeUndefined();
     });
 });
 

--- a/run/tests/models/transaction.test.js
+++ b/run/tests/models/transaction.test.js
@@ -1,0 +1,93 @@
+/**
+ * @fileoverview Tests for the Transaction model's int4 coercion.
+ *
+ * These fields are typed as PostgreSQL `integer` but are filled straight from
+ * the RPC payload, which does not bound them. A single out-of-range value used
+ * to abort the insert of every transaction in the block, so the block was never
+ * stored and its sync job retried until it aged out of view.
+ *
+ * The model is built against an unconnected Sequelize instance: Sequelize does
+ * not open a connection until a query runs, and `build`/`bulkBuild` only apply
+ * setters in memory.
+ */
+
+jest.mock('../../lib/pusher');
+jest.mock('../../lib/logger');
+
+const { Sequelize, DataTypes } = require('sequelize');
+
+const sequelize = new Sequelize('postgres://user:password@localhost:5432/database', { logging: false });
+const Transaction = require('../../models/transaction')(sequelize, DataTypes);
+
+// Epoch milliseconds, observed as a nonce in production
+const TIMESTAMP_NONCE = '0x19ffbdebc88';
+// A 32 byte value, as Arbitrum-style chains report requestId
+const HASH_REQUEST_ID = `0x${'ab'.repeat(32)}`;
+
+describe('Transaction int4 fields', () => {
+    it('Should keep values that fit', () => {
+        const transaction = Transaction.build({
+            nonce: '0x2a',
+            requestId: '0x1',
+            chainId: '0x2',
+            type: '0x0',
+            transactionIndex: '0x3'
+        });
+
+        expect(transaction.nonce).toEqual(42);
+        expect(transaction.requestId).toEqual(1);
+        expect(transaction.chainId).toEqual(2);
+        expect(transaction.type).toEqual(0);
+        expect(transaction.transactionIndex).toEqual(3);
+    });
+
+    it('Should null a nonce the column cannot hold', () => {
+        expect(Transaction.build({ nonce: TIMESTAMP_NONCE }).nonce).toBeNull();
+    });
+
+    it('Should null a requestId the column cannot hold', () => {
+        expect(Transaction.build({ requestId: HASH_REQUEST_ID }).requestId).toBeNull();
+    });
+
+    it('Should null the remaining chain-supplied int4 fields when out of range', () => {
+        const transaction = Transaction.build({
+            chainId: TIMESTAMP_NONCE,
+            type: TIMESTAMP_NONCE,
+            transactionIndex: TIMESTAMP_NONCE
+        });
+
+        expect(transaction.chainId).toBeNull();
+        expect(transaction.type).toBeNull();
+        expect(transaction.transactionIndex).toBeNull();
+    });
+
+    it('Should not confuse a zero value with an absent one', () => {
+        const transaction = Transaction.build({ nonce: '0x0', type: 0, transactionIndex: 0 });
+
+        expect(transaction.nonce).toEqual(0);
+        expect(transaction.type).toEqual(0);
+        expect(transaction.transactionIndex).toEqual(0);
+    });
+
+    it('Should keep the rest of the transaction intact when one field overflows', () => {
+        const transaction = Transaction.build({
+            hash: '0xAbC',
+            blockNumber: 24746942,
+            nonce: TIMESTAMP_NONCE
+        });
+
+        expect(transaction.nonce).toBeNull();
+        expect(transaction.hash).toEqual('0xAbC');
+        expect(transaction.blockNumber).toEqual(24746942);
+    });
+
+    it('Should coerce through the bulk path, which is how blocks are stored', () => {
+        const [good, bad] = Transaction.bulkBuild([
+            { hash: '0x1', nonce: '0x2a' },
+            { hash: '0x2', nonce: TIMESTAMP_NONCE }
+        ]);
+
+        expect(good.nonce).toEqual(42);
+        expect(bad.nonce).toBeNull();
+    });
+});


### PR DESCRIPTION
## What's broken

One explorer (workspace 17302, network 2184) has not been syncing cleanly for days. Its chain reports transactions whose **nonce is an epoch-millisecond timestamp** — e.g. `0x19ffbdebc88` = `1786637106312`, about 832× the maximum an int4 column can hold.

Because all transactions in a block are inserted as one statement, that single field aborts the whole insert and the block is rolled back. The sync job then retries 50 times with exponential backoff, so:

- it never reaches its final attempt within any useful horizon, so it never lands in the failed set;
- it accumulates in the **delayed** set instead, which no alert looks at;
- the syncer moves on to newer blocks, so the explorer is not frozen — it is quietly accumulating **permanent holes** while drifting further behind head.

At the time of investigation: 217 delayed jobs, 100% from this one workspace, 100% with the same error, all on attempt 10 of 50. Sentry has ~1000 events on the same issue.

## What this changes

**1. Don't lose a block over a field we can't represent.** The chain-supplied int4 columns on `transactions` — `nonce`, `requestId`, `chainId`, `type`, `transactionIndex` — now store `null` when the value is out of range, instead of failing the insert.

Nothing is lost: `preserveUnstorableInts` copies the out-of-range value into the row's `raw` payload before insert, so the column is nulled but the chain's actual value is still there. This is safe because the columns are already nullable, unindexed, and never filtered/joined/sorted on, and the UI already renders a dash when a value is absent.

`requestId` is included deliberately: it is chain-supplied and unbounded, and it is the next identical incident waiting to happen. (It pairs against `orbit_deposits.messageIndex`, which is itself an int4 column — so an out-of-range requestId could never have matched a deposit anyway, and before this change it took the whole block down with it.)

**2. Fail unstorable payloads fast.** A new retryability classifier recognises the Postgres codes that describe data the schema can never accept, and the block sync job now fails those immediately and visibly rather than backing off into the delayed set. Transient conditions — unique violations, foreign key violations, serialization failures, deadlocks — are deliberately left retryable.

## Why no migration

All five columns are already nullable, so nothing in the schema needs to change.

Widening `nonce` to 64-bit was considered and rejected for now: `transactions` is 19.7M rows / 25 GB (16 GB heap + 8 GB indexes), and an in-place type change forces a full table rewrite plus index rebuild while holding an exclusive lock — roughly 15–40 minutes during which the application's hottest table is unreadable and unwritable. The online alternative (new column, batched backfill, dual-write, swap) is hours of churn and ~16 GB of bloat for a column nothing reads programmatically. Not worth it; revisit if these fields ever become queryable.

## Scope note

`blocks` also has int4 columns fed from the RPC (`l1BlockNumber`, `size`). They are left alone — overflow there is implausible, and the fast-fail guard now makes any such case loud instead of silent.

## Testing

- `toInt32OrNull`: boundaries, zero vs absent, hex/decimal/number/bigint/BigNumber inputs, malformed input, the real production nonce and a 32-byte value.
- `preserveUnstorableInts`: all five fields, absent values, no-op when everything fits, no mutation of the input, missing `raw`, BigNumber stringification.
- `isPermanentDataError`: each permanent code, each deliberately-retryable code, driver code nested under `parent`/`original`/the error itself.
- Transaction model: coercion through both `build` and the `bulkBuild` path that block storage actually uses; unaffected fields stay intact.
- Block sync: permanent failure is unrecoverable and names the offending block; transient failures stay retryable.

Full backend suite run locally — the only failures (`opDeposits`, `erc721Collections`) reproduce identically on `develop` and are unrelated ordering flakiness.
